### PR TITLE
Try to create new log file before testing if it is readable | #36047

### DIFF
--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -60,6 +60,10 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 	protected function obtain_handle() {
 		$this->close_handle();
 
+		if ( ! file_exists( $this->log_file ) ) {
+			touch( $this->log_file );
+		}
+
 		if ( is_readable( $this->log_file ) ) {
 			$this->handle = fopen( $this->log_file, $this->context );
 		}


### PR DESCRIPTION
Further fix to allow creation of log file where it doesn't already exist.

[#36047](https://central.tri.be/issues/36047)