### PR TITLE
Compare to 4.0beta

### DIFF
--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -178,7 +178,7 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 				return true;
 			}
 
-			if ( version_compare( Tribe__Events__Main::VERSION, '4.0', '>=' ) ) {
+			if ( version_compare( Tribe__Events__Main::VERSION, '4.0beta', '>=' ) ) {
 				return true;
 			}
 
@@ -218,6 +218,7 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 					$this->adminSlug,
 					array( $this, 'generatePage' )
 				);
+
 			}
 		}
 


### PR DESCRIPTION
Our Settings page were not been added due to `version_compare` considering `4.0beta` lower than `4.0`.