### PR TITLE
Replace HTTP host field with value of the site and home URL options | 26385

### DIFF
--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -107,7 +107,8 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 			$keys = apply_filters( 'tribe-pue-install-keys', array() );
 
 			$systeminfo = array(
-				'url'                => 'http://' . $_SERVER['HTTP_HOST'],
+				'Home URL'           => get_home_url(),
+				'Site URL'           => get_site_url(),
 				'name'               => $user->display_name,
 				'email'              => $user->user_email,
 				'install keys'       => $keys,


### PR DESCRIPTION
Previously we just used the HTTP host field for the URL included in the sys info - which was misleading at times. This replaces it with both the site and home URLs.

[C#26835](https://central.tri.be/issues/26835)