### PR TITLE
Bump common version to avoid fatals

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -17,7 +17,7 @@ class Tribe__Main {
 	const OPTIONNAME          = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK   = 'tribe_events_calendar_network_options';
 
-	const VERSION           = '4.3.1';
+	const VERSION           = '4.4dev1';
 	const FEED_URL          = 'https://theeventscalendar.com/feed/';
 
 	protected $plugin_context;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/69503 

When on `develop` common version (the constant `Tribe__Main::VERSION`) should always be updated to be > to the one set on `master`.