### PR TITLE
Added the Post Root Pool utility class

### DIFF
--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -1,0 +1,53 @@
+<?php
+
+
+class Tribe__Utils__Post_Root_Pool {
+
+	/**
+	 * @var string
+	 */
+	protected $root_separator = '-';
+
+	/**
+	 * Generates a unique root for a post using its post_name.
+	 *
+	 * @param WP_Post $post
+	 *
+	 * @return string
+	 */
+	public function generate_unique_root( WP_Post $post ) {
+		$post_name = $post->post_name;
+
+		$root = $this->build_root_from( $post_name );
+
+		return $root . $this->root_separator;
+	}
+
+	/**
+	 * @param $post_name
+	 *
+	 * @return string
+	 */
+	protected function build_root_from( $post_name ) {
+		$frags = explode( '-', $post_name );
+
+		$candidate = implode( '', array_map( 'strtoupper', $frags ) );
+
+		if ( strlen( $candidate ) < 10 ) {
+			return $candidate;
+		}
+
+		$frags = array_filter( $frags );
+
+		return implode( '', array_map( array( $this, 'uc_first_letter' ), $frags ) );
+	}
+
+	/**
+	 * @param $string
+	 *
+	 * @return string
+	 */
+	protected function uc_first_letter( $string ) {
+		return is_numeric( $string ) ? $string : strtoupper( $string[0] );
+	}
+}

--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -9,6 +9,13 @@ class Tribe__Utils__Post_Root_Pool {
 	protected $root_separator = '-';
 
 	/**
+	 * @var array
+	 */
+	protected $prefixes = array();
+
+	public function __construct(  ) {
+}
+	/**
 	 * Generates a unique root for a post using its post_name.
 	 *
 	 * @param WP_Post $post
@@ -28,18 +35,23 @@ class Tribe__Utils__Post_Root_Pool {
 	 *
 	 * @return string
 	 */
-	protected function build_root_from( $post_name ) {
+	protected function build_root_from( $post_name, $unique_prefix = '' ) {
 		$frags = explode( '-', $post_name );
 
 		$candidate = implode( '', array_map( 'strtoupper', $frags ) );
 
 		if ( strlen( $candidate ) < 10 ) {
 			return $candidate;
+		} else {
+			$frags     = array_filter( $frags );
+			$candidate = implode( '', array_map( array( $this, 'uc_first_letter' ), $frags ) );
 		}
 
-		$frags = array_filter( $frags );
+		if ( $this->is_in_pool( $candidate ) ) {
+			$candidate = $this->build_root_from( $candidate, next( $this->prefixes) );
+		}
 
-		return implode( '', array_map( array( $this, 'uc_first_letter' ), $frags ) );
+		return $candidate . $unique_prefix;
 	}
 
 	/**

--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -3,6 +3,9 @@
 
 class Tribe__Utils__Post_Root_Pool {
 
+	/**
+	 * @var string
+	 */
 	protected $pool_transient_name = 'tribe_ticket_prefix_pool';
 
 	/**
@@ -58,6 +61,13 @@ class Tribe__Utils__Post_Root_Pool {
 		$this->insert_root_in_pool( $candidate );
 
 		return $candidate;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_pool_transient_name() {
+		return $this->pool_transient_name;
 	}
 
 	/**

--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -152,4 +152,13 @@ class Tribe__Utils__Post_Root_Pool {
 			set_transient( $this->pool_transient_name, $pool );
 		}
 	}
+
+	/**
+	 * Whether the pool transient has been primed or not.
+	 *
+	 * @return bool
+	 */
+	public function is_primed() {
+		return get_transient( $this->pool_transient_name ) !== false;
+	}
 }

--- a/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Tribe\Utils;
 
+use \Tribe__Utils__Post_Root_Pool as Post_Root_Pool;
+
 class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 
 	public function setUp() {
@@ -8,6 +10,7 @@ class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 		parent::setUp();
 
 		// your set up methods here
+		Post_Root_Pool::reset_pool();
 	}
 
 	public function tearDown() {
@@ -85,6 +88,8 @@ class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 			[ 'barbecue-with-john', 'BWJ-' ],
 			[ 'barbecue-with-john-1', 'BWJ1-' ],
 			[ 'this-post-has-a-very-long-post-name-with-a-lot-of-words-in-it', 'TPHAVLPNWALOWII-' ],
+			[ 'oktoberfest-2016', 'O2016-' ],
+			[ 'burning-man-2016', 'BM2016-' ],
 		];
 	}
 
