### PR TITLE
Let's not deprecate this

### DIFF
--- a/src/deprecated/Tribe__Events__Template_Factory.php
+++ b/src/deprecated/Tribe__Events__Template_Factory.php
@@ -1,4 +1,0 @@
-<?php
-_deprecated_file( __FILE__, '4.0', 'Tribe__Template_Factory.php' );
-
-class Tribe__Events__Template_Factory extends Tribe__Template_Factory {}


### PR DESCRIPTION
The original rework had eliminated the Tribe__Events__Template_Factory class, however, the end result was the continued existence of that class that extends Tribe__Template_Factory.

See: https://central.tri.be/issues/40318#note-2