### PR TITLE
get_log_entries() should always return an array, even if it's empty | spotfix

### DIFF
--- a/src/Tribe/Log/Admin.php
+++ b/src/Tribe/Log/Admin.php
@@ -171,8 +171,10 @@ class Tribe__Log__Admin {
 	protected function get_log_entries( $log = null ) {
 		if ( $logger = $this->current_logger() ) {
 			$logger->use_log( $log );
-			return $logger->retrieve();
+			return (array) $logger->retrieve();
 		}
+
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
If logging hasn't yet been enabled, null is returned where an array is expected. This corrects that to an empty array.