### PR TITLE
Disable logging | #36047

### DIFF
--- a/src/admin-views/tribe-options-help.php
+++ b/src/admin-views/tribe-options-help.php
@@ -36,9 +36,6 @@ $help->add_section_content( 'system-info', __( 'The details of your calendar plu
 
 $help->add_section( 'template-changes', __( 'Recent Template Changes', 'tribe-common' ), 40 );
 $help->add_section_content( 'template-changes', Tribe__Support__Template_Checker_Report::generate() );
-
-$help->add_section( 'event-log', __( 'Event Log', 'tribe-common' ), 50 );
-$help->add_section_content( 'event-log', Tribe__Main::instance()->log()->admin()->display_log() );
 ?>
 
 <div id="tribe-help-general">


### PR DESCRIPTION
Per discussion in linked issue, we'll keep the logging code in place but effectively disable it until we add code elsewhere that can make use of it.

[C#36047](https://central.tri.be/issues/36047)