### PR TITLE
Is_embed move method remove superfluous else

### DIFF
--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -70,9 +70,10 @@ class Tribe__Templates {
 		global $wp_version;
 		if ( version_compare( $wp_version, '4.4', '<' ) || ! function_exists( 'is_embed' ) ) {
 			return false;
-		} else {
-			return is_embed();
 		}
+
+		return is_embed();
+
 	}
 
 }//end class


### PR DESCRIPTION
_Ref:_ [C#62577](https://central.tri.be/issues/62577) - method in common for #62577

Miss a note about the superfluous else and removing it here.