### PR TITLE
fallback to initializing the fs if empty

### DIFF
--- a/src/Tribe/PUE/Package_Handler.php
+++ b/src/Tribe/PUE/Package_Handler.php
@@ -100,6 +100,12 @@ class Tribe__PUE__Package_Handler {
 	 * @return string|WP_Error The full path to the downloaded package file, or a WP_Error object.
 	 */
 	protected function download( $package ) {
+		if ( empty( $this->filesystem ) ) {
+			$this->upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
+			global $wp_filesystem;
+			$this->filesystem = $wp_filesystem;
+		}
+
 		$this->upgrader->skin->feedback( 'downloading_package', $package );
 
 		$download_file = download_url( $package );

--- a/src/Tribe/PUE/Package_Handler.php
+++ b/src/Tribe/PUE/Package_Handler.php
@@ -101,11 +101,14 @@ class Tribe__PUE__Package_Handler {
 	 */
 	protected function download( $package ) {
 		if ( empty( $this->filesystem ) ) {
+			// try to connect
 			$this->upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
 
 			global $wp_filesystem;
 
+			// still empty?
 			if ( empty( $wp_filesystem ) ) {
+				// bail
 				return false;
 			}
 

--- a/src/Tribe/PUE/Package_Handler.php
+++ b/src/Tribe/PUE/Package_Handler.php
@@ -102,7 +102,13 @@ class Tribe__PUE__Package_Handler {
 	protected function download( $package ) {
 		if ( empty( $this->filesystem ) ) {
 			$this->upgrader->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
+
 			global $wp_filesystem;
+
+			if ( empty( $wp_filesystem ) ) {
+				return false;
+			}
+
 			$this->filesystem = $wp_filesystem;
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/62552

Fixes the possibility that the `wp_filesystem` global is empty at that point.

Or would it be better to bail?