### PR TITLE
Fix/46581 date utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribe-common",
-  "version": "4.2.0",
+  "version": "4.2.1dev1",
   "repository": "git@github.com:moderntribe/tribe-common.git",
   "_resourcepath": "src/resources",
   "_domainPath": "lang",

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -17,7 +17,7 @@ class Tribe__Main {
 	const OPTIONNAME          = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK   = 'tribe_events_calendar_network_options';
 
-	const VERSION           = '4.2';
+	const VERSION           = '4.2.1dev1';
 	const FEED_URL          = 'https://theeventscalendar.com/feed/';
 
 	protected $plugin_context;

--- a/tribe-common.php
+++ b/tribe-common.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Tribe Common
 Description: An event settings framework for managing shared options
-Version: 4.2
+Version: 4.2.1dev1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/1x
 Text Domain: tribe-common


### PR DESCRIPTION
Adds the static `wp_strtotime()` method to `Tribe__Date_Utils` (it's a straight lift almost from core's ical class) - this will allow us to use it from various other locations rather than duplicating it across multiple plugins and classes.

https://central.tri.be/issues/46581