### PR TITLE
Hide full licenses in subsites

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -650,8 +650,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		}
 
 		/**
-         * Whether the plugin is network activated and licensed or not.
-         *
+		 * Whether the plugin is network activated and licensed or not.
+		 *
 		 * @return bool
 		 */
 		public function is_network_licensed() {
@@ -1206,23 +1206,23 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		}
 
 		/**
-         * Returns the plugin file to use when checking for the licensed component or plugin.
-         *
+		 * Returns the plugin file to use when checking for the licensed component or plugin.
+		 *
 		 * @param string $plugin_file The component or plugin file in the `<dir>/<file>.php` format.
 		 *
 		 * @return string A component or plugins file in the `<dir>/<file>.php` format.
 		 */
 		protected function get_network_plugin_file( $plugin_file ) {
-		    $map = array(
-		     'event-aggregator/event-aggregator.php' => 'the-events-calendar/the-events-calendar.php',
-            );
+			$map = array(
+				'event-aggregator/event-aggregator.php' => 'the-events-calendar/the-events-calendar.php',
+			);
 
-		    return isset($map[$plugin_file]) ? $map[$plugin_file] : $plugin_file;
+			return isset( $map[ $plugin_file ] ) ? $map[ $plugin_file ] : $plugin_file;
 		}
 
 		/**
 		 * Returns the localized string for a plugin or component license state.
-         *
+		 *
 		 * @return string The localized state string.
 		 */
 		protected function get_network_license_state_string() {

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -403,24 +403,48 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @return array Modified list of fields.
 		 */
 		public function do_license_key_fields( $fields ) {
+		    $show_license = true;
+
+			if(
+                is_multisite()
+                && !is_network_admin()
+                && is_plugin_active_for_network( $this->get_network_plugin_file($this->plugin_file) ) ){
+		        $network_key = get_network_option(null,$this->pue_install_key);
+		        $local_key = get_option($this->pue_install_key);
+
+		        $show_license = $network_key !== $local_key;
+            }
+
+            // common fields whether licenses should be hidden or not
+			$to_insert = array(
+				$this->pue_install_key . '-heading' => array(
+					'type'  => 'heading',
+					'label' => $this->get_plugin_name(),
+				)
+			);
 
 			// we want to inject the following license settings at the end of the licenses tab
-			$fields = self::array_insert_after_key( 'tribe-form-content-start', $fields, array(
-					$this->pue_install_key . '-heading' => array(
-						'type'  => 'heading',
-						'label' => $this->get_plugin_name(),
-					),
-					$this->pue_install_key => array(
+			if ( $show_license ) {
+				$to_insert[$this->pue_install_key ] = array(
 						'type'            => 'license_key',
 						'size'            => 'large',
 						'validation_type' => 'license_key',
 						'label'           => sprintf( esc_attr__( 'License Key', 'tribe-common' ) ),
-						'tooltip'         => esc_html__( 'A valid license key is required for support and updates', 'tribe-common' ),
+						'tooltip'         => esc_html__(
+							'A valid license key is required for support and updates', 'tribe-common'
+						),
 						'parent_option'   => false,
 						'network_option'  => true,
-					),
-				)
-			);
+				);
+			} else {
+				$to_insert[$this->pue_install_key. '-state' ] = array(
+					'type'  => 'html',
+					'label' => sprintf( esc_attr__( 'License Key State', 'tribe-common' ) ),
+					'html'  => sprintf( '<p>%s</p>', $this->get_network_license_state_string() ),
+				);
+            }
+
+			$fields    = self::array_insert_after_key( 'tribe-form-content-start', $fields, $to_insert );
 
 			return $fields;
 		}
@@ -1172,6 +1196,56 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			} else {
 				return strtolower( $site_url['host'] );
 			}
