### PR TITLE
Allow tribe_asset(s) to pass in a full URL to allow for custom overrides

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -319,7 +319,11 @@ class Tribe__Assets {
 		$is_vendor = strpos( $asset->file, 'vendor/' ) !== false ? true : false;
 
 		// Setup the actual URL
-		$asset->url = $this->maybe_get_min_file( tribe_resource_url( $asset->file, false, ( $is_vendor ? '' : null ), $asset->origin ) );
+		if ( filter_var( $asset->file, FILTER_VALIDATE_URL ) ) {
+			$asset->url = $asset->file;
+		} else {
+			$asset->url = $this->maybe_get_min_file( tribe_resource_url( $asset->file, false, ( $is_vendor ? '' : null ), $asset->origin ) );
+		}
 
 		// If you are passing localize, you need `name` and `data`
 		if ( ! empty( $asset->localize ) && ( is_array( $asset->localize ) || is_object( $asset->localize ) ) ) {

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -43,11 +43,11 @@ class Tribe__Templates {
 			return $fallback;
 		}
 		foreach ( $stylesheets as $filename ) {
-			if ( file_exists( STYLESHEETPATH . '/' . $filename ) ) {
+			if ( file_exists( get_stylesheet_directory() . '/' . $filename ) ) {
 				$located = trailingslashit( get_stylesheet_directory_uri() ) . $filename;
 				break;
 			} else {
-				if ( file_exists( TEMPLATEPATH . '/' . $filename ) ) {
+				if ( file_exists( get_template_directory() . '/' . $filename ) ) {
 					$located = trailingslashit( get_template_directory_uri() ) . $filename;
 					break;
 				}


### PR DESCRIPTION
Additionally, retire the use of `TEMPLATEPATH` and `STYLESHEETPATH`

Related: https://github.com/moderntribe/events-community/pull/142
See: https://tribe.slack.com/archives/products-dev/p1472743176000692