### PR TITLE
tribe_update_option(): return a boolean indicating success or failure

### DIFF
--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -101,16 +101,16 @@ class Tribe__Settings_Manager {
 	 * @param array $options formatted the same as from get_options()
 	 * @param bool  $apply_filters
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public static function set_options( $options, $apply_filters = true ) {
 		if ( ! is_array( $options ) ) {
-			return;
+			return false;
 		}
 		if ( $apply_filters == true ) {
 			$options = apply_filters( 'tribe-events-save-options', $options );
 		}
-		update_option( Tribe__Main::OPTIONNAME, $options );
+		return update_option( Tribe__Main::OPTIONNAME, $options );
 	}
 
 	/**
@@ -119,13 +119,13 @@ class Tribe__Settings_Manager {
 	 * @param string $name
 	 * @param mixed  $value
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public static function set_option( $name, $value ) {
 		$newOption        = array();
 		$newOption[ $name ] = $value;
 		$options          = self::get_options();
-		self::set_options( wp_parse_args( $newOption, $options ) );
+		return self::set_options( wp_parse_args( $newOption, $options ) );
 	}
 
 	/**

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -40,10 +40,10 @@ if ( ! function_exists( 'tribe_update_option' ) ) {
 	 * @param string $optionName Name of the option to retrieve.
 	 * @param string $value      Value to save
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	function tribe_update_option( $optionName, $value ) {
-		Tribe__Settings_Manager::set_option( $optionName, $value );
+		return Tribe__Settings_Manager::set_option( $optionName, $value );
 	}
 }//end if
 


### PR DESCRIPTION
It would be useful to get an indication of whether a `tribe_update_option()` call was successful or not.