### PR TITLE
avoid array_diff_key warning if non array

### DIFF
--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -78,7 +78,11 @@ class Tribe__PUE__Notices {
 	 */
 	public function maybe_undismiss_notices() {
 		foreach ( $this->notices as $notice_type => $plugin_list ) {
-			$new_plugins = array_diff_key( $this->notices[ $notice_type ], $this->saved_notices[ $notice_type ] );
+			if ( is_array( $this->saved_notices ) ) {
+				$new_plugins = array_diff_key( $this->notices[ $notice_type ], $this->saved_notices[ $notice_type ] );
+			} else {
+				$new_plugins = $this->notices[ $notice_type ];
+			}
 
 			if ( ! empty( $new_plugins ) ) {
 				Tribe__Admin__Notices::instance()->undismiss_for_all( 'pue_key-' . $notice_type );


### PR DESCRIPTION
Ticket: none

Avoid PHP warnings when PUE checks for notices; found out while spinning up latest `develop` code.