### PR TITLE
Feature/tribe exception

### DIFF
--- a/src/Tribe/Exception.php
+++ b/src/Tribe/Exception.php
@@ -1,0 +1,63 @@
+<?php
+
+
+/**
+ * Class Tribe__Exception
+ * 
+ * Handles exceptions to log when not in debug mode.
+ */
+class Tribe__Exception extends Exception {
+
+	/**
+	 * @var Exception
+	 */
+	private $original_exception;
+
+	/**
+	 * Tribe__Exception constructor.
+	 *
+	 * @param Exception $original_exception
+	 */
+	public function __construct( Exception $original_exception ) {
+		$this->original_exception = $original_exception;
+	}
+
+	/**
+	 * Handles the exception throwing the original when debugging (`WP_DEBUG` defined and `true`)
+	 * or quietly logging when `WP_DEBUG` is false or not set.
+	 *
+	 * @return bool  `true` if the message was logged, `false` otherwise.
+	 *
+	 * @throws Exception
+	 */
+	public function handle() {
+		$debug = defined( 'WP_DEBUG' ) && WP_DEBUG;
+
+		if ( $debug ) {
+			throw  $this->original_exception;
+		}
+
+		if ( ! class_exists( 'Tribe__Log' ) ) {
+			return false;
+		}
+
+		$logger   = new Tribe__Log();
+		$message  = $this->original_exception->getMessage();
+		$log_type = $this->get_log_type_for_exception_code( $this->original_exception->getCode() );
+		$src      = $this->original_exception->getFile() . ':' . $this->original_exception->getLine();
+
+		$logger->log( $message, $log_type, $src );
+
+		return true;
+	}
+
+	/**
+	 * @return string
+	 */
+	private function get_log_type_for_exception_code( $code ) {
+		$map = array(// @todo: let's add a decent exception code to log type map here
+		);
+
+		return isset( $map[ $code ] ) ? $map[ $code ] : Tribe__Log::ERROR;
+	}
+}

--- a/src/Tribe/Exception.php
+++ b/src/Tribe/Exception.php
@@ -3,7 +3,7 @@
 
 /**
  * Class Tribe__Exception
- * 
+ *
  * Handles exceptions to log when not in debug mode.
  */
 class Tribe__Exception extends Exception {
@@ -34,9 +34,46 @@ class Tribe__Exception extends Exception {
 		$debug = defined( 'WP_DEBUG' ) && WP_DEBUG;
 
 		if ( $debug ) {
-			throw  $this->original_exception;
+			$this->throw_original_exception();
 		}
 
+		return $this->log_original_exception_message();
+	}
+
+	/**
+	 * @return string
+	 */
+	private function get_log_type_for_exception_code( $code ) {
+		$map = array(
+			// @todo: let's add a decent exception code to log type map here
+		);
+
+		return isset( $map[ $code ] ) ? $map[ $code ] : Tribe__Log::ERROR;
+	}
+
+	/**
+	 * Throws the original exception.
+	 *
+	 * Provided as a manual override over the default `WP_DEBUG` dependent behaviour.
+	 *
+	 * @see Tribe__Exception::handle()
+	 *
+	 * @throws Exception
+	 */
+	public function throw_original_exception() {
+		throw  $this->original_exception;
+	}
+
+	/**
+	 * Logs the original exception message.
+	 *
+	 * Provided as a manual override over the default `WP_DEBUG` dependent behaviour.
+	 *
+	 * @see Tribe__Exception::handle()
+	 *
+	 * @return bool  `true` if the message was logged, `false` otherwise.
+	 */
+	private function log_original_exception_message() {
 		if ( ! class_exists( 'Tribe__Log' ) ) {
 			return false;
 		}
@@ -49,16 +86,5 @@ class Tribe__Exception extends Exception {
 		$logger->log( $message, $log_type, $src );
 
 		return true;
-	}
-
-	/**
-	 * @return string
-	 */
-	private function get_log_type_for_exception_code( $code ) {
-		$map = array(
-			// @todo: let's add a decent exception code to log type map here
-		);
-
-		return isset( $map[ $code ] ) ? $map[ $code ] : Tribe__Log::ERROR;
 	}
 }

--- a/src/Tribe/Exception.php
+++ b/src/Tribe/Exception.php
@@ -24,7 +24,7 @@ class Tribe__Exception extends Exception {
 
 	/**
 	 * Handles the exception throwing the original when debugging (`WP_DEBUG` defined and `true`)
-	 * or quietly logging when `WP_DEBUG` is false or not set.
+	 * or quietly logging when `WP_DEBUG` is `false` or not set.
 	 *
 	 * @return bool  `true` if the message was logged, `false` otherwise.
 	 *
@@ -55,7 +55,8 @@ class Tribe__Exception extends Exception {
 	 * @return string
 	 */
 	private function get_log_type_for_exception_code( $code ) {
-		$map = array(// @todo: let's add a decent exception code to log type map here
+		$map = array(
+			// @todo: let's add a decent exception code to log type map here
 		);
 
 		return isset( $map[ $code ] ) ? $map[ $code ] : Tribe__Log::ERROR;


### PR DESCRIPTION
Marginally coherent with ticket: https://central.tri.be/issues/61451

This PR simply adds an exception handling class that's meant to be used like this:

```php
try {
    // something risky
} catch (Exception $e) {
    $exception = new Tribe__Exception($e);
    $exception->handle(); // will either throw or log and return

    return; // we survived: let's now make a sensible decision about the flow on a per-case base
}
```

See an example at: https://github.com/moderntribe/events-pro/pull/352/commits/3f0eef8b9e8601cb6cd0ea95721d433635789d30