### PR TITLE
Don't try to call die or exit via call_user_func() | spotfix

### DIFF
--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -110,6 +110,11 @@ if ( ! function_exists( 'tribe_exit' ) ) {
 		 */
 		$handler = apply_filters( 'tribe_exit', $handler, $status );
 
+		// Die and exit are language constructs that cannot be used as callbacks on all PHP runtimes
+		if ( 'die' === $handler || 'exit' === $handler ) {
+			exit;
+		}
+
 		return call_user_func( $handler, $status );
 	}
 }


### PR DESCRIPTION
Language constructs like `exit` and `die` don't seem to be viable as callbacks. Solid catch by [Jeff](https://tribe.slack.com/archives/quality-assurance/p1475188920001344).