### PR TITLE
Fix/70623 common script data

### DIFF
--- a/src/Tribe/Asset/Data.php
+++ b/src/Tribe/Asset/Data.php
@@ -48,7 +48,7 @@ class Tribe__Asset__Data {
 		echo '<script type=\'text/javascript\'> /* <![CDATA[ */';
 
 		foreach ( $this->objects as $object_name => $data ) {
-			echo "var $object_name = " . wp_json_encode( $data ) . ';';
+			echo 'var ' . esc_html( $object_name ) . ' = ' . wp_json_encode( $data ) . ';';
 		}
 
 		echo '/* ]]> */ </script>';

--- a/src/Tribe/Asset/Data.php
+++ b/src/Tribe/Asset/Data.php
@@ -6,7 +6,7 @@
  * Should generally be accessed via tribe( 'tribe.asset.script-data' )
  * rather than via direct instantiation.
  */
-class Tribe__Asset__Script_Data {
+class Tribe__Asset__Data {
 	/**
 	 * Container for any JS data objects that should be added to the page.
 	 *

--- a/src/Tribe/Asset/Data.php
+++ b/src/Tribe/Asset/Data.php
@@ -30,9 +30,9 @@ class Tribe__Asset__Data {
 	 * to other scripts.
 	 *
 	 * @param string $object_name
-	 * @param array  $data
+	 * @param mixed  $data
 	 */
-	public function add( $object_name, array $data ) {
+	public function add( $object_name, $data ) {
 		$this->objects[ $object_name ] = $data;
 	}
 

--- a/src/Tribe/Asset/Script_Data.php
+++ b/src/Tribe/Asset/Script_Data.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Handles adding script data to the page in cases where localizing a
+ * specific script is not suitable.
+ *
+ * Should generally be accessed via tribe( 'tribe.asset.script-data' )
+ * rather than via direct instantiation.
+ */
+class Tribe__Asset__Script_Data {
+	/**
+	 * Container for any JS data objects that should be added to the page.
+	 *
+	 * @var array
+	 */
+	protected $objects = array();
+
+	/**
+	 * Hooks up the method used to actually render the JSON data.
+	 */
+	public function hook() {
+		if ( is_admin() ) {
+			add_action( 'admin_footer', array( $this, 'render_json' ) );
+		} else {
+			add_action( 'wp_footer', array( $this, 'render_json' ) );
+		}
+	}
+
+	/**
+	 * Adds the provided data to the list of objects that should be available
+	 * to other scripts.
+	 *
+	 * @param string $object_name
+	 * @param array  $data
+	 */
+	public function add( $object_name, array $data ) {
+		$this->objects[ $object_name ] = $data;
+	}
+
+	/**
+	 * Outputs the
+	 * @internal
+	 */
+	public function render_json() {
+		if ( empty( $this->objects ) ) {
+			return;
+		}
+
+		echo '<script type=\'text/javascript\'> /* <![CDATA[ */';
+
+		foreach ( $this->objects as $object_name => $data ) {
+			echo "var $object_name = " . wp_json_encode( $data ) . ';';
+		}
+
+		echo '/* ]]> */ </script>';
+	}
+}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -234,7 +234,7 @@ class Tribe__Main {
 			'admin_enqueue_scripts'
 		);
 
-		tribe( 'tribe.asset.script-data' )->add( 'tribe_l10n_datatables', array(
+		tribe( 'tribe.asset.data' )->add( 'tribe_l10n_datatables', array(
 			'aria' => array(
 				'sort_ascending' => __( ': activate to sort column ascending', 'tribe-common' ),
 				'sort_descending' => __( ': activate to sort column descending', 'tribe-common' ),
@@ -486,6 +486,6 @@ class Tribe__Main {
 	public function bind_implementations() {
 		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
 		tribe_singleton( 'settings', 'Tribe__Settings', array( 'hook' ) );
-		tribe_singleton( 'tribe.asset.script-data', 'Tribe__Asset__Script_Data', array( 'hook' ) );
+		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Script_Data', array( 'hook' ) );
 	}
 }

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -231,49 +231,45 @@ class Tribe__Main {
 			'tribe-common',
 			'tribe-common.js',
 			array( 'tribe-clipboard' ),
-			'admin_enqueue_scripts',
-			array(
-				'localize' => array(
-					'name' => 'tribe_l10n_datatables',
-					'data' => array(
-						'aria' => array(
-							'sort_ascending' => __( ': activate to sort column ascending', 'tribe-common' ),
-							'sort_descending' => __( ': activate to sort column descending', 'tribe-common' ),
-						),
-						'length_menu'   => __( 'Show _MENU_ entries', 'tribe-common' ),
-						'empty_table'   => __( 'No data available in table', 'tribe-common' ),
-						'info'          => __( 'Showing _START_ to _END_ of _TOTAL_ entries', 'tribe-common' ),
-						'info_empty'    => __( 'Showing 0 to 0 of 0 entries', 'tribe-common' ),
-						'info_filtered' => __( '(filtered from _MAX_ total entries)', 'tribe-common' ),
-						'zero_records'  => __( 'No matching records found', 'tribe-common' ),
-						'search'        => __( 'Search:', 'tribe-common' ),
-						'pagination' => array(
-							'all' => __( 'All', 'tribe-common' ),
-							'next' => __( 'Next', 'tribe-common' ),
-							'previous' => __( 'Previous', 'tribe-common' ),
-						),
-						'select' => array(
-							'rows' => array(
-								0 => '',
-								'_' => __( ': Selected %d rows', 'tribe-common' ),
-								1 => __( ': Selected 1 row', 'tribe-common' ),
-							),
-						),
-						'datepicker' => array(
-							'dayNames'        => Tribe__Date_Utils::get_localized_weekdays_full(),
-							'dayNamesShort'   => Tribe__Date_Utils::get_localized_weekdays_short(),
-							'dayNamesMin'     => Tribe__Date_Utils::get_localized_weekdays_initial(),
-							'monthNames'      => $datepicker_months,
-							'monthNamesShort' => $datepicker_months, // We deliberately use full month names here
-							'nextText'        => esc_html__( 'Next', 'the-events-calendar' ),
-							'prevText'        => esc_html__( 'Prev', 'the-events-calendar' ),
-							'currentText'     => esc_html__( 'Today', 'the-events-calendar' ),
-							'closeText'       => esc_html__( 'Done', 'the-events-calendar' ),
-						),
-					),
-				),
-			)
+			'admin_enqueue_scripts'
 		);
+
+		tribe( 'tribe.asset.script-data' )->add( 'tribe_l10n_datatables', array(
+			'aria' => array(
+				'sort_ascending' => __( ': activate to sort column ascending', 'tribe-common' ),
+				'sort_descending' => __( ': activate to sort column descending', 'tribe-common' ),
+			),
+			'length_menu'   => __( 'Show _MENU_ entries', 'tribe-common' ),
+			'empty_table'   => __( 'No data available in table', 'tribe-common' ),
+			'info'          => __( 'Showing _START_ to _END_ of _TOTAL_ entries', 'tribe-common' ),
+			'info_empty'    => __( 'Showing 0 to 0 of 0 entries', 'tribe-common' ),
+			'info_filtered' => __( '(filtered from _MAX_ total entries)', 'tribe-common' ),
+			'zero_records'  => __( 'No matching records found', 'tribe-common' ),
+			'search'        => __( 'Search:', 'tribe-common' ),
+			'pagination' => array(
+				'all' => __( 'All', 'tribe-common' ),
+				'next' => __( 'Next', 'tribe-common' ),
+				'previous' => __( 'Previous', 'tribe-common' ),
+			),
+			'select' => array(
+				'rows' => array(
+					0 => '',
+					'_' => __( ': Selected %d rows', 'tribe-common' ),
+					1 => __( ': Selected 1 row', 'tribe-common' ),
+				),
+			),
+			'datepicker' => array(
+				'dayNames'        => Tribe__Date_Utils::get_localized_weekdays_full(),
+				'dayNamesShort'   => Tribe__Date_Utils::get_localized_weekdays_short(),
+				'dayNamesMin'     => Tribe__Date_Utils::get_localized_weekdays_initial(),
+				'monthNames'      => $datepicker_months,
+				'monthNamesShort' => $datepicker_months, // We deliberately use full month names here
+				'nextText'        => esc_html__( 'Next', 'the-events-calendar' ),
+				'prevText'        => esc_html__( 'Prev', 'the-events-calendar' ),
+				'currentText'     => esc_html__( 'Today', 'the-events-calendar' ),
+				'closeText'       => esc_html__( 'Done', 'the-events-calendar' ),
+			),
+		) );
 	}
 
 	/**
@@ -487,8 +483,9 @@ class Tribe__Main {
 	/**
 	 * Registers the slug bound to the implementations in the container.
 	 */
-	public function bind_implementations(  ) {
+	public function bind_implementations() {
 		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
 		tribe_singleton( 'settings', 'Tribe__Settings', array( 'hook' ) );
+		tribe_singleton( 'tribe.asset.script-data', 'Tribe__Asset__Script_Data', array( 'hook' ) );
 	}
 }


### PR DESCRIPTION
* Makes the `tribe_l10n_datatables` object available independently of whether `tribe-common.js` or any other single asset is enqueued
* Adds a helper class to achieve that (ie, add data to the page without localizing individual scripts)

https://central.tri.be/issues/70682