### PR TITLE
do not strip slashes

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -158,8 +158,7 @@ if ( ! function_exists( 'tribe_get_date_format' ) ) {
 			$format = tribe_get_date_option( 'dateWithoutYearFormat', 'F j' );
 		}
 
-		// Strip slashes - otherwise the slashes for escaped characters will themselves be escaped
-		return apply_filters( 'tribe_date_format', stripslashes( $format ) );
+		return apply_filters( 'tribe_date_format', $format );
 	}
 }//end if
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/41127

This PR remove the slash stripping that's preventing date format from being applied as intended; at that point slashes are the correct ones that are part of the format specification