### PR TITLE
added filtering to the address components

### DIFF
--- a/src/Tribe/Utils/Coordinates_Provider.php
+++ b/src/Tribe/Utils/Coordinates_Provider.php
@@ -66,7 +66,7 @@ class Tribe__Utils__Coordinates_Provider {
 	public function provide_coordinates_for_address( $address ) {
 
 		if ( is_array( $address ) ) {
-			$address = implode( ', ', $address );
+			$address = implode( ', ', array_filter( array_map( 'trim', $address ) ) );
 		}
 
 		$address = trim( $address );

--- a/tests/wpunit/Tribe/Utils/Coordinates_ProviderTest.php
+++ b/tests/wpunit/Tribe/Utils/Coordinates_ProviderTest.php
@@ -241,6 +241,49 @@ JSON;
 
 	/**
 	 * @test
+	 * it should accept array addresses as arguments
+	 */
+	public function it_should_accept_array_addresses_as_well() {
+		$string_address      = '10, Downing Street, London, UK';
+		$address      = [
+			'10, Downing Street',
+			'London', 
+			'UK',
+		];
+		
+		$expected_url = esc_url( add_query_arg( array( 'address' => $string_address ), Coordinates_Provider::$google_api_base . Coordinates_Provider::$google_api_json_format ) );
+		$this->http->get( $expected_url )->shouldBeCalled();
+
+		$sut = $this->make_instance();
+
+		$sut->provide_coordinates_for_address( $address );
+	}
+
+	/**
+	 * @test
+	 * it should filter out empty strings from the address
+	 */
+	public function it_should_filter_out_empty_strings_from_the_address() {
+		$string_address      = '10, Downing Street, London, UK';
+		$address      = [
+			'10, Downing Street',
+			'',
+			'London',
+			'       ',
+			'UK',
+			'  ',
+		];
+
+		$expected_url = esc_url( add_query_arg( array( 'address' => $string_address ), Coordinates_Provider::$google_api_base . Coordinates_Provider::$google_api_json_format ) );
+		$this->http->get( $expected_url )->shouldBeCalled();
+
+		$sut = $this->make_instance();
+
+		$sut->provide_coordinates_for_address( $address );
+	}
+
+	/**
+	 * @test
 	 * it should return false if request fails
 	 */
 	public function it_should_return_false_if_request_fails() {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/45712

Collateral to the work done by @bordoni here.

This PR makes sure the `Coordinates_Provider` will filter out empty address components.