### PR TITLE
Add MU help page

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -433,5 +433,6 @@ class Tribe__Main {
 	 */
 	public function bind_implementations(  ) {
 		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
+		tribe_singleton( 'settings', 'Tribe__Settings' );
 	}
 }

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -71,6 +71,8 @@ class Tribe__Main {
 
 		$this->init_autoloading();
 
+		$this->bind_implementations();
+
 		$this->init_libraries();
 		$this->add_hooks();
 
@@ -124,7 +126,7 @@ class Tribe__Main {
 	 */
 	public function init_libraries() {
 		Tribe__Debug::instance();
-		Tribe__Settings_Manager::instance();
+		tribe('settings.manager');
 		$this->pue_notices();
 
 		require_once $this->plugin_path . 'src/functions/utils.php';
@@ -424,5 +426,12 @@ class Tribe__Main {
 		 * @since 4.3
 		 */
 		do_action( 'tribe_plugins_loaded' );
+	}
+
+	/**
+	 * Registers the slug bound to the implementations in the container.
+	 */
+	public function bind_implementations(  ) {
+		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
 	}
 }

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -136,11 +136,7 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 		 * @return Tribe__Settings
 		 */
 		public static function instance() {
-			if ( empty( self::$instance ) ) {
-				self::$instance = new self();
-			}
-
-			return self::$instance;
+			return tribe( 'settings' );
 		}
 
 		/**
@@ -655,6 +651,13 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 			}
 
 			return $slug;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_help_slug() {
+			return $this->help_slug;
 		}
 	} // end class
 } // endif class_exists

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -13,7 +13,6 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 	 *
 	 */
 	class Tribe__Settings {
-
 		/**
 		 * Slug of the parent menu slug
 		 * @var string
@@ -71,10 +70,17 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 		public $noSaveTabs;
 
 		/**
-		 * the slug used in the admin to generate the settings page
+		 * The slug used in the admin to generate the settings page
 		 * @var string
 		 */
 		public $adminSlug;
+
+		/**
+		 * The slug used in the admin to generate the help page
+		 * @var string
+		 */
+		protected $help_slug;
+
 
 		/**
 		 * the menu name used for the settings page
@@ -148,6 +154,7 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 			$this->menuName    = apply_filters( 'tribe_settings_menu_name', esc_html__( 'Events', 'tribe-common' ) );
 			$this->requiredCap = apply_filters( 'tribe_settings_req_cap', 'manage_options' );
 			$this->adminSlug   = apply_filters( 'tribe_settings_admin_slug', 'tribe-common' );
+			$this->help_slug   = apply_filters( 'tribe_settings_help_slug', 'tribe-common-help' );
 			$this->errors      = get_option( 'tribe_settings_errors', array() );
 			$this->major_error = get_option( 'tribe_settings_major_error', false );
 			$this->sent_data   = get_option( 'tribe_settings_sent_data', array() );
@@ -236,6 +243,18 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 				'settings.php', esc_html__( 'Events Settings', 'tribe-common' ), esc_html__( 'Events Settings', 'tribe-common' ), $this->requiredCap, $this->adminSlug, array(
 					$this,
 					'generatePage',
+				)
+			);
+
+			$this->admin_page = add_submenu_page(
+				'settings.php',
+				esc_html__( 'Events Help', 'tribe-common' ),
+				esc_html__( 'Events Help', 'tribe-common' ),
+				$this->requiredCap,
+				$this->help_slug,
+				array(
+					tribe( 'settings.manager' ),
+					'do_help_tab',
 				)
 			);
 		}

--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -317,13 +317,6 @@ class Tribe__Settings_Manager {
 	 * @return Tribe__Settings_Manager
 	 */
 	public static function instance() {
-		static $instance;
-
-		if ( ! $instance ) {
-			$class_name = __CLASS__;
-			$instance = new $class_name;
-		}
-
-		return $instance;
+		return tribe( 'settings.manager' );
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/68665

This PR adds the Help page as per the ticket in the network admin and refactors some code to use the container.

There is the possibility here to switch any plugin using the pervasive `Tribe__Settings` and `Tribe__Settings_Manager` classes to use the container. I'd do that in a different PR (*many* PRs)