### PR TITLE
tribe-common should register its own deprecated classes with the autoloader

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -86,9 +86,16 @@ class Tribe__Main {
 			require_once dirname( __FILE__ ) . '/Autoloader.php';
 		}
 
-		$prefixes = array( 'Tribe__' => dirname( __FILE__ ) );
 		$autoloader = Tribe__Autoloader::instance();
+
+		$prefixes = array( 'Tribe__' => dirname( __FILE__ ) );
 		$autoloader->register_prefixes( $prefixes );
+
+		foreach ( glob( $this->plugin_path . 'src/deprecated/*.php' ) as $file ) {
+			$class_name = str_replace( '.php', '', basename( $file ) );
+			$autoloader->register_class( $class_name, $file );
+		}
+
 		$autoloader->register_autoloader();
 	}
 


### PR DESCRIPTION
Let tribe-common register its own deprecated classes, rather than have dependencies like TEC and ET take care of it. Apart from better separation of concerns, this should help avoid fatals upon updates where both those plugins are installed and activated.

https://central.tri.be/issues/66872