### PR TITLE
Add tribe_is_truthy() for truthiness comparisons | spotfix

### DIFF
--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -157,3 +157,47 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 		return $default;
 	}
 }
+
+if ( ! function_exists( 'tribe_is_truthy' ) ) {
+	/**
+	 * Determines if the provided value should be regarded as 'true'.
+	 *
+	 * @param mixed $var
+	 *
+	 * @return bool
+	 */
+	function tribe_is_truthy( $var ) {
+		if ( is_bool( $var ) ) {
+			return $var;
+		}
+
+		/**
+		 * Provides an opportunity to modify strings that will be
+		 * deemed to evaluate to true.
+		 *
+		 * @param array $truthy_strings
+		 */
+		$truthy_strings = (array) apply_filters( 'tribe_is_truthy_strings', array(
+			'1',
+			'enable',
+			'enabled',
+			'on',
+			'y',
+			'yes',
+			'true',
+		) );
+
+		// If $var is a string, it is only true if it is contained in the above array
+		if ( in_array( $var, $truthy_strings, true ) ) {
+			return true;
+		}
+
+		// All other strings will be treated as false
+		if ( is_string( $var ) ) {
+			return false;
+		}
+
+		// For other types (ints, floats etc) cast to bool
+		return (bool) $var;
+	}
+}


### PR DESCRIPTION
General purpose is-this-thing-truthy function to avoid per-class replication of the same logic.