### PR TITLE
Remove extra characters after closing script tag | spotfix

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -297,7 +297,7 @@ class Tribe__Main {
 			'use strict';
 			body.className = body.className.replace( /\btribe-no-js\b/, 'tribe-js' );
 		} )( document.body );
-		</script>";
+		</script>
 		<?php
 	}
 


### PR DESCRIPTION
Spotfix [per this support thread](https://theeventscalendar.com/support/forums/topic/added-characters/) - wanted to get the fix in `develop` irrespective of if a hotfix goes out.