### PR TITLE
Textdomains for plugins need to be loaded relative to the plugins dir

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -167,7 +167,8 @@ class Tribe__Main {
 	 * Loads the textdomain
 	 */
 	public function load_text_domain() {
-		load_plugin_textdomain( 'tribe-common', false, $this->plugin_dir . 'lang/' );
+		$dir = basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/';
+		load_plugin_textdomain( 'tribe-common', false, $dir );
 	}
 
 	public function admin_enqueue_scripts() {


### PR DESCRIPTION
Common is a child directory of either the-events-calendar or event-tickets