### PR TITLE
Switch away from using constants on tribe_resource_url()

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -113,7 +113,7 @@ if ( ! function_exists( 'tribe_resource_url' ) ) {
 		$file = $plugin_path . $path;
 
 		// Turn the Path into a URL
-		$url = str_replace( wp_normalize_path( WP_CONTENT_DIR ), WP_CONTENT_URL, $file );
+		$url = str_replace( wp_normalize_path( WP_CONTENT_DIR ), content_url(), $file );
 
 		// Make it compatible with Windows and other OS
 		$url = str_replace( DIRECTORY_SEPARATOR, '/', $url );


### PR DESCRIPTION
_Ref:_ [C#68372](https://central.tri.be/issues/68372)
_Merged because it was already code reviewed, but PRed against `develop`_