### PR TITLE
make menu position match with The Events Calendar

### DIFF
--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -204,7 +204,8 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 						apply_filters( 'tribe_common_event_page_capability', 'manage_options' ),
 						'tribe-common',
 						null,
-						'dashicons-calendar'
+						'dashicons-calendar',
+						6
 					);
 				}
 


### PR DESCRIPTION
When you have just ET activated, it's menu position should be the same as when you have The Events Calendar active.