### PR TITLE
Make our common dropdowns methods publicly accessible

### DIFF
--- a/src/resources/js/dropdowns.js
+++ b/src/resources/js/dropdowns.js
@@ -1,3 +1,5 @@
+var tribe_dropdowns = tribe_dropdowns || {};
+
 ( function( $, obj ) {
 	'use strict';
 
@@ -318,4 +320,4 @@
 	$( function() {
 		$( obj.selector.dropdown ).tribe_dropdowns();
 	} );
-} )( jQuery, {} );
+} )( jQuery, tribe_dropdowns );


### PR DESCRIPTION
Make dropdown methods accessible from other code via `tribe_dropdowns`.

I'm assuming all of the current `obj.*` methods can be public here, but actually all I really need is `obj.dropdown` - if the remainder ought to be made 'private' that's doable.

[#69686/R125 findings](https://central.tri.be/issues/69686)