### PR TITLE
provide fallback when API fails to load

### DIFF
--- a/src/Tribe/App_Shop.php
+++ b/src/Tribe/App_Shop.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 		/**
 		 * URL of the API
 		 */
-		const API_ENDPOINT = 'http://tri.be/api/app-shop/';
+		const API_ENDPOINT = 'https://theeventscalendar.com/api/app-shop/';
 
 		/**
 		 * Base name for the transients key
@@ -107,27 +107,24 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 		 * Renders the Shop App page
 		 */
 		public function do_menu_page() {
+			$products = null;
+			$banner = null;
+			$categories = null;
+
 			$remote = $this->get_all_products();
 
 			if ( ! empty( $remote ) ) {
-				$products = null;
 				if ( property_exists( $remote, 'data' ) ) {
 					$products = $remote->data;
+					$categories = array_unique( wp_list_pluck( $products, 'category' ) );
 				}
-				$banner = null;
+
 				if ( property_exists( $remote, 'banner' ) ) {
 					$banner = $remote->banner;
 				}
-
-				if ( empty( $products ) ) {
-					return;
-				}
-
-				$categories = array_unique( wp_list_pluck( $products, 'category' ) );
-
-				include_once Tribe__Main::instance()->plugin_path . 'src/admin-views/app-shop.php';
 			}
 
+			include_once Tribe__Main::instance()->plugin_path . 'src/admin-views/app-shop.php';
 		}
 
 		/**
@@ -152,7 +149,6 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 			}
 
 			return $products;
-
 		}
 
 		/**
@@ -174,7 +170,6 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 			}
 
 			return null;
-
 		}
 
 		/**
@@ -190,6 +185,5 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 
 			return self::$instance;
 		}
-
 	}
 }

--- a/src/admin-views/app-shop.php
+++ b/src/admin-views/app-shop.php
@@ -4,7 +4,6 @@
 		<h1><?php esc_html_e( 'Tribe Event Add-Ons', 'tribe-common' ); ?></h1>
 	</div>
 
-
 	<div class="content-wrapper">
 		<?php
 
@@ -19,50 +18,54 @@
 			echo $banner_markup;
 		}
 
-		$category = null;
-		$i = 1;
-		foreach ( (array) $products as $product ) {
+		if ( empty( $products ) ) {
+			?>
+			<a class="button button-primary" href="https://theeventscalendar.com/products/?utm_campaign=in-app&utm_source=addonspage&utm_medium=noload"><?php _e( 'Get Add-Ons', 'tribe-common' ); ?></a>
+			<?php
+		}
+		else {
+			$category = null;
+			$i = 0;
+			foreach ( (array) $products as $product ) {
+				if ( $product->category != $category ) {
+					if ( $category !== null ) { ?>
+						</div>
+					<?php } ?>
 
-		?>
+					<div class="addon-grid">
 
-		<?php if ( $product->category != $category ) { ?>
-
-			<?php if ( $category !== null ) : ?>
-				</div>
-			<?php endif; ?>
-
-	<div class="addon-grid">
-
-		<?php
-		$category = $product->category;
-		} ?>
-		<div class="tribe-addon<?php if ( $i == 1 ) {
-			echo ' first tribe-clearfix';
-		} ?>">
-			<div class="thumb">
-				<a href="<?php echo esc_url( $product->permalink ); ?>"><img src="<?php echo esc_attr( $product->featured_image_url ); ?>" /></a>
-			</div>
-			<div class="caption">
-				<h4><a href="<?php echo esc_url( $product->permalink ); ?>"><?php echo $product->title; ?></a></h4>
-
-				<div class="description">
-					<p><?php echo $product->description; ?></p>
-				</div>
-				<div class="meta">
 					<?php
-					if ( $product->version ) {
-						echo sprintf( '<strong>%s</strong>: %s<br/>', esc_html__( 'Version', 'tribe-common' ), esc_html( $product->version ) );
-					}
-					if ( $product->last_update ) {
-						echo sprintf( '<strong>%s</strong>: %s<br/>', esc_html__( 'Last Update', 'tribe-common' ), esc_html( $product->last_update ) );
-					}
-					?>
-				</div>
-				<a class="button button-primary" href="<?php echo esc_url( $product->permalink ); ?>">Get This Add-on</a>
-			</div>
-		</div>
+					$category = $product->category;
+				}
+				?>
+				<div class="tribe-addon<?php echo ( $i % 4 == 0 ) ? ' first tribe-clearfix' : '';?>">
+					<div class="thumb">
+						<a href="<?php echo esc_url( $product->permalink ); ?>"><img src="<?php echo esc_attr( $product->featured_image_url ); ?>" /></a>
+					</div>
+					<div class="caption">
+						<h4><a href="<?php echo esc_url( $product->permalink ); ?>"><?php echo $product->title; ?></a></h4>
 
-		<?php $i ++;
-		} ?>
+						<div class="description">
+							<p><?php echo $product->description; ?></p>
+						</div>
+						<div class="meta">
+							<?php
+							if ( $product->version ) {
+								echo sprintf( '<strong>%s</strong>: %s<br/>', esc_html__( 'Version', 'tribe-common' ), esc_html( $product->version ) );
+							}
+							if ( $product->last_update ) {
+								echo sprintf( '<strong>%s</strong>: %s<br/>', esc_html__( 'Last Update', 'tribe-common' ), esc_html( $product->last_update ) );
+							}
+							?>
+						</div>
+						<a class="button button-primary" href="<?php echo esc_url( $product->permalink ); ?>">Get This Add-on</a>
+					</div>
+				</div>
+
+				<?php
+				$i++;
+			}
+		}
+		?>
 	</div>
 </div>


### PR DESCRIPTION
Also:
* updated API URL to point directly at theeventscalendar.com
* made the 5th product span full width for improved promotion

See: https://central.tri.be/issues/63558