### PR TITLE
Relocate the help tab to a top level help page

### DIFF
--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -428,7 +428,7 @@ class Tribe__Admin__Help_Page {
 		// Loop to start the HTML
 		foreach ( $mixed as &$line ) {
 			// If we have content we use that
-			if ( ! empty( $line->content ) ) {
+			if ( isset( $line->content ) ) {
 				$line = $line->content;
 			}
 
@@ -503,14 +503,14 @@ class Tribe__Admin__Help_Page {
 	 * @return int
 	 */
 	protected function by_priority( $a, $b ) {
-		if ( empty( $a->priority ) || empty( $b->priority ) || $a->priority === $b->priority ) {
-			if ( empty( $a->unique_call_order ) || empty( $b->unique_call_order ) ) {
+		if ( ! isset( $a->priority ) || ! isset( $b->priority ) || $a->priority === $b->priority ) {
+			if ( ! isset( $a->unique_call_order ) || ! isset( $b->unique_call_order ) ) {
 				return 0;
 			} else {
-				return $a->unique_call_order - $b->unique_call_order;
+				return $a->unique_call_order > $b->unique_call_order ? 1 : -1;
 			}
 		} else {
-			return $a->priority - $b->priority;
+			return $a->priority > $b->priority ? 1 : -1;
 		}
 	}
 

--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -28,7 +28,6 @@ class Tribe__Settings_Manager {
 		add_action( 'admin_menu', array( $this, 'add_help_admin_menu_item' ), 50 );
 		add_action( 'tribe_settings_do_tabs', array( $this, 'do_setting_tabs' ) );
 		add_action( 'tribe_settings_do_tabs', array( $this, 'do_network_settings_tab' ), 400 );
-		add_action( 'tribe_settings_content_tab_help', array( $this, 'do_help_tab' ) );
 		add_action( 'tribe_settings_validate_tab_network', array( $this, 'save_all_tabs_hidden' ) );
 	}
 
@@ -56,15 +55,6 @@ class Tribe__Settings_Manager {
 		new Tribe__Settings_Tab( 'display', esc_html__( 'Display', 'tribe-common' ), $displayTab );
 
 		$this->do_licenses_tab();
-
-		new Tribe__Settings_Tab(
-			'help',
-			esc_html__( 'Help', 'tribe-common' ),
-			array(
-				'priority'  => 60,
-				'show_save' => false,
-			)
-		);
 	}
 
 	/**
@@ -285,21 +275,11 @@ class Tribe__Settings_Manager {
 			return;
 		}
 
-		$parent = Tribe__Settings::$parent_slug;
+		$parent = Tribe__Settings::$parent_page;
 		$title  = esc_html__( 'Help', 'tribe-common' );
-		$slug   = esc_url(
-			apply_filters( 'tribe_settings_url',
-				add_query_arg(
-					array(
-						'page'      => 'tribe-common',
-						'tab'       => 'help',
-					),
-					Tribe__Settings::$parent_page
-				)
-			)
-		);
+		$slug   = 'tribe-help';
 
-		add_submenu_page( $parent, $title, $title, 'manage_options', $slug, '' );
+		add_submenu_page( $parent, $title, $title, 'manage_options', $slug, array( $this, 'do_help_tab' ) );
 	}
 
 	/**

--- a/src/admin-views/tribe-options-help.php
+++ b/src/admin-views/tribe-options-help.php
@@ -32,8 +32,15 @@ $help->add_section_content( 'extra-help', '<div style="text-align: right;"><a hr
 
 // Creates the System Info section
 $help->add_section( 'system-info', __( 'System Information', 'tribe-common' ), 30 );
-$help->add_section_content( 'system-info', __( 'The details of your calendar plugin and settings is often needed for you or our staff to help troubleshoot an issue. We may ask you to share this information if you ask for support. If you post in one of our premium forums, please copy and paste this information into the System Information field and it will help us help you faster!', 'tribe-common' ), 0 );
-$help->add_section_content( 'system-info', '<div class="system-info-copy"><button data-clipboard-action="copy" class="system-info-copy-btn" data-clipboard-target=".support-stats" ><span class="dashicons dashicons-clipboard license-btn"></span>' .  __( 'Copy to clipboard', 'tribe-common' ) . '</button></div>', 0 );
+$help->add_section_content( 'system-info', __( 'The details of your calendar plugin and settings is often needed for you or our staff to help troubleshoot an issue. Please opt-in below to automatically share your system information with our support team. This will allow us to assist you faster if you post in our forums.', 'tribe-common' ), 0 );
+
+$help->add_section_content(
+	'system-info',
+	Tribe__Support::opt_in(),
+	10
+);
+
+$help->add_section_content( 'system-info', '<div class="system-info-copy"><button data-clipboard-action="copy" class="system-info-copy-btn" data-clipboard-target=".support-stats" ><span class="dashicons dashicons-clipboard license-btn"></span>' .  __( 'Copy to clipboard', 'tribe-common' ) . '</button></div>', 10 );
 
 $help->add_section( 'template-changes', __( 'Recent Template Changes', 'tribe-common' ), 40 );
 $help->add_section_content( 'template-changes', Tribe__Support__Template_Checker_Report::generate() );
@@ -45,7 +52,6 @@ $help->add_section_content( 'event-log', Tribe__Main::instance()->log()->admin()
 <div id="tribe-help-general">
 	<?php $help->get_sections(); ?>
 </div>
-
 
 <div id="tribe-help-sidebar">
 	<?php

--- a/src/admin-views/tribe-options-licenses.php
+++ b/src/admin-views/tribe-options-licenses.php
@@ -56,14 +56,6 @@ if ( is_multisite() ) {
 	$html .= "<p> $network_all_sites_text $network_admin_only </p>";
 }
 
-// Explanatory text about license settings for the tab information box
-$support_html = '<p>' . sprintf(
-		esc_html__( 'The details of your plugin and settings are often needed for you or our staff to help troubleshoot an issue. Please opt-in below to automatically share your system information with our support team. This will allow us to assist you faster if you post in our forums%2$s. You can see exactly what information you\'ll be sharing by viewing the System Info section on the %3$sHelp Tab%2$s.', 'tribe-common' ),
-		'<a href="http://m.tri.be/194m" target="_blank">',
-		'<span class="screen-reader-text">' . __( ' (opens in new window)', 'tribe-common' ) . '</span></a>',
-		'<a href="' . Tribe__Settings::instance()->get_url( array( 'tab' => 'help' ) ) . '" target="_blank">'
-	) . '</p>';
-
 $licenses_tab = array(
 	'info-start' => array(
 		'type' => 'html',
@@ -78,30 +70,6 @@ $licenses_tab = array(
 		'html' => $html,
 	),
 	'info-end' => array(
-		'type' => 'html',
-		'html' => '</div>',
-	),
-	'tribe-form-content-start' => array(
-		'type' => 'html',
-		'html' => '<div class="tribe-settings-form-wrap">',
-	),
-
-	'sysinfo-box-title' => array(
-		'type' => 'html',
-		'html' => '<h3>' . esc_html__( 'Support', 'tribe-common' ) . '</h3>',
-	),
-	'sysinfo-box-description' => array(
-		'type' => 'html',
-		'html' =>
-			$support_html,
-	),
-	'sysinfo-optin-checkbox' => array(
-		'type' => 'html',
-		'html' => Tribe__Support::opt_in(),
-	),
-
-	// TODO: Figure out how properly close this wrapper after the license content
-	'tribe-form-content-end'   => array(
 		'type' => 'html',
 		'html' => '</div>',
 	),


### PR DESCRIPTION
* Move the Support opt-in checkbox to the help page sysinfo section
* Fix bugs with help page content injection

Related: https://github.com/moderntribe/the-events-calendar/pull/1020

See: https://central.tri.be/issues/67093