### PR TITLE
Basis for logging across the plugin suite

### DIFF
--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -816,12 +816,12 @@ class Tribe__Admin__Help_Page {
 
 					<dt><?php esc_html_e( 'Rating:', 'tribe-common' ); ?></dt>
 					<dd><a href="<?php echo esc_url( $plugin->stars_url ); ?>" target="_blank">
-							<?php wp_star_rating( array(
-								'rating' => $api_data->rating,
-								'type'   => 'percent',
-								'number' => $api_data->num_ratings,
-							) );?>
-						</a></dd>
+						<?php wp_star_rating( array(
+							'rating' => $api_data->rating,
+							'type'   => 'percent',
+							'number' => $api_data->num_ratings,
+						) );?>
+					</a></dd>
 				</dl>
 			<?php } ?>
 

--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -411,7 +411,10 @@ class Tribe__Admin__Help_Page {
 	}
 
 	/**
-	 * Parses the help text from an Array to the final HTML
+	 * Parses the help text from an Array to the final HTML.
+	 *
+	 * It is the responsibility of code calling this function to ensure proper escaping
+	 * within any HTML.
 	 *
 	 * @since  4.0
 	 *
@@ -419,28 +422,6 @@ class Tribe__Admin__Help_Page {
 	 * @return string
 	 */
 	public function get_content_html( $mixed = '' ) {
-		$html_allowed = array(
-			'a'      => array( 'href' => array(), 'title' => array(), 'target' => array(), 'style' => array(), 'class' => array(), 'id' => array() ),
-			'img'    => array( 'title' => array(), 'src' => array(), 'alt' => array(), 'style' => array(), 'class' => array(), 'id' => array() ),
-
-			'br'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'em'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'strong' => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'b'      => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'i'      => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'u'      => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-
-			'div'    => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'h5'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'p'      => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'ol'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'ul'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'li'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'dl'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'dt'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-			'dd'     => array( 'style' => array(), 'class' => array(), 'id' => array() ),
-		);
-
 		// If it's an StdObj or String it will be converted
 		$mixed = (array) $mixed;
 
@@ -452,8 +433,6 @@ class Tribe__Admin__Help_Page {
 			}
 
 			if ( is_string( $line ) ) {
-				// Make sure we are safe when it's a string
-				$line = wp_kses( $line, $html_allowed );
 				continue;
 			} elseif ( is_array( $line ) ) {
 				// Allow the developer to pass some configuration
@@ -577,7 +556,7 @@ class Tribe__Admin__Help_Page {
 
 			// Setup the Base for the content to come
 			'content' => array(),
- 		);
+		);
 
 		$this->sections[ $section->id ] = $section;
 
@@ -825,25 +804,25 @@ class Tribe__Admin__Help_Page {
 			?>
 
 			<?php if ( $api_data ) { ?>
-			<dl>
-				<dt><?php esc_html_e( 'Latest Version:', 'tribe-common' ); ?></dt>
-				<dd><?php echo esc_html( $api_data->version ); ?></dd>
+				<dl>
+					<dt><?php esc_html_e( 'Latest Version:', 'tribe-common' ); ?></dt>
+					<dd><?php echo esc_html( $api_data->version ); ?></dd>
 
-				<dt><?php esc_html_e( 'Requires:', 'tribe-common' ); ?></dt>
-				<dd><?php echo esc_html__( 'WordPress ', 'tribe-common' ) . esc_html( $api_data->requires ); ?>+</dd>
+					<dt><?php esc_html_e( 'Requires:', 'tribe-common' ); ?></dt>
+					<dd><?php echo esc_html__( 'WordPress ', 'tribe-common' ) . esc_html( $api_data->requires ); ?>+</dd>
 
-				<dt><?php esc_html_e( 'Active Users:', 'tribe-common' ); ?></dt>
-				<dd><?php echo esc_html( number_format( $api_data->active_installs ) ); ?>+</dd>
+					<dt><?php esc_html_e( 'Active Users:', 'tribe-common' ); ?></dt>
+					<dd><?php echo esc_html( number_format( $api_data->active_installs ) ); ?>+</dd>
 
-				<dt><?php esc_html_e( 'Rating:', 'tribe-common' ); ?></dt>
-				<dd><a href="<?php echo esc_url( $plugin->stars_url ); ?>" target="_blank">
-				<?php wp_star_rating( array(
-					'rating' => $api_data->rating,
-					'type'   => 'percent',
-					'number' => $api_data->num_ratings,
-				) );?>
-				</a></dd>
-			</dl>
+					<dt><?php esc_html_e( 'Rating:', 'tribe-common' ); ?></dt>
+					<dd><a href="<?php echo esc_url( $plugin->stars_url ); ?>" target="_blank">
+							<?php wp_star_rating( array(
+								'rating' => $api_data->rating,
+								'type'   => 'percent',
+								'number' => $api_data->num_ratings,
+							) );?>
+						</a></dd>
+				</dl>
 			<?php } ?>
 
 			<?php
@@ -878,6 +857,6 @@ class Tribe__Admin__Help_Page {
 				</ul>
 			<?php } ?>
 		</div>
-	<?php
+		<?php
 	}
 }

