### PR TITLE
load common translations

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -45,6 +45,8 @@ class Tribe__Main {
 		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
 		$this->plugin_url  = plugins_url( $this->plugin_dir );
 
+		$this->load_text_domain( 'tribe-common', basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/' );
+
 		$this->init_autoloading();
 
 		$this->init_libraries();
@@ -165,8 +167,6 @@ class Tribe__Main {
 	public function add_hooks() {
 		add_action( 'plugins_loaded', array( 'Tribe__App_Shop', 'instance' ) );
 
-		$this->load_text_domain( 'tribe-common', basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/' );
-
 		// Register for the assets to be availble everywhere
 		add_action( 'init', array( $this, 'register_resources' ), 1 );
 		add_action( 'init', array( $this, 'register_vendor' ), 1 );
@@ -187,7 +187,7 @@ class Tribe__Main {
 	 */
 	public function load_text_domain( $domain, $dir = false ) {
 		// Added safety just in case this runs twice...
-		if ( is_textdomain_loaded( $domain ) ) {
+		if ( is_textdomain_loaded( $domain ) && ! is_a( $GLOBALS['l10n'][ $domain ], 'NOOP_Translations' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
`Tribe_Log` was trying to get translated strings earlier than they were registered. This combined with the new `load_text_domain` checking that they had been loaded without confirming they had loaded properly led to any strings in common not being translated.

See: https://central.tri.be/issues/62562