+		}
+
+		/**
+         * Returns the plugin file to use when checking for the licensed component or plugin.
+         *
+		 * @param string $plugin_file The component or plugin file in the `<dir>/<file>.php` format.
+		 *
+		 * @return string A component or plugins file in the `<dir>/<file>.php` format.
+		 */
+		protected function get_network_plugin_file( $plugin_file ) {
+		    $map = array(
+		     'event-aggregator/event-aggregator.php' => 'the-events-calendar/the-events-calendar.php',
+            );
+
+		    return isset($map[$plugin_file]) ? $map[$plugin_file] : $plugin_file;
+		}
+
+		/**
+		 * Returns the localized string for a plugin or component license state.
+         *
+		 * @return string The localized state string.
+		 */
+		protected function get_network_license_state_string() {
+			$transient_key = 'pue-' . $this->plugin_slug . '-key_state';
+
+			$state = get_transient( $transient_key );
+
+			$states = array(
+				'licensed'     => esc_html_x( 'Licensed', 'The license for this plugin is valid.', 'tribe-common' ),
+				'not-licensed' => esc_html( 'No license entered. Consult your network administrator.', 'tribe-common' ),
+				'expired'      => esc_html( 'Expired license. Consult your network administrator.', 'tribe-common' ),
+			);
+
+			if ( is_string( $state ) && array_key_exists( $state, $states ) ) {
+				return $states[ $state ];
+			}
+
+			$response = $this->validate_key( get_network_option( null, $this->pue_install_key ) );
+
+			if ( isset( $response['status'] ) && $response['status'] === 1 ) {
+				$state = 'licensed';
+			} else if ( isset( $response['api_expired'] ) && $response['api_expired'] == true ) {
+				$state = 'expired';
+			} else {
+				$state = 'not-licensed';
+			}
+
+			set_transient( $transient_key, $state, 900 );
+
+			return $states[ $state ];
 		}
 	}
 }

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -655,8 +655,6 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @return bool
 		 */
 		public function is_network_licensed() {
-			$show_license = true;
-
 			if ( is_multisite()
 			     && ! is_network_admin()
 			     && is_plugin_active_for_network( $this->get_network_plugin_file( $this->plugin_file ) )
@@ -664,12 +662,10 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$network_key = get_network_option( null, $this->pue_install_key );
 				$local_key   = get_option( $this->pue_install_key );
 
-				$show_license = $network_key !== $local_key;
-
-				return $show_license;
+				return $network_key === $local_key;
 			}
 
-			return $show_license;
+			return false;
 		}
 
 		private function get_api_update_message() {

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -403,19 +403,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @return array Modified list of fields.
 		 */
 		public function do_license_key_fields( $fields ) {
-		    $show_license = true;
-
-			if(
-                is_multisite()
-                && !is_network_admin()
-                && is_plugin_active_for_network( $this->get_network_plugin_file($this->plugin_file) ) ){
-		        $network_key = get_network_option(null,$this->pue_install_key);
-		        $local_key = get_option($this->pue_install_key);
-
-		        $show_license = $network_key !== $local_key;
-            }
-
-            // common fields whether licenses should be hidden or not
+			// common fields whether licenses should be hidden or not
 			$to_insert = array(
 				$this->pue_install_key . '-heading' => array(
 					'type'  => 'heading',
@@ -424,7 +412,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			);
 
 			// we want to inject the following license settings at the end of the licenses tab
-			if ( $show_license ) {
+			if ( ! $this->is_network_licensed() ) {
 				$to_insert[$this->pue_install_key ] = array(
 						'type'            => 'license_key',
 						'size'            => 'large',
@@ -661,6 +649,29 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			return $message;
 		}
 
+		/**
+         * Whether the plugin is network activated and licensed or not.
+         *
+		 * @return bool
+		 */
+		public function is_network_licensed() {
+			$show_license = true;
+
+			if ( is_multisite()
+			     && ! is_network_admin()
+			     && is_plugin_active_for_network( $this->get_network_plugin_file( $this->plugin_file ) )
+			) {
+				$network_key = get_network_option( null, $this->pue_install_key );
+				$local_key   = get_option( $this->pue_install_key );
+
+				$show_license = $network_key !== $local_key;
+
+				return $show_license;
+			}
+
+			return $show_license;
+		}
+
 		private function get_api_update_message() {
 			$plugin_info = $this->plugin_info;
 
@@ -709,7 +720,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		}
 
 		public function add_notice_to_plugin_notices( $notices ) {
-			if ( ! $this->plugin_notice ) {
+			if ( ! $this->plugin_notice || $this->is_network_licensed() ) {
 				return $notices;
 			}
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -131,6 +131,12 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 		private static $instance;
 
 		/**
+		 * The settings page URL.
+		 * @var string
+		 */
+		protected $url;
+
+		/**
 		 * Static Singleton Factory Method
 		 *
 		 * @return Tribe__Settings


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/68662

This PR:

* will replace the license field and the AJAX verification with a message about the license state
* the AJAX based license verification is made server-side to avoid grabbing the license from subsites
* plugin notices are hidden as well for network activated MT plugins