--- a/src/Tribe/Log.php
+++ b/src/Tribe/Log.php
@@ -184,7 +184,7 @@ class Tribe__Log {
 			$engine = tribe_get_option( 'logging_engine', null );
 			$available = $this->get_logging_engines();
 
-			if ( empty( $engine ) || ! isset( $available[$engine] ) ) {
+			if ( empty( $engine ) || ! isset( $available[ $engine ] ) ) {
 				return null;
 			}
 
@@ -227,7 +227,7 @@ class Tribe__Log {
 			$object = new $class_name;
 
 			if ( is_a( $object, 'Tribe__Log__Logger' ) ) {
-				$this->loggers[$class_name] = new $class_name();
+				$this->loggers[ $class_name ] = new $class_name();
 			}
 		}
 

--- a/src/Tribe/Log.php
+++ b/src/Tribe/Log.php
@@ -181,7 +181,7 @@ class Tribe__Log {
 	 */
 	public function get_current_logger() {
 		if ( ! $this->current_logger ) {
-			$engine = tribe_get_option( 'logging_engine', null );
+			$engine = tribe_get_option( 'logging_class', null );
 			$available = $this->get_logging_engines();
 
 			if ( empty( $engine ) || ! isset( $available[ $engine ] ) ) {
@@ -210,7 +210,7 @@ class Tribe__Log {
 			throw new Exception( sprintf( __( 'Cannot set %s as the current logging engine', 'tribe-common' ), $engine ) );
 		}
 
-		tribe_update_option( 'logging_engine', $engine );
+		tribe_update_option( 'logging_class', $engine );
 		$this->current_logger = $available_engines[ $engine ];
 	}
 

--- a/src/Tribe/Log.php
+++ b/src/Tribe/Log.php
@@ -1,0 +1,354 @@
+<?php
+if ( class_exists( 'Tribe__Log' ) ) {
+	return;
+}
+
+/**
+ * Provides access to and management of core logging facilities.
+ */
+class Tribe__Log {
+	const DISABLE = 'disable';
+	const DEBUG   = 'debug';
+	const WARNING = 'warning';
+	const ERROR   = 'error';
+	const CLEANUP = 'tribe_common_log_cleanup';
+
+	/**
+	 * @var Tribe__Log__Admin
+	 */
+	protected $admin;
+
+	/**
+	 * @var Tribe__Log__Logger
+	 */
+	protected $current_logger;
+
+	/**
+	 * @var string
+	 */
+	protected $current_level;
+
+	/**
+	 * All logging levels in priority order. Each level is represented by
+	 * an array in the form [ code => description ].
+	 *
+	 * @var array
+	 */
+	protected $levels = array();
+
+	/**
+	 * Alternative representation of the $levels property allowing quick look
+	 * up of levels by priority.
+	 *
+	 * @var array
+	 */
+	protected $prioritized_levels = array();
+
+	/**
+	 * Instantiated loggers, stored for re-use.
+	 *
+	 * @var array
+	 */
+	protected $loggers = array();
+
+
+	public function __construct() {
+		if ( is_admin() ) {
+			$this->admin = new Tribe__Log__Admin();
+		}
+
+		$this->current_level = $this->get_level();
+		$this->log_cleanup();
+	}
+
+	/**
+	 * @return Tribe__Log__Admin
+	 */
+	public function admin() {
+		return $this->admin;
+	}
+
+	/**
+	 * Facilitates daily cleanup and log rotation.
+	 */
+	protected function log_cleanup() {
+		$this->register_cleanup_task();
+		do_action( self::CLEANUP, array( $this, 'do_cleanup' ) );
+	}
+
+	/**
+	 * Schedules a daily cleanup task if one is not already in place.
+	 */
+	protected function register_cleanup_task() {
+		if ( ! wp_next_scheduled( self::CLEANUP ) ) {
+			wp_schedule_event( strtotime( '+1 day' ), 'daily', self::CLEANUP );
+		}
+	}
+
+	/**
+	 * Call the cleanup() method for each available logging engine.
+	 *
+	 * We don't just call it on the current engine since, if there was a recent change,
+	 * we'll generally still want the now unused engine's output to be cleaned up.
+	 */
+	public function do_cleanup() {
+		foreach ( $this->get_logging_engines() as $engine ) {
+			/**
+			 * @var Tribe__Log__Logger $engine
+			 */
+			$engine->cleanup();
+		}
+	}
+
+	/**
+	 * Logs a debug-level entry.
+	 *
+	 * @param string $entry
+	 * @param string $src
+	 */
+	public function log_debug( $entry, $src ) {
+		$this->log( $entry, self::DEBUG, $src );
+	}
+
+	/**
+	 * Logs a warning.
+	 *
+	 * @param string $entry
+	 * @param string $src
+	 */
+	public function log_warning( $entry, $src ) {
+		$this->log( $entry, self::WARNING, $src );
+	}
+
+	/**
+	 * Logs an error.
+	 *
+	 * @param string $entry
+	 * @param string $src
+	 */
+	public function log_error( $entry, $src ) {
+		$this->log( $entry, self::ERROR, $src );
+	}
+
+	/**
+	 * Adds an entry to the log (if it is at the appropriate level, etc).
+	 *
+	 * This is simply a shorthand for calling log() on the current logger.
+	 */
+	public function log( $entry, $type = self::DEBUG, $src = '' ) {
+		if ( $this->should_log( $type ) ) {
+			$this->get_current_logger()->log( $entry, $type, $src );
+		}
+	}
+
+	/**
+	 * Returns a list of available logging engines as an array where each
+	 * key is the classname and the value is the logger itself.
+	 *
+	 * @return array
+	 */
+	public function get_logging_engines() {
+		$available_engines = array();
+		$bundled_engines   = array(
+			'Tribe__Log__File_Logger',
+		);
+
+		foreach ( $bundled_engines as $engine_class ) {
+			$engine = $this->get_engine( $engine_class );
+
+			// Check that we have a valid engine that is available for use in the current environment
+			if ( $engine && $engine->is_available() ) {
+				$available_engines[ $engine_class ] = $engine;
+			}
+		}
+
+		/**
+		 * Offers a chance to modify the array of currently available logging engines.
+		 *
+		 * The array is organized with each key as the class name of the logging
+		 * implementation and the matching value is the actual logger object.
+		 *
+		 * @var array $available_engines
+		 */
+		return apply_filters( 'tribe_common_logging_engines', $available_engines );
+	}
+
+	/**
+	 * Returns the currently active logger or null if none is set/none are
+	 * available.
+	 *
+	 * @return Tribe__Log__Logger|null
+	 */
+	public function get_current_logger() {
+		if ( ! $this->current_logger ) {
+			$engine = tribe_get_option( 'logging_engine', null );
+			$available = $this->get_logging_engines();
+
+			if ( empty( $engine ) || ! isset( $available[$engine] ) ) {
+				return null;
+			}
+
+			$this->current_logger = $this->get_engine( $engine );
+		}
+
+		return $this->current_logger;
+	}
+
+	/**
+	 * Sets the current logging engine to the provided class (if it is a valid
+	 * and currently available logging class, else will set this to null - ie
+	 * no logging).
+	 *
+	 * @param string $engine
+	 *
+	 * @throws Exception if the specified logging engine is invalid
+	 */
+	public function set_current_logger( $engine ) {
+		$available_engines = $this->get_logging_engines();
+
+		if ( ! isset( $available_engines[ $engine ] ) ) {
+			throw new Exception( sprintf( __( 'Cannot set %s as the current logging engine', 'tribe-common' ), $engine ) );
+		}
+
+		tribe_update_option( 'logging_engine', $engine );
+		$this->current_logger = $available_engines[ $engine ];
+	}
+
+	/**
+	 * Attempts to return the requested logging object or null if that
+	 * is not possible.
+	 *
+	 * @param $class_name
+	 *
+	 * @return Tribe__Log__Logger|null
+	 */
+	public function get_engine( $class_name ) {
+		if ( ! isset( $this->loggers[ $class_name ] ) ) {
+			$object = new $class_name;
+
+			if ( is_a( $object, 'Tribe__Log__Logger' ) ) {
+				$this->loggers[$class_name] = new $class_name();
+			}
+		}
+
+		if ( isset( $this->loggers[ $class_name ] ) ) {
+			return $this->loggers[ $class_name ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Sets the current logging level to the provided level (if it is a valid
+	 * level, else will set the level to 'default').
+	 *
+	 * @param string $level
+	 */
+	public function set_level( $level ) {
+		$available_levels = wp_list_pluck( $this->get_logging_levels(), 0 );
+
+		if ( ! in_array( $level, $available_levels ) ) {
+			$level = self::DISABLE;
+		}
+
+		tribe_update_option( 'logging_level', $level );
+		$this->current_level = $level;
+	}
+
+	/**
+	 * Returns the current logging level as a string.
+	 *
+	 * @return string
+	 */
+	public function get_level() {
+		$current_level = tribe_get_option( 'logging_level', null );
+		$available_levels = wp_list_pluck( $this->get_logging_levels(), 0 );
+
+		if ( ! in_array( $current_level, $available_levels ) ) {
+			$current_level = self::DISABLE;
+		}
+
+		return $current_level;
+	}
+
+	/**
+	 * Returns a list of logging levels.
+	 *
+	 * The format is an array of arrays, each inner array being comprised of the
+	 * level code (index 0) and a human readable description (index 1).
+	 *
+	 * The ordering of the inner arrays is critical as it dictates what will be logged
+	 * when a given logging level is in effect. Example: if the current logging level
+	 * is "error" mode (only record error-level problems) then debug-level notices will
+	 * *not* be recorded and nor will warnings.
+	 *
+	 * On the other hand, if the current logging level is "debug" then debug level
+	 * notices *and* all higher levels (including warnings and errors) will be recorded.
+	 *
+	 * @return array
+	 */
+	public function get_logging_levels() {
+		if ( empty( $this->levels ) ) {
+			/**
+			 * Provides an opportunity to add or remove logging levels. This is expected
+			 * to be organized as an array of arrays: the ordering of each inner array
+			 * is critical, see Tribe__Log::get_logging_levels() docs.
+			 *
+			 * General form:
+			 *
+			 *     [
+			 *         [ 'disable' => 'description' ],  // * Do not log anything
+			 *         [ 'error'   => 'description' ],  // ^ Log only the most critical problems
+			 *         [ 'warning' => 'description' ],  // | ...
+			 *         [ 'debug'   => 'description' ]   // v Log as much data as possible, including less important trivia
+			 *     ]
+			 *
+			 * @param array $logging_levels
+			 */
+			$this->levels = (array) apply_filters( 'tribe_common_logging_levels', array(
+				array( self::DISABLE, __( 'Disabled', 'tribe-common' ) ),
+				array( self::ERROR,   __( 'Only errors', 'tribe-common' ) ),
+				array( self::WARNING, __( 'Warnings and errors', 'tribe-common' ) ),
+				array( self::DEBUG,   __( 'Full debug (all events)', 'tribe-common' ) ),
+			) );
+		}
+
+		return $this->levels;
+	}
+
+	/**
+	 * Indicates if errors relating to the specified logging level should indeed
+	 * be logged.
+	 *
+	 * Examples if the current logging level is "warning" (log all warnings and errors):
+	 *
+	 *     * Returns true for "error"
+	 *     * Returns true for "warning"
+	 *     * Returns false for "debug"
+	 *
+	 * The above assumes we are using the default logging levels.
+	 *
+	 * @param string $level_code
+	 *
+	 * @return bool
+	 */
+	protected function should_log( $level_code ) {
+		if ( empty( $this->prioritized_levels ) ) {
+			$this->build_prioritized_levels();
+		}
+
+		return $this->prioritized_levels[ $level_code ] <= $this->prioritized_levels[ $this->current_level ];
+	}
+
+	/**
+	 * Creates a second list of logging levels allowing easy lookup of
+	 * their relative priorities (ie, a means of quickly checking if
+	 * an "error" level entry should be recorded when we're in debug
+	 * mode).
+	 */
+	protected function build_prioritized_levels() {
+		foreach ( $this->get_logging_levels() as $index => $level_data ) {
+			$this->prioritized_levels[ $level_data[1] ] = $index;
+		}
+	}
+}

--- a/src/Tribe/Log/Admin.php
+++ b/src/Tribe/Log/Admin.php
@@ -212,10 +212,20 @@ class Tribe__Log__Admin {
 			return;
 		}
 
-		if ( ! empty( $_GET['log'] ) && in_array( $_GET['log'], $this->get_available_logs() ) ) {
-			$log_name = filter_var( $_GET['log'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
-			$this->current_logger()->use_log( $log_name );
+		if ( empty( $_GET['log'] ) || ! in_array( $_GET['log'], $this->get_available_logs() ) ) {
+			return;
 		}
+
+		$log_name = filter_var( $_GET['log'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
+		$this->current_logger()->use_log( $log_name );
+
+		/**
+		 * Provides an opportunity to modify the recommended filename for a downloaded
+		 * log file.
+		 * 
+		 * @param string $log_name
+		 */
+		$log_name = apply_filters( 'tribe_common_log_download_filename', $log_name );
 
 		header( 'Content-Disposition: attachment; filename="tribe-log-' . $log_name . '"' );
 		$output = fopen( 'php://output', 'w' );

--- a/src/Tribe/Log/Admin.php
+++ b/src/Tribe/Log/Admin.php
@@ -1,0 +1,220 @@
+<?php
+class Tribe__Log__Admin {
+	public function __construct() {
+		add_action( 'wp_ajax_tribe_logging_controls', array( $this, 'listen' ) );
+	}
+
+	/**
+	 * Returns the HTML comprising the event log section for use in the
+	 * Events > Settings > Help screen.
+	 *
+	 * @return string
+	 */
+	public function display_log() {
+		$log_choices  = $this->get_available_logs();
+		$log_engines  = $this->get_log_engines();
+		$log_levels   = $this->get_logging_levels();
+		$log_entries  = $this->get_log_entries();
+		$download_url = $this->get_log_url();
+
+		$this->setup_script();
+
+		ob_start();
+		include trailingslashit( Tribe__Main::instance()->plugin_path ) . 'src/admin-views/event-log.php';
+		return ob_get_clean();
+	}
+
+	/**
+	 * Listens for changes to the event log settings updating and returning
+	 * an appropriate response.
+	 */
+	public function listen() {
+		$fields = wp_parse_args( $_POST, array(
+			'check'      => '',
+			'log-level'  => '',
+			'log-engine' => '',
+		) );
+
+		foreach ( $fields as &$single_field ) {
+			$single_field = filter_var( $single_field, FILTER_SANITIZE_STRING, FILTER_FLAG_ENCODE_HIGH );
+		}
+
+		if ( ! wp_verify_nonce( $fields['check'], 'logging-controls' ) ) {
+			return;
+		}
+
+		/**
+		 * Fires before log settings are committed.
+		 *
+		 * This will not happen unless a nonce check has already passed.
+		 */
+		do_action( 'tribe_common_update_log_settings' );
+
+		$this->update_logging_level( $fields['log-level'] );
+		$this->update_logging_engine( $fields['log-engine'] );
+
+		/**
+		 * Fires immediately after log settings have been committed.
+		 */
+		do_action( 'tribe_common_updated_log_settings' );
+
+		$data = array(
+			'logs' => $this->get_available_logs(),
+		);
+
+		if ( ! empty( $fields['log-view'] ) ) {
+			$data['entries'] = $this->get_log_entries( $fields['log-view'] );
+		}
+
+		wp_send_json_success( $data );
+	}
+
+	/**
+	 * Sets the current logging level to the provided level (if it is a valid
+	 * level, else will set the level to 'default').
+	 *
+	 * @param string $level
+	 */
+	protected function update_logging_level( $level ) {
+		$this->log_manager()->set_level( $level );
+	}
+
+	/**
+	 * Sets the current logging engine to the provided class (if it is a valid
+	 * and currently available logging class, else will set this to null - ie
+	 * no logging).
+	 *
+	 * @param string $engine
+	 */
+	protected function update_logging_engine( $engine ) {
+		try {
+			$this->log_manager()->set_current_logger( $engine );
+		}
+		catch ( Exception $e ) {
+			// The class name did not relate to a valid logging engine
+		}
+	}
+
+	/**
+	 * Adds a script to handle the event log settings.
+	 */
+	protected function setup_script() {
+		wp_enqueue_script(
+			'tribe-common-logging-controls',
+			tribe_resource_url( 'admin-log-controls.js', false, 'common' ),
+			array( 'jquery' ),
+			Tribe__Main::VERSION,
+			true
+		);
+
+		wp_localize_script( 'tribe-common-logging-controls', 'tribe_logger_data', array(
+			'check' => wp_create_nonce( 'logging-controls' )
+		) );
+	}
+
+	/**
+	 * Returns a list of logs that are available for perusal.
+	 *
+	 * @return array
+	 */
+	protected function get_available_logs() {
+		$available_logs = $this->current_logger()->list_available_logs();
+
+		if ( empty( $available_logs ) ) {
+			return array( '' => _x( 'None currently available', 'log selector', 'tribe-common' ) );
+		}
+
+		return $available_logs;
+	}
+
+	/**
+	 * Returns a list of logging engines that are available for use.
+	 *
+	 * @return array
+	 */
+	protected function get_log_engines(){
+		$available_engines = $this->log_manager()->get_logging_engines();
+
+		if ( empty( $available_engines ) ) {
+			return array( '' => _x( 'None currently available', 'log engines', 'tribe-common' ) );
+		}
+
+		$engine_list = array();
+
+		foreach ( $available_engines as $class_name => $engine ) {
+			/**
+			 * @var Tribe__Log__Logger $engine
+			 */
+			$engine_list[ $class_name ] = $engine->get_name();
+		}
+
+		return $engine_list;
+	}
+
+	/**
+	 * Returns all log entries for the current or specified log.
+	 *
+	 * @return array
+	 */
+	protected function get_log_entries( $log = null ) {
+		$logger = $this->current_logger();
+		$logger->use_log( $log );
+		return $logger->retrieve();
+	}
+
+	/**
+	 * Returns an array of logging levels arranged as key:value pairs, with
+	 * each key being the level code and the value being the human-friendly
+	 * description.
+	 *
+	 * @return array
+	 */
+	protected function get_logging_levels() {
+		$levels = array();
+		$available_levels = $this->log_manager()->get_logging_levels();
+
+		foreach ( $available_levels as $logging_level ) {
+			$levels[ $logging_level[0] ] = $logging_level[1];
+		}
+
+		return $levels;
+	}
+
+	/**
+	 * Provides a URL that can be used to download the current or specified
+	 * log.
+	 *
+	 * @param $log
+	 *
+	 * @return string
+	 */
+	protected function get_log_url( $log = null ) {
+		$query = array(
+			'download' => 'tribe-common-log',
+			'check'    => wp_create_nonce( 'download_log' )
+		);
+
+		$log_download_url = add_query_arg( $query, get_admin_url( null, 'edit.php' ) );
+
+		return esc_url( $log_download_url );
+	}
+
+	/**
+	 * Returns a reference to the main log management object.
+	 *
+	 * @return Tribe__Log
+	 */
+	protected function log_manager() {
+		return Tribe__Main::instance()->log();
+	}
+
+	/**
+	 * Returns the currently enabled logging object or null if it is not
+	 * available.
+	 *
+	 * @return Tribe__Log__Logger|null
+	 */
+	protected function current_logger() {
+		return Tribe__Main::instance()->log()->get_current_logger();
+	}
+}

--- a/src/Tribe/Log/Admin.php
+++ b/src/Tribe/Log/Admin.php
@@ -3,6 +3,7 @@ class Tribe__Log__Admin {
 	public function __construct() {
 		add_action( 'wp_ajax_tribe_logging_controls', array( $this, 'listen' ) );
 		add_action( 'init', array( $this, 'serve_log_downloads' ) );
+		add_action( 'init', array( $this, 'register_script' ) );
 	}
 
 	/**
@@ -37,7 +38,7 @@ class Tribe__Log__Admin {
 		) );
 
 		foreach ( $fields as &$single_field ) {
-			$single_field = filter_var( $single_field, FILTER_SANITIZE_STRING, FILTER_FLAG_ENCODE_HIGH );
+			$single_field = sanitize_text_field( $single_field );
 		}
 
 		if ( ! wp_verify_nonce( $fields['check'], 'logging-controls' ) ) {
@@ -97,17 +98,23 @@ class Tribe__Log__Admin {
 	}
 
 	/**
-	 * Adds a script to handle the event log settings.
+	 * Register our script early.
 	 */
-	protected function setup_script() {
-		wp_enqueue_script(
+	public function register_script() {
+		wp_register_script(
 			'tribe-common-logging-controls',
 			tribe_resource_url( 'admin-log-controls.js', false, 'common' ),
 			array( 'jquery' ),
 			Tribe__Main::VERSION,
 			true
 		);
+	}
 
+	/**
+	 * Adds a script to handle the event log settings.
+	 */
+	protected function setup_script() {
+		wp_enqueue_script( 'tribe-common-logging-controls' );
 		wp_localize_script( 'tribe-common-logging-controls', 'tribe_logger_data', array(
 			'check' => wp_create_nonce( 'logging-controls' )
 		) );

--- a/src/Tribe/Log/Admin.php
+++ b/src/Tribe/Log/Admin.php
@@ -216,13 +216,13 @@ class Tribe__Log__Admin {
 			return;
 		}
 
-		$log_name = filter_var( $_GET['log'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
+		$log_name = sanitize_file_name( $_GET['log'] );
 		$this->current_logger()->use_log( $log_name );
 
 		/**
 		 * Provides an opportunity to modify the recommended filename for a downloaded
 		 * log file.
-		 * 
+		 *
 		 * @param string $log_name
 		 */
 		$log_name = apply_filters( 'tribe_common_log_download_filename', $log_name );

--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Simple file based logging implementation.
+ *
+ * By default, this logger uses the system temporary directory for logging
+ * purposes and performs daily log rotation.
+ */
+class Tribe__Log__File_Logger implements Tribe__Log__Logger {
+	protected $module_id = 'tribe_tmp_file_logger';
+	protected $log_dir   = '';
+	protected $log_file  = '';
+	protected $context   = 'a';
+	protected $handle;
+
+	public function __construct() {
+		$this->set_log_dir();
+		$this->set_log_file();
+	}
+
+	public function __destruct() {
+		$this->close_handle();
+	}
+
+	protected function set_log_dir() {
+		/**
+		 * Controls the directory used for logging.
+		 *
+		 * @var string $log_dir
+		 */
+		$this->log_dir = apply_filters( 'tribe_file_logger_directory', sys_get_temp_dir() );
+	}
+
+	/**
+	 * Sets the path for the log file we're currently interested in using.
+	 *
+	 * @param string $date = null
+	 */
+	protected function set_log_file( $date = null ) {
+		$this->log_file = $this->get_log_file_name( $date );
+		$this->obtain_handle();
+	}
+
+	/**
+	 * Used to switch between contexts for reading ('r') and writing
+	 * ('a' := append) modes.
+	 *
+	 * @see fopen() documentation
+	 *
+	 * @param string $context
+	 */
+	protected function set_context( $context ) {
+		$this->context = $context;
+		$this->close_handle();
+		$this->obtain_handle();
+	}
+
+	/**
+	 * Attempts to obtain a file handle for the current log file.
+	 */
+	protected function obtain_handle() {
+		$this->close_handle();
+		$this->handle = fopen( $this->log_file, $this->context );
+	}
+
+	/**
+	 * Closes the current file handle, if one is open.
+	 */
+	protected function close_handle() {
+		// is_resource() only returns true for open resources
+		if ( is_resource( $this->handle ) ) {
+			fclose( $this->handle );
+		}
+	}
+
+	/**
+	 * Returns the log name to be used for reading/writing events for a specified date
+	 * (defaulting to today, if no date is specified).
+	 *
+	 * @param string $date = null
+	 *
+	 * @return string
+	 */
+	protected function get_log_file_name( $date = null ) {
+		if ( null === $date ) {
+			$date = date_i18n( 'Y-m-d' );
+		}
+
+		$filename = $this->log_dir . DIRECTORY_SEPARATOR . $this->get_log_file_basename() . $date . '.log';
+
+		/**
+		 * Dictates the filename of the log used to record events for the specified date.
+		 *
+		 * @var string $filename
+		 * @var string $date
+		 */
+		return apply_filters( 'tribe_file_logger_filename', $filename, $date );
+	}
+
+	protected function get_log_file_basename() {
+		/**
+		 * Log files share a common prefix, which aids identifying archived/rotated logs.
+		 * This filter allows a degree of control to be exercised over the prefix to avoid
+		 * conflicts, etc.
+		 *
+		 * @var string $log_file_base_name
+		 */
+		return apply_filters( 'tribe_file_logger_file_prefix', $this->module_id . '_' );
+	}
+
+	/**
+	 * Returns a 'human friendly' name for the logging implementation.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Default (uses temporary files)', 'tribe-common' );
+	}
+
+	/**
+	 * Indicates if the logger will work in the current environment.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return is_writable( $this->log_dir ) && is_readable( $this->log_dir );
+	}
+
+	/**
+	 * Responsible for commiting the entry to the log.
+	 *
+	 * @param string $entry
+	 * @param string $type
+	 * @param string $src
+	 */
+	public function log( $entry, $type = Tribe__Log::DEBUG, $src = '' ) {
+		// Ensure we're in 'append' mode before we try to write
+		if ( 'a' !== $this->context ) {
+			$this->set_context( 'a' );
+		}
+
+		fputcsv( $this->handle, array( date_i18n( 'Y-m-d H:i:s' ), $entry, $type, $src ) );
+	}
+
+	/**
+	 * Retrieve up to $limit most recent log entries in reverse chronological
+	 * order. If $limit is a negative or zero value, there is no limit.
+	 *
+	 * Supports passing a 'log' argument to recover
+	 *
+	 * @see Tribe__Log__Logger::list_available_logs()
+	 *
+	 * @param int   $limit
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	public function retrieve( $limit = 0, array $args = array() ) {
+		// Ensure we're in 'read' mode before we try to retrieve
+		if ( 'r' !== $this->context ) {
+			$this->set_context( 'r' );
+		}
+
+		$rows = array();
+
+		while ( $current_row = fgetcsv( $this->handle ) ) {
+			if ( $limit && $limit === count( $rows ) ) {
+				array_shift( $rows );
+			}
+
+			$rows[] = $current_row;
+		}
+
+		return array_reverse( $rows );
+	}
+
+	/**
+	 * Returns a list of currently accessible logs (current first, oldest last).
+	 * Each is refered to by date.
+	 *
+	 * Example:
+	 *
+	 *     [ '2016-12-31',
+	 *       '2016-12-30',
+	 *       '2016-12-30',
+	 *       '2016-12-30',
+	 *       '2016-12-30', ... ]
+	 *
+	 * @return array
+	 */
+	public function list_available_logs() {
+		$logs = array();
+		$basename = $this->get_log_file_basename();
+
+		// Look through the log storage directory
+		foreach ( new DirectoryIterator( $this->log_dir ) as $node ) {
+			$name = $node->getFilename();
+
+			// Skip unless it is a .log file with the expected prefix
+			if ( 'log' !== $node->getExtension() || 0 !== strpos( $name, $basename ) ) {
+				continue;
+			}
+
+			if ( preg_match( '/([0-9]{4}\-[0-9]{2}\-[0-9]{2})/', $name, $matches ) ) {
+				$logs[] = $matches[1];
+			}
+		}
+
+		rsort( $logs );
+		return $logs;
+	}
+
+	/**
+	 * Switches to the specified log. The $log_identifier should take the
+	 * form of a "yyyy-mm-dd" format date string.
+	 *
+	 * If optional param $create is true then it will try to create a log
+	 * using the provided identifier. If the log does not exist, cannot be
+	 * created or an invalid identifier has been passed in then boolean false
+	 * will be returned, otherwise it will attempt to switch to the new log.
+	 *
+	 * @param mixed $log_identifier
+	 * @param bool $create
+	 *
+	 * @return bool
+	 */
+	public function use_log( $log_identifier, $create = false ) {
+		$log_file = $this->get_log_file_name( $log_identifier );
+		$exists   = file_exists( $log_file );
+
+		if ( ! $exists && ! $create ) {
+			return false;
+		}
+
+		if ( ! $exists && $create && preg_match( '/^([0-9]{4}\-[0-9]{2}\-[0-9]{2})$/', $log_file ) ) {
+			if ( false === file_put_contents( $log_file, '' ) ) {
+				return false;
+			}
+		}
+
+		$this->set_log_file( $log_identifier );
+		return true;
+	}
+
+	/**
+	 * Performs routine maintenance and cleanup work (such as log rotation)
+	 * whenever it is called.
+	 */
+	public function cleanup() {
+		// Default to retaining 7 days worth of logs
+		$cutoff = date_i18n( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS );
+
+		/**
+		 * Logs falling on or earlier than this date will be removed.
+		 *
+		 * @param string $cutoff 'Y-m-d' format date string
+		 */
+		$cutoff = apply_filters( 'tribe_file_logger_cutoff', $cutoff );
+
+		foreach ( $this->list_available_logs() as $available_log ) {
+			if ( $available_log <= $cutoff ) {
+				unlink( $this->get_log_file_name( $available_log ) );
+			}
+		}
+	}
+}

--- a/src/Tribe/Log/Logger.php
+++ b/src/Tribe/Log/Logger.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Specifies the minimal interface required of all logging implementations.
+ */
+interface Tribe__Log__Logger {
+	/**
+	 * Indicates if the logger will work in the current environment.
+	 *
+	 * @return bool
+	 */
+	public function is_available();
+
+	/**
+	 * Returns a 'human friendly' name for the logging implementation.
+	 *
+	 * @return string
+	 */
+	public function get_name();
+
+	/**
+	 * Responsible for commiting the entry to the log (but only if the debug level
+	 * is appropriate).
+	 *
+	 * @param string $entry
+	 * @param string $type
+	 * @param string $src
+	 */
+	public function log( $entry, $type = Tribe__Log::DEBUG, $src = '' );
+
+	/**
+	 * Retrieve up to $limit most recent log entries in reverse chronological
+	 * order. If $limit is a negative or zero value, there is no limit.
+	 *
+	 * Implementation-specific arguments can optionally be provided as a second
+	 * parameter. This may include support for a 'log' param where an identifer
+	 * obtained via the list_availalbe_logs() method is passed in order to query
+	 * a specific archived log.
+	 *
+	 * @see Tribe__Log__Logger::list_available_logs()
+	 *
+	 * @param int   $limit
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	public function retrieve( $limit = 0, array $args = array() );
+
+	/**
+	 * Returns a list of currently accessible logs (current first, oldest last).
+	 *
+	 * This can be useful if, for instance, a particular logger organizes logging
+	 * by dates and keeps an archive of upto 1 week's worth of logs - in which case
+	 * the array might look like:
+	 *
+	 *     [ '2016-12-31',
+	 *       '2016-12-30',
+	 *       '2016-12-30',
+	 *       '2016-12-30',
+	 *       '2016-12-30', ... ]
+	 *
+	 * Note that a) the array may be empty and b) it won't necessarily contain
+	 * date strings, it could contain identifiers like 'current', 'prev', 'prev2'
+	 * or really anything the logging engine prefers.
+	 *
+	 * @return array
+	 */
+	public function list_available_logs();
+
+	/**
+	 * Switches to the specified log.
+	 *
+	 * If optional param $create is true the logger will try to create a new log
+	 * using the provided identifier if it doesn't already exist.
+	 *
+	 * @param mixed $log_identifier
+	 * @param bool $create
+	 *
+	 * @return bool
+	 */
+	public function use_log( $log_identifier, $create = false );
+
+
+	/**
+	 * Performs routine maintenance and cleanup work (such as log rotation)
+	 * whenever it is called.
+	 */
+	public function cleanup();
+}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -23,6 +23,7 @@ class Tribe__Main {
 	protected $plugin_context;
 	protected $plugin_context_class;
 	protected $doing_ajax = false;
+	protected $log;
 
 	public static $tribe_url = 'http://tri.be/';
 	public static $tec_url = 'http://theeventscalendar.com/';
@@ -89,6 +90,9 @@ class Tribe__Main {
 
 		require_once $this->plugin_path . 'src/functions/template-tags/general.php';
 		require_once $this->plugin_path . 'src/functions/template-tags/date.php';
+
+		// Starting the log manager needs to wait until after the tribe_*_option() functions have loaded
+		$this->log = new Tribe__Log();
 	}
 
 	/**
@@ -208,6 +212,13 @@ class Tribe__Main {
 		if ( $helper->is_post_type_screen() ) {
 			wp_enqueue_style( 'tribe-jquery-ui-datepicker' );
 		}
+	}
+
+	/**
+	 * @return Tribe__Log
+	 */
+	public function log() {
+		return $this->log;
 	}
 
 	/**

--- a/src/admin-views/event-log.php
+++ b/src/admin-views/event-log.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @var array  $log_choices
+ * @var array  $log_engines
+ * @var array  $log_levels
+ * @var array  $log_entries
+ * @var string $download_url
+ */
+?>
+<div id="tribe-log-controls">
+
+	<?php
+	/**
+	 * Fires within the #tribe-log-controls div, before any of the default
+	 * controls are generated.
+	 */
+	do_action( 'tribe_common_log_controls_top' );
+	?>
+
+	<div>
+		<label for="log-levels"><?php esc_html_e( 'Logging level', 'tribe-common' ) ?></label>
+		<select name="log-level" id="log-level">
+			<?php foreach ( $log_levels as $code => $name ): ?>
+				<option name="<?php echo esc_attr( $code ) ?>" <?php selected( $code, tribe_get_option( 'logging_level') ); ?>>
+					<?php echo esc_html( $name ) ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+	</div>
+
+	<?php
+	/**
+	 * Fires within the #tribe-log-controls div, after the #log-level control.
+	 */
+	do_action( 'tribe_common_log_controls_after_log_level' );
+	?>
+
+	<div>
+		<label for="log-engine"><?php esc_html_e( 'Method', 'tribe-common' ) ?></label>
+		<select name="log-engine" id="log-engine">
+			<?php foreach ( $log_engines as $code => $name ): ?>
+				<option name="<?php echo esc_attr( $code ) ?>" <?php selected( $code, tribe_get_option( 'logging_engine') ); ?>>
+					<?php echo esc_html( $name ) ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+	</div>
+
+	<?php
+	/**
+	 * Fires within the #tribe-log-controls div, after the #log-engine control.
+	 */
+	do_action( 'tribe_common_log_controls_after_log_engine' );
+	?>
+
+	<div>
+		<label for="log-selector"><?php esc_html_e( 'View', 'tribe-common' ) ?></label>
+		<select name="log-selector" id="log-selector">
+			<?php foreach ( $log_choices as $name ): ?>
+				<option name="<?php echo esc_attr( $name ) ?>"><?php echo esc_html( $name ) ?></option>
+			<?php endforeach; ?>
+		</select>
+	</div>
+
+	<?php
+	/**
+	 * Fires within the #tribe-log-controls div, after the #log-selector control.
+	 */
+	do_action( 'tribe_common_log_controls_after_log_selector' );
+	?>
+
+	<div class="working hidden">
+		<img src="<?php echo esc_url( get_admin_url( null, '/images/spinner.gif' ) ); ?>" />
+	</div>
+
+	<?php
+	/**
+	 * Fires within the #tribe-log-controls div, after all of the default
+	 * controls have been generated.
+	 */
+	do_action( 'tribe_common_log_controls_bottom' );
+	?>
+
+</div>
+
+<div id="tribe-log-viewer">
+
+	<table>
+		<?php foreach ( $log_entries as $data ): ?>
+			<tr>
+				<?php foreach ( $data as $single_cell ): ?>
+					<td><?php echo esc_html( $single_cell ); ?></td>
+				<?php endforeach; ?>
+			</tr>
+		<?php endforeach; ?>
+	</table>
+
+	<?php if ( empty( $log_entries ) ): ?>
+		<p><?php esc_html_e( 'The selected log file is empty or has not been generated yet.', 'tribe-common' ); ?></p>
+	<?php endif; ?>
+
+</div>
+
+<p> <a href="<?php echo esc_url( $download_url ) ?>" class="download_log" target="_blank"><?php esc_html_e( 'Download log', 'tribe-common' ); ?> </a> </p>

--- a/src/admin-views/tribe-options-help.php
+++ b/src/admin-views/tribe-options-help.php
@@ -36,6 +36,9 @@ $help->add_section_content( 'system-info', __( 'The details of your calendar plu
 
 $help->add_section( 'template-changes', __( 'Recent Template Changes', 'tribe-common' ), 40 );
 $help->add_section_content( 'template-changes', Tribe__Support__Template_Checker_Report::generate() );
+
+$help->add_section( 'event-log', __( 'Event Log', 'tribe-common' ), 50 );
+$help->add_section_content( 'event-log', Tribe__Main::instance()->log()->admin()->display_log() );
 ?>
 
 <div id="tribe-help-general">

--- a/src/resources/css/tribe-common-admin.css
+++ b/src/resources/css/tribe-common-admin.css
@@ -406,7 +406,30 @@ table.plugins .tribe-plugin-update-message a {
 .tribe-section-type-box ul ul {
 	list-style: circle;
 }
+#tribe-log-controls {
+	padding-bottom: 16px;
+	padding-bottom: 1rem;
+	
+	/* For consistency with help screen h3 and p elements */
+	padding-left: 12px;
+}
+#tribe-log-controls > div {
+	display: inline-block;
+	padding-right: 16px;
+	padding-right: 1rem;
+}
+#tribe-log-controls .working {
+	opacity: 1;
+	-webkit-transition: opacity 0.2s;
+	transition: opacity 0.2s;
+}
+#tribe-log-controls .working.hidden {
+	opacity: 0;
+	-webkit-transition: opacity 0.2s;
+	transition: opacity 0.2s;
+}
 #tribe-system-info dl.support-stats,
+#tribe-log-viewer,
 .template-updates-wrapper {
 	background: #000;
 	border-radius: 2px;

--- a/src/resources/js/admin-log-controls.js
+++ b/src/resources/js/admin-log-controls.js
@@ -1,0 +1,107 @@
+var tribe_logger_admin = tribe_logger_admin || {};
+var tribe_logger_data  = tribe_logger_data || {};
+
+( function( $, obj ) {
+	var working      = false;
+	var current_view = '';
+	var view_changed = false;
+	var $controls    = $( '#tribe-log-controls' );
+	var $options     = $controls.find( 'select' );
+	var $spinner     = $controls.find( '.working' );
+	var $viewer      = $( '#tribe-log-viewer' );
+
+	function update() {
+		// If an update is already in progress let's wait until that job completes
+		if ( working ) {
+			return;
+		}
+
+		detect_view_change();
+		freeze();
+		request();
+	}
+
+	function request() {
+		var data = {
+			'action':     'tribe_logging_controls',
+			'check':      tribe_logger_data.check,
+			'log-level':  $( '#log-level' ).find( ':selected' ).attr( 'name' ),
+			'log-engine': $( '#log-engine' ).find( ':selected' ).attr( 'name' )
+		};
+
+		if ( view_changed ) {
+			data['log-view'] = current_view;
+		}
+
+		$.ajax( ajaxurl, {
+			'method':   'POST',
+			'success':  on_success,
+			'error':    on_error,
+			'dataType': 'json',
+			'data':     data
+		} );
+	}
+
+	function on_success( data ) {
+		unfreeze();
+
+		if ( $.isArray( data.data.entries ) ) {
+			$viewer.html( to_table( data.data.entries ) );
+		}
+	}
+
+	/**
+	 * Converts data_array, which is expected to be an array of
+	 * arrays, into an HTML table.
+	 */
+	function to_table( data_array ) {
+		var html = '<table>';
+
+		for ( var row in data_array ) {
+			html += '<tr>';
+
+			for ( var cell in data_array[row] ) {
+				html += '<td>' + data_array[row][cell] + '</td>';
+			}
+
+			html += '</tr>';
+		}
+
+		return html + '</table>';
+	}
+
+	function on_error() {
+		unfreeze();
+	}
+
+	function freeze() {
+		working = true;
+		$options.prop( 'disabled', true );
+		$spinner.removeClass( 'hidden' );
+	}
+
+	function unfreeze() {
+		working = false;
+		$options.prop( 'disabled', false );
+		$spinner.addClass( 'hidden' );
+	}
+
+	function detect_view_change() {
+		var new_view = get_current_view();
+
+		if ( new_view !== current_view ) {
+			view_changed = true;
+			current_view = new_view;
+		} else {
+			view_changed = false;
+		}
+	}
+
+	function get_current_view() {
+		return $( '#log-selector' ).find( ':selected' ).attr( 'name' );
+	}
+
+	// Setup
+	current_view = get_current_view();
+	$options.change( update );
+} )( jQuery, tribe_logger_admin );

--- a/src/resources/js/admin-log-controls.js
+++ b/src/resources/js/admin-log-controls.js
@@ -2,13 +2,15 @@ var tribe_logger_admin = tribe_logger_admin || {};
 var tribe_logger_data  = tribe_logger_data || {};
 
 ( function( $, obj ) {
-	var working      = false;
-	var current_view = '';
-	var view_changed = false;
-	var $controls    = $( '#tribe-log-controls' );
-	var $options     = $controls.find( 'select' );
-	var $spinner     = $controls.find( '.working' );
-	var $viewer      = $( '#tribe-log-viewer' );
+	var working        = false;
+	var current_view   = '';
+	var current_engine = '';
+	var view_changed   = false;
+	var $controls      = $( '#tribe-log-controls' );
+	var $options       = $controls.find( 'select' );
+	var $spinner       = $controls.find( '.working' );
+	var $viewer        = $( '#tribe-log-viewer' );
+	var $download_link = $( 'a.download_log' );
 
 	function update() {
 		// If an update is already in progress let's wait until that job completes
@@ -47,6 +49,7 @@ var tribe_logger_data  = tribe_logger_data || {};
 
 		if ( $.isArray( data.data.entries ) ) {
 			$viewer.html( to_table( data.data.entries ) );
+			update_download_link();
 		}
 	}
 
@@ -70,6 +73,23 @@ var tribe_logger_data  = tribe_logger_data || {};
 		return html + '</table>';
 	}
 
+	function update_download_link() {
+		var url = $download_link.attr( 'href' );
+		var log = encodeURI( get_current_view() );
+		var matches = url.match(/&log=([a-z0-9\-]+)/i);
+
+		// Update or add the log parameter
+		if ( $.isArray( matches ) && 2 === matches.length ) {
+			url = url.replace( matches[0], '&log=' + log );
+		} else if ( url.indexOf( '?' ) ) {
+			url = url + '&log=' + log;
+		} else {
+			url = url + '?log=' + log;
+		}
+
+		$download_link.attr( 'href', url );
+	}
+
 	function on_error() {
 		unfreeze();
 	}
@@ -88,10 +108,12 @@ var tribe_logger_data  = tribe_logger_data || {};
 
 	function detect_view_change() {
 		var new_view = get_current_view();
+		var new_engine = get_current_engine();
 
-		if ( new_view !== current_view ) {
+		if ( new_view !== current_view || new_engine !== current_engine ) {
 			view_changed = true;
 			current_view = new_view;
+			current_engine = new_engine;
 		} else {
 			view_changed = false;
 		}
@@ -101,7 +123,14 @@ var tribe_logger_data  = tribe_logger_data || {};
 		return $( '#log-selector' ).find( ':selected' ).attr( 'name' );
 	}
 
+	function get_current_engine() {
+		return $( '#log-engine' ).find( ':selected' ).attr( 'name' );
+	}
+
 	// Setup
 	current_view = get_current_view();
+	current_engine = get_current_engine();
+
+	update_download_link();
 	$options.change( update );
 } )( jQuery, tribe_logger_admin );

--- a/src/resources/js/admin-log-controls.js
+++ b/src/resources/js/admin-log-controls.js
@@ -12,6 +12,9 @@ var tribe_logger_data  = tribe_logger_data || {};
 	var $viewer        = $( '#tribe-log-viewer' );
 	var $download_link = $( 'a.download_log' );
 
+	/**
+	 * Update the log view based on changes to the various selectors.
+	 */
 	function update() {
 		// If an update is already in progress let's wait until that job completes
 		if ( working ) {
@@ -23,6 +26,10 @@ var tribe_logger_data  = tribe_logger_data || {};
 		request();
 	}
 
+	/**
+	 * Communicate any changes back to the server so we can obtain fresh log data
+	 * to display to the user.
+	 */
 	function request() {
 		var data = {
 			'action':     'tribe_logging_controls',
@@ -44,6 +51,11 @@ var tribe_logger_data  = tribe_logger_data || {};
 		} );
 	}
 
+	/**
+	 * Unfreeze the controls (following an update) and refresh on-screen data as needed.
+	 *
+	 * @param data
+	 */
 	function on_success( data ) {
 		unfreeze();
 
@@ -73,6 +85,10 @@ var tribe_logger_data  = tribe_logger_data || {};
 		return html + '</table>';
 	}
 
+	/**
+	 * Add, append or update the log download link so it points to the
+	 * currently selected log file.
+	 */
 	function update_download_link() {
 		var url = $download_link.attr( 'href' );
 		var log = encodeURI( get_current_view() );
@@ -90,22 +106,41 @@ var tribe_logger_data  = tribe_logger_data || {};
 		$download_link.attr( 'href', url );
 	}
 
+	/**
+	 * If our request back to the server failed, unfreeze the controls so
+	 * we can try again.
+	 *
+	 * @todo in a future iteration we should add substantive handling for this scenario
+	 */
 	function on_error() {
 		unfreeze();
 	}
 
+	/**
+	 * Freeze/disable the controls and show the spinner.
+	 */
 	function freeze() {
 		working = true;
 		$options.prop( 'disabled', true );
 		$spinner.removeClass( 'hidden' );
 	}
 
+	/**
+	 * Unfreeze/enable the controls and hide the spinner.
+	 */
 	function unfreeze() {
 		working = false;
 		$options.prop( 'disabled', false );
 		$spinner.addClass( 'hidden' );
 	}
 
+	/**
+	 * Check if a change in controls constituting a change of view has occured.
+	 *
+	 * This could be because the user changed logging engine or because they picked
+	 * a different log to peruse; a change in logging level on the other hand does
+	 * not count.
+	 */
 	function detect_view_change() {
 		var new_view = get_current_view();
 		var new_engine = get_current_engine();

--- a/src/resources/postcss/tribe-common-admin.pcss
+++ b/src/resources/postcss/tribe-common-admin.pcss
@@ -446,7 +446,30 @@ table.plugins .tribe-plugin-update-message a {
 	list-style: circle;
 }
 
+#tribe-log-controls {
+	padding-bottom: 1rem;
+	
+	/* For consistency with help screen h3 and p elements */
+	padding-left: 12px;
+
+	& > div {
+		display: inline-block;
+		padding-right: 1rem;
+	}
+
+	.working {
+		opacity: 1;
+		transition: opacity 0.2s;
+	}
+
+	.working.hidden {
+		opacity: 0;
+		transition: opacity 0.2s;
+	}
+}
+
 #tribe-system-info dl.support-stats,
+#tribe-log-viewer,
 .template-updates-wrapper {
 	background: #000;
 	border-radius: 2px;

--- a/tests/functional/File_Logging_Test.php
+++ b/tests/functional/File_Logging_Test.php
@@ -1,0 +1,174 @@
+<?php
+namespace Tribe\Common;
+
+use Codeception\TestCase\WPTestCase,
+	Tribe__Log,
+	Tribe__Log__Logger,
+	Tribe__Main;
+
+class Logging_Test extends WPTestCase {
+	/**
+	 * @var Tribe__Log
+	 */
+	protected $log_manager;
+
+	/**
+	 * @var Tribe__Log__Logger
+	 */
+	protected $logger;
+
+	/**
+	 * Dates for which test logs are available.
+	 *
+	 * @var array
+	 */
+	protected $test_dates = array();
+
+	public function setUp() {
+		$this->use_test_prefix();
+		$this->configure_logging();
+	}
+
+	/**
+	 * We switch away from the default log file prefix to prevent file ownership
+	 * issues during testing.
+	 */
+	protected function use_test_prefix() {
+		add_filter( 'tribe_file_logger_file_prefix', function() {
+			return 'tribe_common_logging_test_';
+		} );
+	}
+
+	/**
+	 * Each test run normally starts with a clean installation, so we need to set
+	 * up the default file logger for the first time.
+	 */
+	protected function configure_logging() {
+		$this->log_manager = Tribe__Main::instance()->log();
+		$this->log_manager->set_current_logger( 'Tribe__Log__File_Logger' );
+		$this->logger = $this->log_manager->get_current_logger();
+	}
+
+	/**
+	 * (Re-)creates a set of test logs staggered over the default cleanup threshold.
+	 */
+	protected function create_test_logs() {
+		$this->assertNotNull( $this->logger );
+		$test_data_dir = dirname( __DIR__ ) . '/_data/log_file_data';
+
+		$this->test_dates = array(
+			// Subject to cleanup by default (at least 7 days old):
+			date_i18n( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS - DAY_IN_SECONDS ),
+			date_i18n( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS ),
+
+			// Safe from cleanup by default:
+			date_i18n( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS + DAY_IN_SECONDS ),
+			date_i18n( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS + ( 2 * DAY_IN_SECONDS ) ),
+		);
+
+		$existing_logs = $this->logger->list_available_logs();
+
+		foreach ( $this->test_dates as $log_date ) {
+			// Only (re-)create the test logs when required
+			if ( in_array( $log_date, $existing_logs ) ) {
+				continue;
+			}
+
+			$this->logger->use_log( $log_date, true );
+			$test_entries = rand( 10, 20 );
+
+			for ( $i = 0; $i <= $test_entries; $i++ ) {
+				$this->logger->log(
+					$this->get_gibberish_text(),
+					$this->get_gibberish_text(),
+					$this->get_gibberish_text()
+				);
+			}
+		}
+	}
+
+	/**
+	 * Returns a random 'sentence' of words with randomish characters.
+	 *
+	 * Example: '91cf5305fb 6de72e032d1 00ad3ee86a76 1c0d 0f087 e3a2c5d16482 a6bede4'
+	 *
+	 * @return string
+	 */
+	protected function get_gibberish_text() {
+		$text = '';
+		$count = rand( 2, 12 );
+
+		for ( $i = 0; $i <= $count; $i++ ) {
+			$text .= substr( hash( 'md5', uniqid() ), 0, rand( 4, 12 ) ) . ' ';
+		}
+
+		return trim( $text );
+	}
+
+	/**
+	 * The default file logger should be listed as available and indeed ought to be
+	 * set as the current logger.
+	 */
+	public function test_logger_is_available() {
+		$this->assertArrayHasKey( 'Tribe__Log__File_Logger', $this->log_manager->get_logging_engines() );
+		$this->assertInstanceOf( 'Tribe__Log__Logger', $this->logger );
+	}
+
+	/**
+	 * Ensure logs can be created for specified dates.
+	 */
+	public function test_logs_can_be_created() {
+		$this->create_test_logs();
+		$available_logs = $this->logger->list_available_logs();
+		$this->assertNotEmpty( $available_logs );
+	}
+
+	/**
+	 * Ensure that when we have written to logs we can later retrieve the
+	 * content.
+	 */
+	public function test_logs_can_be_read() {
+		$last_log_signature = '';
+
+		foreach ( $this->test_dates as $log_date ) {
+			$this->assertTrue( $this->logger->use_log( $log_date, 'Can switch to specified log' ) );
+
+			// Get the log entries and get a unique hash: by comparing with the hash from the last set
+			// of logs we can ensure we aren't repeatedly fetching the same entries from the same log
+			$log_entries = $this->logger->retrieve();
+			$log_signature = hash( 'md5', join( $log_entries ) );
+
+			$this->assertNotEmpty( $log_entries, 'Entries were retrieved from the log' );
+			$this->assertNotEquals( $log_signature, $last_log_signature, 'Entries were retrieved from the desired log' );
+
+			$last_log_signature = $log_signature;
+		}
+	}
+
+	/**
+	 * Run the cleanup function and ensure it removes expired logs as
+	 * expected.
+	 */
+	public function test_log_cleanup() {
+		// Our test log setup creates 2 expired logs and 2 that are still valid
+		// ...another valid log is also created automatically for today's date
+		$original_count = $this->count_available_logs();
+		$this->logger->cleanup();
+
+		// We expect at least 3 logs to survive cleanup and at least 2 to have
+		// been purged
+		$new_count = $this->count_available_logs();
+		$difference = $original_count - $new_count;
+
+		$this->assertGreaterThanOrEqual( 2, $difference, 'At least 2 logs should have been removed' );
+		$this->assertGreaterThanOrEqual( 3, $new_count, 'At least 3 logs should have survived cleanup' );
+	}
+
+	/**
+	 * @return int
+	 */
+	protected function count_available_logs() {
+		$available = $this->logger->list_available_logs();
+		return count( $available );
+	}
+}

--- a/tests/functional/File_Logging_Test.php
+++ b/tests/functional/File_Logging_Test.php
@@ -2,9 +2,9 @@
 namespace Tribe\Common;
 
 use Codeception\TestCase\WPTestCase,
-	Tribe__Log,
-	Tribe__Log__Logger,
-	Tribe__Main;
+    Tribe__Log,
+    Tribe__Log__Logger,
+    Tribe__Main;
 
 class Logging_Test extends WPTestCase {
 	/**


### PR DESCRIPTION
Adds a logging framework, with help tab integration, that our plugins can take advantage of. 

Notes:

* Includes a @todo item, I'm aware of this but inclined to defer further work for this specifically
* Changes in `get_content_html()` (stripping out usage of Kses) was discussed in team chat, I don't believe there's a disadvantage to this and it makes it easier to add new items to the help screen - definitely up for more discussion though :-)

[C#36047](https://central.tri.be/issues/36047)