### PR TITLE
Update reference to Tribe__Asset__Data | spotfix

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -486,6 +486,6 @@ class Tribe__Main {
 	public function bind_implementations() {
 		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
 		tribe_singleton( 'settings', 'Tribe__Settings', array( 'hook' ) );
-		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Script_Data', array( 'hook' ) );
+		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Data', array( 'hook' ) );
 	}
 }


### PR DESCRIPTION
Missed updating a reference to this class (renamed in a previous change).