### PR TITLE
Change the license key save and check to the singular option instead …

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -430,12 +430,12 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				} elseif ( isset( $pluginInfo->api_invalid ) && $pluginInfo->api_invalid == 1 ) {
 					$response['message'] = esc_html__( 'Sorry, this key is not valid.', 'tribe-common' );
 				} else {
-					$api_secret_key = tribe_get_option( $this->pue_install_key );
+					$api_secret_key = get_option( $this->pue_install_key );
 					if ( $api_secret_key && $api_secret_key === $queryArgs['pu_install_key'] ){
 						$default_success_msg = sprintf( esc_html__( 'Valid Key! Expires on %s', 'tribe-common' ), $expiration );
 					} else {
 						// Set the key
-						tribe_update_option( $this->pue_install_key, $queryArgs['pu_install_key'] );
+						update_option( $this->pue_install_key, $queryArgs['pu_install_key'] );
 
 						$default_success_msg = sprintf( esc_html__( 'Thanks for setting up a valid key, it will expire on %s', 'tribe-common' ), $expiration );
 					}


### PR DESCRIPTION
_Ref:_ [C#43736](https://central.tri.be/issues/43736)

Since the license keys are saved as their own individual option this change is to just detect and save it to that option per plugin instead of the serialized main option. 

This change is in Core and Common