### PR TITLE
Licenses settings tab is missing if DISALLOW_FILE_MODS is enabled

### DIFF
--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -234,12 +234,12 @@ class Tribe__Settings_Manager {
 	 * only if premium addons are detected.
 	 */
 	protected function do_licenses_tab() {
-		$show_tab = ( current_user_can( 'update_plugins' ) && $this->have_addons() );
+		$show_tab = ( current_user_can( 'activate_plugins' ) && $this->have_addons() );
 
 		/**
 		 * Provides an oppotunity to override the decision to show or hide the licenses tab
 		 *
-		 * Normally it will only show if the current user has the "update_plugins" capability
+		 * Normally it will only show if the current user has the "activate_plugins" capability
 		 * and there are some currently-activated premium plugins.
 		 *
 		 * @var bool


### PR DESCRIPTION
Aloha fellow Modern Tribe team!

We discovered the following bug in the plugin _The Events Calendar_ upon trying to re-install it on a production site:

**Problem**

* When the `DISALLOW_FILE_MODS` constant is `TRUE` in `wp-config.php` (so as to not allow any kind of modifications to application files through the WordPress user interface), then you cannot enter a license key for the plugin _Events Calendar Pro_.

**Cause**

* The plugin checks for the capability `'update_plugins'` to check whether the Licenses settings tab may be displayed.

**Details**

* However, the `'update_plugins'` capability allows users to update (replace) the code of plugins, which is not granted in case `DISALLOW_FILE_MODS` is enabled.

* The currently checked capability was introduced in https://github.com/moderntribe/the-events-calendar/pull/185 - unfortunately without any reasoning, so most likely by mistake.

**Proposed solution**

1. Replace the checked capability with `'activate_plugins'`, because a user who is able to enable the plugin should also be able to enter the license key.


This PR performs the necessary fix.