### PR TITLE
Add notices any time we save the key 

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -548,15 +548,12 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			} elseif ( isset( $plugin_info->api_expired ) && $plugin_info->api_expired == 1 ) {
 				$response['message'] = $this->get_license_expired_message();
 				$response['api_expired'] = true;
-				$pue_notices->add_notice( Tribe__PUE__Notices::EXPIRED_KEY, $plugin_name );
 			} elseif ( isset( $plugin_info->api_upgrade ) && $plugin_info->api_upgrade == 1 ) {
 				$response['message'] = $this->get_api_message( $plugin_info );
 				$response['api_upgrade'] = true;
-				$pue_notices->add_notice( Tribe__PUE__Notices::UPGRADE_KEY, $plugin_name );
 			} elseif ( isset( $plugin_info->api_invalid ) && $plugin_info->api_invalid == 1 ) {
 				$response['message'] = $this->get_api_message( $plugin_info );
 				$response['api_invalid'] = true;
-				$pue_notices->add_notice( Tribe__PUE__Notices::INVALID_KEY, $plugin_name );
 			} else {
 				$api_secret_key = get_option( $this->pue_install_key );
 				if ( $api_secret_key && $api_secret_key === $queryArgs['pu_install_key'] ){
@@ -1000,6 +997,21 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				delete_site_option( $this->pue_option_name );
 				$this->check_for_updates();
 			}
+
+			// are we saving THIS PUE key to the options table?
+			if ( empty( $_POST[ $this->pue_install_key ] ) || $value !== $_POST[ $this->pue_install_key ] ) {
+				return;
+			}
+
+			// if we are saving this PUE key, we need to make sure we update the license key notices
+			// appropriately. Otherwise, we could have an invalid license key in place but the notices
+			// aren't being thrown globally
+			$args = array(
+				'pu_checking_for_updates' => 1,
+				'pu_install_key' => $_POST[ $this->pue_install_key ],
+			);
+
+			$this->license_key_status( $args );
 		}
 
 		/**

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -540,17 +540,23 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$plugin_info = $this->request_info( $queryArgs );
 			$expiration = isset( $plugin_info->expiration ) ? $plugin_info->expiration : esc_html__( 'unknown date', 'tribe-common' );
 
+			$pue_notices = Tribe__Main::instance()->pue_notices();
+			$plugin_name = $this->get_plugin_name();
+
 			if ( empty( $plugin_info ) ) {
 				$response['message'] = esc_html__( 'Sorry, key validation server is not available.', 'tribe-common' );
 			} elseif ( isset( $plugin_info->api_expired ) && $plugin_info->api_expired == 1 ) {
 				$response['message'] = $this->get_license_expired_message();
 				$response['api_expired'] = true;
+				$pue_notices->add_notice( Tribe__PUE__Notices::EXPIRED_KEY, $plugin_name );
 			} elseif ( isset( $plugin_info->api_upgrade ) && $plugin_info->api_upgrade == 1 ) {
 				$response['message'] = $this->get_api_message( $plugin_info );
 				$response['api_upgrade'] = true;
+				$pue_notices->add_notice( Tribe__PUE__Notices::UPGRADE_KEY, $plugin_name );
 			} elseif ( isset( $plugin_info->api_invalid ) && $plugin_info->api_invalid == 1 ) {
 				$response['message'] = $this->get_api_message( $plugin_info );
 				$response['api_invalid'] = true;
+				$pue_notices->add_notice( Tribe__PUE__Notices::INVALID_KEY, $plugin_name );
 			} else {
 				$api_secret_key = get_option( $this->pue_install_key );
 				if ( $api_secret_key && $api_secret_key === $queryArgs['pu_install_key'] ){
@@ -567,6 +573,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 						Tribe__Support::send_sysinfo_key( $optin_key, $queryArgs['domain'], false, true );
 					}
 				}
+
+				$pue_notices->clear_notices( $plugin_name );
 
 				$response['status']     = isset( $plugin_info->api_message ) ? 2 : 1;
 				$response['message']    = isset( $plugin_info->api_message ) ? wp_kses( $plugin_info->api_message, 'data' ) : $default_success_msg;

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -125,6 +125,28 @@ class Tribe__PUE__Notices {
 	}
 
 	/**
+	 * Returns whether or not a given plugin name has a specific notice
+	 *
+	 * @param string $plugin_name
+	 * @param string|null $notice_type
+	 *
+	 * @return boolean
+	 */
+	public function has_notice( $plugin_name, $notice_type = null ) {
+		if ( $notice_type ) {
+			return ! empty( $this->notices[ $notice_type ][ $plugin_name ] );
+		}
+
+		foreach ( $this->notices as $notice_type => $plugins ) {
+			if ( ! empty( $plugins[ $plugin_name ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Removes any notifications for the specified plugin.
 	 *
 	 * Useful when a valid license key is detected for a plugin, where previously


### PR DESCRIPTION
Additionally, clear notices when saving the key.

Related: https://github.com/moderntribe/the-events-calendar/pull/987

See: https://central.tri.be/issues/65378