### PR TITLE
Delete error msgs once displayed, not each shutdown | #46544

### DIFF
--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -161,7 +161,6 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 			add_action( 'admin_init', array( $this, 'initTabs' ) );
 			add_action( 'tribe_settings_below_tabs', array( $this, 'displayErrors' ) );
 			add_action( 'tribe_settings_below_tabs', array( $this, 'displaySuccess' ) );
-			add_action( 'shutdown', array( $this, 'deleteOptions' ) );
 		}
 
 		/**
@@ -565,6 +564,9 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 
 				// final output, filtered of course
 				echo apply_filters( 'tribe_settings_error_message', $output );
+
+				// Now that we've displayed the errors we can delete them
+				$this->deleteOptions();
 			}
 		}
 


### PR DESCRIPTION
Delete stored errors after displaying them rather than each time `shutdown` fires (otherwise they are lost if we add them immediately before a redirect).

https://central.tri.be/issues/46544