### PR TITLE
Fix to_tz method name

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -347,7 +347,7 @@ class Tribe__Timezones {
 	 *
 	 * @return string
 	 */
-	public static function jo_tz( $datetime, $tzstring ) {
+	public static function to_tz( $datetime, $tzstring ) {
 		if ( Tribe__Events__Timezones::is_utc_offset( $tzstring ) ) {
 			return Tribe__Events__Timezones::apply_offset( $datetime, $tzstring );
 		}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/41324

While working on the ticket I've found out this issue where `to_tz` method name was changed to `jo_tz` which is a cool as it is not functional.