### PR TITLE
Add rule to make sure our modals are functional | #41462

### DIFF
--- a/src/resources/css/tribe-common-admin.css
+++ b/src/resources/css/tribe-common-admin.css
@@ -555,3 +555,8 @@ a.tribe-rating-link {
 .bumpdown-trigger .target {
 	color: #0074a2;
 }
+
+/* Useful to ensure modals rise above the grey 'miasma' */
+.ui-front {
+    z-index: 1000000;
+}


### PR DESCRIPTION
Modals can be obscured under the grey 'screen'. This change is essentially just copying a rule currently used in TEC's admin CSS to common.

[C#41462](https://central.tri.be/issues/41462)