### PR TITLE
make sure some data is carried over

### DIFF
--- a/src/resources/js/dropdowns.js
+++ b/src/resources/js/dropdowns.js
@@ -190,14 +190,14 @@
 				};
 			}
 
-			$container = ($select.select2( args )).select2('container');
+			$container = ( $select.select2( args ) ).select2( 'container' );
 
 			if ( carryOverData.length > 0 ) {
 				carryOverData.map( function ( dataKey ) {
 					var attr = 'data-' + dataKey,
 						val = $select.attr( attr );
 
-					if ( !val ) {
+					if ( ! val ) {
 						return;
 					}
 

--- a/src/resources/js/dropdowns.js
+++ b/src/resources/js/dropdowns.js
@@ -29,7 +29,21 @@
 					dropdownCss: {
 						'min-width': '5rem'
 					}
-				};
+				},
+				carryOverData = [
+					'depends',
+					'condition',
+					'conditionNot',
+					'conditionNotEmpty',
+					'condition-not-empty',
+					'conditionEmpty',
+					'condition-empty',
+					'conditionIsNumeric',
+					'condition-is-numeric',
+					'conditionIsNotNumeric',
+					'condition-is-not-numeric'
+				],
+				$container;
 
 			if ( ! $select.is( 'select' ) ) {
 				// Better Method for finding the ID
@@ -176,7 +190,20 @@
 				};
 			}
 
-			$select.select2( args );
+			$container = ($select.select2( args )).select2('container');
+
+			if ( carryOverData.length > 0 ) {
+				carryOverData.map( function ( dataKey ) {
+					var attr = 'data-' + dataKey,
+						val = $select.attr( attr );
+
+					if ( !val ) {
+						return;
+					}
+
+					this.attr( attr, val );
+				}, $container );
+			}
 		})
 		.on( 'change', function( event ) {
 			var $select = $(this),


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67143

This PR updates dropdowns.js to carry over some `data` attributes from elements after applying `select2` to it.
The reason being that @bordoni's excellent dependency automagical lib will require those `data` attributes on the top element and not on the hidden `select`