### PR TITLE
Add AJAX helper function where we can override as necessary

### DIFF
--- a/src/Tribe/Admin/Helpers.php
+++ b/src/Tribe/Admin/Helpers.php
@@ -43,8 +43,8 @@ class Tribe__Admin__Helpers {
 			return false;
 		}
 
-		// Not doing AJAX
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		// Doing AJAX? bail.
+		if ( Tribe__Main::instance()->doing_ajax() ) {
 			return false;
 		}
 
@@ -88,8 +88,8 @@ class Tribe__Admin__Helpers {
 			return false;
 		}
 
-		// Not doing AJAX
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		// Doing AJAX? bail.
+		if ( Tribe__Main::instance()->doing_ajax() ) {
 			return false;
 		}
 
@@ -138,8 +138,8 @@ class Tribe__Admin__Helpers {
 			return false;
 		}
 
-		// Not doing AJAX
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		// Doing AJAX? bail.
+		if ( Tribe__Main::instance()->doing_ajax() ) {
 			return false;
 		}
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -22,6 +22,7 @@ class Tribe__Main {
 
 	protected $plugin_context;
 	protected $plugin_context_class;
+	protected $doing_ajax = false;
 
 	public static $tribe_url = 'http://tri.be/';
 	public static $tec_url = 'http://theeventscalendar.com/';
@@ -47,6 +48,8 @@ class Tribe__Main {
 
 		$this->init_libraries();
 		$this->add_hooks();
+
+		$this->doing_ajax = defined( 'DOING_AJAX' ) && DOING_AJAX;
 	}
 
 	/**
@@ -238,6 +241,23 @@ class Tribe__Main {
 				return false;
 			}
 		}
+	}
+
+	/**
+	 * Helper function to indicate whether the current execution context is AJAX
+	 *
+	 * This method exists to allow us test code that behaves differently depending on the execution
+	 * context.
+	 *
+	 * @since 4.0
+	 * @return boolean
+	 */
+	public function doing_ajax( $doing_ajax = null ) {
+		if ( ! is_null( $doing_ajax ) ) {
+			$this->doing_ajax = $doing_ajax;
+		}
+
+		return $this->doing_ajax;
 	}
 
 	/**


### PR DESCRIPTION
This change - once implemented in all the places, should make testing code that reacts to DOING_AJAX a bit easier without breaking things.

See: https://central.tri.be/issues/41385