### PR TITLE
Undo a change that meant the file handle was set to a boolean value | spotfix

### DIFF
--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -141,6 +141,11 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 			$this->set_context( 'a' );
 		}
 
+		// Couldn't obtain the file handle? We'll bail out without causing further disruption
+		if ( ! $this->handle ) {
+			return;
+		}
+
 		fputcsv( $this->handle, array( date_i18n( 'Y-m-d H:i:s' ), $entry, $type, $src ) );
 	}
 
@@ -161,6 +166,11 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 		// Ensure we're in 'read' mode before we try to retrieve
 		if ( 'r' !== $this->context ) {
 			$this->set_context( 'r' );
+		}
+
+		// Couldn't obtain the file handle? We'll bail out without causing further disruption
+		if ( ! $this->handle ) {
+			return array();
 		}
 
 		$rows = array();

--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -59,7 +59,10 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 	 */
 	protected function obtain_handle() {
 		$this->close_handle();
-		$this->handle = is_readable( $this->log_file ) && fopen( $this->log_file, $this->context );
+
+		if ( is_readable( $this->log_file ) ) {
+			$this->handle = fopen( $this->log_file, $this->context );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Bah! I saw the previous change adding `is_readable()` come in in an earlier PR and didn't spot it would break things. This keeps the same test, but ensures the handle is set appropriately.