@@ -110,14 +115,36 @@ class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 	public function it_should_avoid_root_conflicts_when_generating_roots_for_similarly_titled_posts() {
 		$post_1 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => 'an-awesome-event' ] );
 		$post_2 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Appaling Event', 'post_name' => 'an-appaling-event' ] );
+		$post_3 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Astonishing Event', 'post_name' => 'an-astonishing-event' ] );
+		$post_4 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Amazing Event', 'post_name' => 'an-amazing-event' ] );
 
 		$sut = $this->make_instance();
 
 		$root_1 = $sut->generate_unique_root( $post_1 );
 		$root_2 = $sut->generate_unique_root( $post_2 );
+		$root_3 = $sut->generate_unique_root( $post_3 );
+		$root_4 = $sut->generate_unique_root( $post_4 );
 
 		$this->assertEquals( 'AAE-', $root_1 );
-		$this->assertEquals( 'AAEA-', $root_2 );
+		$this->assertEquals( 'AAE-1-', $root_2 );
+		$this->assertEquals( 'AAE-2-', $root_3 );
+		$this->assertEquals( 'AAE-3-', $root_4 );
+	}
+
+	/**
+	 * @test
+	 * it should handle n scale unique pool creation
+	 */
+	public function it_should_handle_n_scale_unique_pool_creation() {
+		$post = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => 'an-awesome-event' ] );
+
+		$sut = $this->make_instance();
+
+		for ( $i = 0; $i < 200; $i ++ ) {
+			$root = $sut->generate_unique_root( $post );
+		}
+
+		$this->assertEquals( 'AAE-199-', $root );
 	}
 
 	private function make_instance() {

--- a/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
@@ -136,18 +136,37 @@ class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 	 * it should handle n scale unique pool creation
 	 */
 	public function it_should_handle_n_scale_unique_pool_creation() {
-		$post = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => 'an-awesome-event' ] );
-
 		$sut = $this->make_instance();
 
 		for ( $i = 0; $i < 200; $i ++ ) {
-			$root = $sut->generate_unique_root( $post );
+			$post_name = 'an-awesome-e' . md5( microtime() );
+			$post      = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => $post_name ] );
+			$root      = $sut->generate_unique_root( $post );
 		}
 
 		$this->assertEquals( 'AAE-199-', $root );
 	}
 
+	/**
+	 * @test
+	 * it should not generate a root for the same post twice
+	 */
+	public function it_should_not_generate_a_root_for_the_same_post_twice() {
+		$post = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => 'an-awesome-event' ] );
+
+		$sut = $this->make_instance();
+
+		$root_1 = $sut->generate_unique_root( $post );
+		$root_2 = $sut->generate_unique_root( $post );
+		$root_3 = $sut->generate_unique_root( $post );
+
+		$this->assertEquals( 'AAE-', $root_1 );
+		$this->assertEquals( 'AAE-', $root_2 );
+		$this->assertEquals( 'AAE-', $root_3 );
+		$this->assertEquals( array( 'AAE' => $post->ID ), $sut->get_pool() );
+	}
+
 	private function make_instance() {
-		return new \Tribe__Utils__Post_Root_Pool();
+		return new Post_Root_Pool();
 	}
 }

