### PR TITLE
Added set_version method. Will be used in the future for clearing cac…

### DIFF
--- a/src/Tribe/Extension.php
+++ b/src/Tribe/Extension.php
@@ -148,6 +148,15 @@ abstract class Tribe__Extension {
 	}
 
 	/**
+	 * Set the extension's version number
+	 *
+	 * @param string $version Extensions semantic version number.
+	 */
+	final protected function set_version( $version ) {
+		$this->set( 'version', $version );
+	}
+
+	/**
 	 * Checks if the extension has permission to run, if so runs init() in child class
 	 */
 	final public function register() {


### PR DESCRIPTION
It just occurred to me that I forgot to add a `set_version()` method. This is a pretty useless method right now, but we want extensions to be using it. Because in the future we will be caching the plugin header data in the database for performance reasons. In order to invalidate that cache when a plugin is manually updated, we need a method like this. Any extension that releases a version beyond 1.0.0 should use this to specify its version number. If the version number does not match the DB cache, the cache will be rebuilt.