### PR TITLE
PHP 5.2 compatibility fixes | #65678

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -165,12 +165,14 @@ class Tribe__Timezones {
 			$local = self::get_timezone( $tzstring );
 			$utc   = self::get_timezone( 'UTC' );
 
-			$datetime = date_create( $datetime, $local )->setTimezone( $utc );
-			return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			// We can't use method chaining here (ie "date_create(...)->setTimezone(...)") due to PHP 5.2 compatibility concerns
+			if ( $datetime = date_create( $datetime, $local ) && false !== $datetime->setTimezone( $utc ) ) {
+				return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			}
 		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+		catch ( Exception $e ) {}
+
+		return $datetime;
 	}
 
 	/**
@@ -193,12 +195,14 @@ class Tribe__Timezones {
 			$local = self::get_timezone( $tzstring );
 			$utc   = self::get_timezone( 'UTC' );
 
-			$datetime = date_create( $datetime, $utc )->setTimezone( $local );
-			return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			// We can't use method chaining here (ie "date_create(...)->setTimezone(...)") due to PHP 5.2 compatibility concerns
+			if ( $datetime = date_create( $datetime, $utc ) && false !== $datetime->setTimezone( $local ) ) {
+				return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			}
 		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+		catch ( Exception $e ) {}
+
+		return $datetime;
 	}
 
 	/**
@@ -246,12 +250,14 @@ class Tribe__Timezones {
 			if ( $offset > 0 ) $offset = '+' . $offset;
 			$offset = $offset . ' minutes';
 
-			$datetime = date_create( $datetime )->modify( $offset );
-			return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			// We can't use method chaining here (ie "date_create(...)->modify(...)") due to PHP 5.2 compatibility concerns
+			if ( $datetime = date_create( $datetime ) && false !== $datetime->modify( $offset ) ) {
+				return $datetime->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
+			}
 		}
-		catch ( Exception $e ) {
-			return $datetime;
-		}
+		catch ( Exception $e ) {}
+
+		return $datetime;
 	}
 
 	/**
@@ -267,7 +273,9 @@ class Tribe__Timezones {
 		try {
 			$local = self::get_timezone( $tzstring );
 			$datetime = date_create_from_format( 'U', $unix_timestamp )->format( Tribe__Date_Utils::DBDATETIMEFORMAT );
-			return date_create_from_format( 'Y-m-d H:i:s', $datetime, $local )->getTimestamp();
+
+			// We prefer format('U') to getTimestamp() here due to our requirement for compatibility with PHP 5.2
+			return date_create_from_format( 'Y-m-d H:i:s', $datetime, $local )->format( 'U' );
 		}
 		catch( Exception $e ) {
 			return $unix_timestamp;


### PR DESCRIPTION
Fixes for PHP 5.2 compatibility. Notes:

``` php
// On success, the following returns a DateTime object under PHP 5.3+
// but returns null under PHP 5.2 (ditto for the modify() method)
date_create( $datetime, $local )->setTimezone( $utc );

// This method was introduced in PHP 5.3, so we need to use format( 'U' )
// PHP 5.2 compatible alternative
date_create_from_format( ... )->getTimestamp()
```

[#65678](https://central.tri.be/issues/65678)