--- a/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
@@ -1,0 +1,109 @@
+<?php
+namespace Tribe\Utils;
+
+class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( 'Tribe__Utils__Post_Root_Pool', $sut );
+	}
+
+	/**
+	 * @test
+	 * it should generate a unique post root from the post_name
+	 */
+	public function it_should_generate_a_unique_post_root_from_the_post_name() {
+		$post = $this->factory()->post->create_and_get( [ 'post_title' => 'foo', 'post_name' => 'foo' ] );
+
+		$sut = $this->make_instance();
+
+		$root = $sut->generate_unique_root( $post );
+
+		$this->assertEquals( 'FOO-', $root );
+	}
+
+	/**
+	 * @test
+	 * it should generate different post roots for posts with same post_title
+	 */
+	public function it_should_generate_different_post_roots_for_posts_with_same_post_title() {
+		$post_1 = $this->factory()->post->create_and_get( [ 'post_title' => 'foo', 'post_name' => 'foo' ] );
+		$post_2 = $this->factory()->post->create_and_get( [ 'post_title' => 'foo', 'post_name' => 'foo-1' ] );
+
+		$sut = $this->make_instance();
+
+		$root_1 = $sut->generate_unique_root( $post_1 );
+		$root_2 = $sut->generate_unique_root( $post_2 );
+
+		$this->assertEquals( 'FOO-', $root_1 );
+		$this->assertEquals( 'FOO1-', $root_2 );
+	}
+
+	/**
+	 * @test
+	 * it should generate different post roots for posts with same long titles
+	 */
+	public function it_should_generate_different_post_roots_for_posts_with_same_long_titles() {
+		$post_1 = $this->factory()->post->create_and_get( [ 'post_title' => 'Lorem Ipsum Dolor Sit', 'post_name' => 'lorem-ipsum-dolor-sit' ] );
+		$post_2 = $this->factory()->post->create_and_get( [ 'post_title' => 'Lorem Ipsum Dolor Sit', 'post_name' => 'lorem-ipsum-dolor-sit-1' ] );
+
+		$sut = $this->make_instance();
+
+		$root_1 = $sut->generate_unique_root( $post_1 );
+		$root_2 = $sut->generate_unique_root( $post_2 );
+
+		$this->assertEquals( 'LIDS-', $root_1 );
+		$this->assertEquals( 'LIDS1-', $root_2 );
+	}
+
+	public function post_names() {
+		return [
+			[ 'foo', 'FOO-' ],
+			[ 'foo-21', 'FOO21-' ],
+			[ 'foo-bar-baz', 'FOOBARBAZ-' ],
+			[ 'foo-bar-baz-1', 'FBB1-' ],
+			[ 'foo-bar-baz-23', 'FBB23-' ],
+			[ 'barbecue-with-john', 'BWJ-' ],
+			[ 'barbecue-with-john-1', 'BWJ1-' ],
+			[ 'this-post-has-a-very-long-post-name-with-a-lot-of-words-in-it', 'TPHAVLPNWALOWII-' ],
+		];
+	}
+
+	/**
+	 * @test
+	 * it should generate foreseeable post roots
+	 * @dataProvider post_names
+	 */
+	public function it_should_generate_foreseeable_post_roots( $post_name, $expected ) {
+		$post = $this->factory()->post->create_and_get( [ 'post_title' => 'Lorem Ipsum Dolor Sit', 'post_name' => $post_name ] );
+
+		$sut = $this->make_instance();
+
+		$root = $sut->generate_unique_root( $post );
+
+		$this->assertEquals( $expected, $root );
+	}
+
+	private function make_instance() {
+		return new \Tribe__Utils__Post_Root_Pool();
+	}
+}

--- a/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_Root_PoolTest.php
@@ -103,6 +103,23 @@ class Post_Root_PoolTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected, $root );
 	}
 
+	/**
+	 * @test
+	 * it should avoid root conflicts when generating roots for similarly titled posts
+	 */
+	public function it_should_avoid_root_conflicts_when_generating_roots_for_similarly_titled_posts() {
+		$post_1 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Awesome Event', 'post_name' => 'an-awesome-event' ] );
+		$post_2 = $this->factory()->post->create_and_get( [ 'post_title' => 'An Appaling Event', 'post_name' => 'an-appaling-event' ] );
+
+		$sut = $this->make_instance();
+
+		$root_1 = $sut->generate_unique_root( $post_1 );
+		$root_2 = $sut->generate_unique_root( $post_2 );
+
+		$this->assertEquals( 'AAE-', $root_1 );
+		$this->assertEquals( 'AAEA-', $root_2 );
+	}
+
 	private function make_instance() {
 		return new \Tribe__Utils__Post_Root_Pool();
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/25848

This PR adds the `Post_Root_Pool` utility class.
This is used to generate site wide unique post roots to use for tickets.
Priming of the pool happens at first use and a method `set_pool` exists to allow for programmatic priming.

See the tests for expected output.