### PR TITLE
Add a reusable queue system to use and abuse

### DIFF
--- a/src/Tribe/Cron.php
+++ b/src/Tribe/Cron.php
@@ -10,7 +10,7 @@ class Tribe__Cron {
 	 * @return array
 	 */
 	public function filter_cron_schedules( array $schedules ) {
-		$schedules[ 'thirty_seconds' ] = array(
+		$schedules['thirty_seconds'] = array(
 			'interval' => 30,
 			'display'  => esc_html__( 'Every Thirty Seconds' ),
 		);

--- a/src/Tribe/Cron.php
+++ b/src/Tribe/Cron.php
@@ -1,0 +1,29 @@
+<?php
+
+class Tribe__Cron {
+
+	/**
+	 * Filters the cron schedules to add intervals we need.
+	 *
+	 * @param array $schedules
+	 *
+	 * @return array
+	 */
+	public function filter_cron_schedules( array $schedules ) {
+		$schedules[ 'thirty_seconds' ] = array(
+			'interval' => 30,
+			'display'  => esc_html__( 'Every Thirty Seconds' ),
+		);
+
+		return $schedules;
+	}
+
+	/**
+	 * Schedules cron events we need in our plugins.
+	 */
+	public function schedule() {
+		if ( ! wp_next_scheduled( 'tribe_queue_work' ) ) {
+			wp_schedule_event( time(), 'thirty_seconds', 'tribe_queue_work' );
+		}
+	}
+}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -105,6 +105,7 @@ class Tribe__Main {
 		$this->bind_implementations();
 
 		$this->init_libraries();
+
 		$this->add_hooks();
 
 		$this->doing_ajax = defined( 'DOING_AJAX' ) && DOING_AJAX;
@@ -289,6 +290,14 @@ class Tribe__Main {
 
 		add_filter( 'body_class', array( $this, 'add_js_class' ) );
 		add_action( 'wp_footer', array( $this, 'toggle_js_class' ) );
+
+		add_filter( 'cron_schedules', array( tribe( 'cron' ), 'filter_cron_schedules' ) );
+
+		// Queue hooks
+		add_action( 'admin_head', array( 'Tribe__Queue', 'work' ) );
+		add_action( 'wp_ajax_tribe_queue_work', array( 'Tribe_Queue', 'work' ) );
+		add_action( 'wp_ajax_nopriv_tribe_queue_work', array( 'Tribe_Queue', 'work' ) );
+		add_action( 'tribe_queue_work', array( 'Tribe_Queue', 'work' ) );
 	}
 
 	public function add_js_class( $classes = array() ) {
@@ -489,5 +498,7 @@ class Tribe__Main {
 		tribe_singleton( 'settings.manager', 'Tribe__Settings_Manager' );
 		tribe_singleton( 'settings', 'Tribe__Settings', array( 'hook' ) );
 		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Data', array( 'hook' ) );
+		tribe_singleton( 'cron', 'Tribe__Cron', array( 'schedule' ) );
+		tribe_singleton( 'queue', 'Tribe__Queue' );
 	}
 }

--- a/src/Tribe/Queue.php
+++ b/src/Tribe/Queue.php
@@ -1,0 +1,177 @@
+<?php
+
+class Tribe__Queue {
+	const WORKS_OPTION = 'tribe_q_works';
+
+	/**
+	 * Tells the factory to work on all the available works.
+	 *
+	 * This is the method that should be hooked to actions and crons.
+	 *
+	 * @return bool
+	 */
+	public static function work() {
+		$instance = new self();
+
+		$list = array_keys( $instance->get_work_list() );
+
+		if ( empty( $list ) ) {
+			return true;
+		}
+
+		return $instance->work_on( reset( $list ) );
+	}
+
+	/**
+	 * Tells the factory to work on a particular work immediately.
+	 *
+	 * @param string $work_id
+	 *
+	 * @return bool `true` if the work was done successfully, `false` otherwise.
+	 *              Successfully means that something was done, it does not mean complete.
+	 */
+	public function work_on( $work_id ) {
+		$work = $this->get_work( $work_id );
+
+		if ( empty( $work ) ) {
+			return false;
+		}
+
+		$work->work();
+
+		if ( $work->get_status() === Tribe__Queue__Worker::DONE ) {
+			$this->remove_work_from_list( $work );
+		} else {
+			$this->update_work_status( $work );
+		}
+
+		return true;
+	}
+
+	protected function remove_work_from_list( Tribe__Queue__Worker $work ) {
+		$list = $this->get_work_list();
+
+		unset( $list[ $work->get_id() ] );
+
+		update_option( self::WORKS_OPTION, $list );
+	}
+
+	/**
+	 * @param array                 $targets
+	 * @param       callable| array $callback  Either a callable object or array or a container reference in the
+	 *                                         ['tribe', <alias>, <method>] format.
+	 *                                         The callback will receive three arguments: the current target, the
+	 *                                         target index in the complete list of targets and the data for this work.
+	 * @param mixed                 $data      Some additional data that will be passed to the work callback.
+	 *
+	 * @return Tribe__Queue__Worker
+	 */
+	public function queue_work( array $targets, $callback, $data = null ) {
+		// let the Tribe__Queue__Work class make its own verifications
+		$work = new Tribe__Queue__Worker( $targets, $targets, $callback, $data, Tribe__Queue__Worker::QUEUED );
+
+		$this->update_work_status( $work );
+
+		return $work;
+	}
+
+	/**
+	 * Updates the status of a work in the Factory managed option.
+	 *
+	 * @param $work
+	 */
+	protected function update_work_status( Tribe__Queue__Worker $work ) {
+		$list = $this->get_work_list();
+
+		$list[ $work->get_id() ] = $work->get_status();
+
+		update_option( self::WORKS_OPTION, $list );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_work_list() {
+		$list = get_option( self::WORKS_OPTION );
+
+		if ( empty( $list ) ) {
+			$list = array();
+		}
+
+		$working_stati = array( Tribe__Queue__Worker::WORKING, Tribe__Queue__Worker::QUEUED );
+
+		$filtered = array();
+		foreach ( $list as $work_id => $work_status ) {
+			$work = $this->get_work( $work_id );
+			if ( empty( $work ) || ! in_array( $work_status, $working_stati ) ) {
+				continue;
+			}
+			$filtered[ $work_id ] = $work_status;
+		}
+
+		return $filtered;
+	}
+
+	/**
+	 * Returns the status of a work.
+	 *
+	 * @param string $work_id
+	 *
+	 * @see Tribe__Queue__Worker for possible stati.
+	 *
+	 * @return string
+	 */
+	public function get_work_status( $work_id ) {
+		$work = $this->get_work( $work_id );
+
+		return false !== $work ? $work->get_status() : Tribe__Queue__Worker::NOT_FOUND;
+	}
+
+	/**
+	 * Builds and returns a Tribe__Queue__Work object from its id.
+	 *
+	 * @param string $work_id
+	 *
+	 * @return Tribe__Queue__Worker|false Either the built Work object or `false` if the work object could not be found.
+	 */
+	public function get_work( $work_id ) {
+		$work_data = get_transient( $this->build_transient_name( $work_id ) );
+
+		if ( empty( $work_data ) || false === $decoded = json_decode( $work_data ) ) {
+			// either invalid or expired
+			return false;
+		}
+
+		return $this->build_from_data( $decoded );
+	}
+
+	/**
+	 * Builds the name of the transient storing a work information from its work id.
+	 *
+	 * @param string $work_id
+	 *
+	 * @return string The complete transient name.
+	 */
+	protected function build_transient_name( $work_id ) {
+		$transient = Tribe__Queue__Worker::TRANSIENT_PREFIX . $work_id;
+
+		return $transient;
+	}
+
+	/**
+	 * Builds a Work object from its JSON representation.
+	 *
+	 * @param stdClass $work_data
+	 *
+	 * @return Tribe__Queue__Worker
+	 */
+	protected function build_from_data( stdClass $work_data ) {
+		$work = new Tribe__Queue__Worker( $work_data->targets, $work_data->remaining, $work_data->callback, $work_data->data, $work_data->status );
+
+		if ( isset( $work_data->batch_size ) ) {
+			$work->set_batch_size( $work_data->batch_size );
+		}
+
+		return $work;
+	}
+}

--- a/src/Tribe/Queue.php
+++ b/src/Tribe/Queue.php
@@ -4,7 +4,7 @@ class Tribe__Queue {
 	/**
 	 * The name of the option that stores the queue current works and their stati.
 	 */
-	const WORKS_OPTION = 'tribe_q_works';
+	public static $works_option = 'tribe_q_works';
 
 	/**
 	 * Tells the factory to work on all the available works.
@@ -42,7 +42,7 @@ class Tribe__Queue {
 
 		$work->work();
 
-		if ( $work->get_status() === Tribe__Queue__Worker::DONE ) {
+		if ( $work->get_status() === Tribe__Queue__Worker::$done ) {
 			$this->remove_work_from_list( $work );
 		} else {
 			$this->update_work_status( $work );
@@ -56,7 +56,7 @@ class Tribe__Queue {
 
 		unset( $list[ $work->get_id() ] );
 
-		update_option( self::WORKS_OPTION, $list );
+		update_option( self::$works_option, $list );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Tribe__Queue {
 	 */
 	public function queue_work( array $targets, $callback, $data = null ) {
 		// let the Tribe__Queue__Work class make its own verifications
-		$work = new Tribe__Queue__Worker( $targets, $targets, $callback, $data, Tribe__Queue__Worker::QUEUED );
+		$work = new Tribe__Queue__Worker( $targets, $targets, $callback, $data, Tribe__Queue__Worker::$queued );
 
 		$this->update_work_status( $work );
 
@@ -90,14 +90,14 @@ class Tribe__Queue {
 
 		$list[ $work->get_id() ] = $work->get_status();
 
-		update_option( self::WORKS_OPTION, $list );
+		update_option( self::$works_option, $list );
 	}
 
 	/**
 	 * @return array
 	 */
 	public function get_work_list() {
-		$list = get_option( self::WORKS_OPTION );
+		$list = get_option( self::$works_option );
 
 		if ( empty( $list ) ) {
 			$list = array();
@@ -131,7 +131,7 @@ class Tribe__Queue {
 			$work = $work_id;
 		}
 
-		return false !== $work ? $work->get_status() : Tribe__Queue__Worker::NOT_FOUND;
+		return false !== $work ? $work->get_status() : Tribe__Queue__Worker::$not_found;
 	}
 
 	/**
@@ -160,7 +160,7 @@ class Tribe__Queue {
 	 * @return string The complete transient name.
 	 */
 	protected function build_transient_name( $work_id ) {
-		$transient = Tribe__Queue__Worker::TRANSIENT_PREFIX . $work_id;
+		$transient = Tribe__Queue__Worker::$transient_prefix . $work_id;
 
 		return $transient;
 	}
@@ -209,7 +209,7 @@ class Tribe__Queue {
 	 * @return bool
 	 */
 	protected function can_work( Tribe__Queue__Worker $worker ) {
-		$working_stati = array( Tribe__Queue__Worker::WORKING, Tribe__Queue__Worker::QUEUED );
+		$working_stati = array( Tribe__Queue__Worker::$working, Tribe__Queue__Worker::$queued );
 
 		return in_array( $worker->get_status(), $working_stati );
 	}

--- a/src/Tribe/Queue.php
+++ b/src/Tribe/Queue.php
@@ -1,6 +1,9 @@
 <?php
 
 class Tribe__Queue {
+	/**
+	 * The name of the option that stores the queue current works and their stati.
+	 */
 	const WORKS_OPTION = 'tribe_q_works';
 
 	/**
@@ -57,6 +60,8 @@ class Tribe__Queue {
 	}
 
 	/**
+	 * Appends a new work to the queue.
+	 *
 	 * @param array                 $targets
 	 * @param       callable| array $callback  Either a callable object or array or a container reference in the
 	 *                                         ['tribe', <alias>, <method>] format.
@@ -76,14 +81,39 @@ class Tribe__Queue {
 	}
 
 	/**
+	 * Prepends a new work to the queue.
+	 *
+	 * @param array                 $targets
+	 * @param       callable| array $callback  Either a callable object or array or a container reference in the
+	 *                                         ['tribe', <alias>, <method>] format.
+	 *                                         The callback will receive three arguments: the current target, the
+	 *                                         target index in the complete list of targets and the data for this work.
+	 * @param mixed                 $data      Some additional data that will be passed to the work callback.
+	 *
+	 * @return Tribe__Queue__Worker
+	 */
+	public function prepend_work( array $targets, $callback, $data = null ) {
+		// let the Tribe__Queue__Work class make its own verifications
+		$work = new Tribe__Queue__Worker( $targets, $targets, $callback, $data, Tribe__Queue__Worker::QUEUED );
+
+		$this->update_work_status( $work, false );
+
+		return $work;
+	}
+
+	/**
 	 * Updates the status of a work in the Factory managed option.
 	 *
 	 * @param $work
 	 */
-	protected function update_work_status( Tribe__Queue__Worker $work ) {
+	protected function update_work_status( Tribe__Queue__Worker $work, $append = true ) {
 		$list = $this->get_work_list();
 
-		$list[ $work->get_id() ] = $work->get_status();
+		if ( $append ) {
+			$list[ $work->get_id() ] = $work->get_status();
+		} else {
+			$list = array_merge( array( $work->get_id() => $work->get_status() ), $list );
+		}
 
 		update_option( self::WORKS_OPTION, $list );
 	}

--- a/src/Tribe/Queue/Worker.php
+++ b/src/Tribe/Queue/Worker.php
@@ -42,6 +42,11 @@ class Tribe__Queue__Worker {
 	protected $batch_size = 10;
 
 	/**
+	 * @var int
+	 */
+	protected $priority = 10;
+
+	/**
 	 * @var mixed Additional data that will be passed to the callback function to comp
 	 */
 	private $data;
@@ -97,6 +102,7 @@ class Tribe__Queue__Worker {
 			'data'       => $this->data,
 			'status'     => $this->status,
 			'batch_size' => $this->batch_size,
+			'priority'   => $this->priority,
 		);
 	}
 
@@ -234,5 +240,27 @@ class Tribe__Queue__Worker {
 	 */
 	protected function is_container_callback( $callback ) {
 		return is_array( $callback ) && count( $callback ) === 3 && 'tribe' === $callback[0];
+	}
+
+	/**
+	 * Sets the work priority in a way similar to the one used by WordPress hooks and filters: lower goes first.
+	 *
+	 * @param int $priority
+	 */
+	public function set_priority( $priority ) {
+		if ( ! filter_var( $priority, FILTER_VALIDATE_INT ) ) {
+			throw new InvalidArgumentException( 'Priority must be an integer.' );
+		}
+
+		$this->priority = intval( $priority );
+	}
+
+	/**
+	 * Returns the work priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority() {
+		return $this->priority;
 	}
 }

--- a/src/Tribe/Queue/Worker.php
+++ b/src/Tribe/Queue/Worker.php
@@ -63,7 +63,7 @@ class Tribe__Queue__Worker {
 	 * @param mixed                 $data      Some additional data that will be passed to the work callback.
 	 * @param string                $status    A string representing  the status of this Worker.
 	 */
-	public function __construct( array $targets, array $remaining, $callback, $data = null, $status = self::QUEUED ) {
+	public function __construct( array $targets, array $remaining, $callback, $data = null, $status = self::QUEUED, $priority = 10 ) {
 		$this->id = md5( serialize( $targets ) . serialize( $callback ) . serialize( $data ) );
 		$this->targets = $targets;
 		$this->remaining = $remaining;
@@ -75,6 +75,7 @@ class Tribe__Queue__Worker {
 		$this->callback = $callback;
 		$this->data = $data;
 		$this->status = empty( $targets ) ? self::DONE : $status;
+		$this->priority = $priority;
 	}
 
 	/**
@@ -253,6 +254,8 @@ class Tribe__Queue__Worker {
 		}
 
 		$this->priority = intval( $priority );
+
+		return $this;
 	}
 
 	/**

--- a/src/Tribe/Queue/Worker.php
+++ b/src/Tribe/Queue/Worker.php
@@ -1,0 +1,238 @@
+<?php
+
+class Tribe__Queue__Worker {
+
+	const QUEUED = 'queued';
+	const WORKING = 'working';
+	const DONE = 'done';
+	const NOT_FOUND = 'not-found';
+	const TRANSIENT_PREFIX = 'tribe_q_';
+
+	/**
+	 * @var array All the targets for this work.
+	 */
+	protected $targets;
+
+	/**
+	 * @var callable The callback that will be called on each target to complete the work.
+	 *               The callback will receive the following arguments:
+	 *               `target` - the current target object
+	 *               `data` - the optional additional data provided
+	 */
+	protected $callback;
+
+	/**
+	 * @var
+	 */
+	protected $status;
+
+	/**
+	 * @var array An array of the targets that have to be completed yet.
+	 */
+	protected $remaining;
+
+	/**
+	 * @var string
+	 */
+	protected $id;
+
+	/**
+	 * @var int
+	 */
+	protected $batch_size = 10;
+
+	/**
+	 * @var mixed Additional data that will be passed to the callback function to comp
+	 */
+	private $data;
+
+	/**
+	 * Tribe__Queue__Worker constructor.
+	 *
+	 * @param array                 $targets   An array of target objects the worker should commplete.
+	 * @param array                 $remaining An array of target objects the worker still has to work on.
+	 * @param       callable| array $callback  Either a callable object or array or a container reference in the
+	 *                                         ['tribe', <alias>, <method>] format.
+	 *                                         The callback will receive three arguments: the current target, the
+	 *                                         target index in the complete list of targets and the data for this work.
+	 * @param mixed                 $data      Some additional data that will be passed to the work callback.
+	 * @param string                $status    A string representing  the status of this Worker.
+	 */
+	public function __construct( array $targets, array $remaining, $callback, $data = null, $status = self::QUEUED ) {
+		$this->id = md5( serialize( $targets ) . serialize( $callback ) . serialize( $data ) );
+		$this->targets = $targets;
+		$this->remaining = $remaining;
+
+		if ( ! ( is_callable( $callback ) || $this->is_container_callback( $callback ) ) ) {
+			throw new InvalidArgumentException( "Callback argument must be a callable or a container reference in the ['tribe', <alias>, <method>]" );
+		}
+
+		$this->callback = $callback;
+		$this->data = $data;
+		$this->status = empty( $targets ) ? self::DONE : $status;
+	}
+
+	/**
+	 * Saves the status of this worker in a transient on the database.
+	 *
+	 * @return string The worker id.
+	 */
+	public function save() {
+		$transient = $this->build_transient_name();
+		set_transient( $transient, json_encode( $this->to_array() ), 2 * DAY_IN_SECONDS );
+
+		return $this->id;
+	}
+
+	/**
+	 * Returns an array representation of the worker.
+	 *
+	 * @return array An array representation of the worker.
+	 */
+	public function to_array() {
+		return array(
+			'targets'    => $this->targets,
+			'remaining'  => $this->remaining,
+			'callback'   => $this->callback,
+			'data'       => $this->data,
+			'status'     => $this->status,
+			'batch_size' => $this->batch_size,
+		);
+	}
+
+	/**
+	 * Returns the worker current status.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+	/**
+	 * Builds the name of the transient storing a work information from its work id.
+	 *
+	 * @param string $work_id
+	 *
+	 * @return string The complete transient name.
+	 */
+	protected function build_transient_name() {
+		$transient = self::TRANSIENT_PREFIX . $this->id;
+
+		return $transient;
+	}
+
+	/**
+	 * Sets the batch size this worker should use.
+	 *
+	 * @param int $batch_size
+	 *
+	 * @return $this
+	 *
+	 * @throws InvalidArgumentException If the batch size is not a positive integer.
+	 */
+	public function set_batch_size( $batch_size ) {
+		if ( ! filter_var( $batch_size, FILTER_VALIDATE_INT ) || intval( $batch_size ) < 1 ) {
+			throw new InvalidArgumentException( 'The batch size should be a positive integer.' );
+		}
+		$this->batch_size = $batch_size;
+
+		return $this;
+	}
+
+	/**
+	 * Tells the worker to work on a batch of its queue.
+	 *
+	 * @return string The worker id.
+	 */
+	public function work() {
+		if ( empty( $this->remaining ) ) {
+			$this->status = self::DONE;
+
+			return $this->save();
+		}
+
+		$batch = array_splice( $this->remaining, 0, $this->batch_size );
+
+		$failures = array();
+
+		$callback = $this->callback;
+		if ( $this->is_container_callback( $callback ) ) {
+			$callback = array( tribe( $this->callback[1] ), $this->callback[2] );
+		}
+
+		foreach ( $batch as $target ) {
+			$target_index = array_search( $target, $this->targets );
+			try {
+				$success = (bool) call_user_func_array( $callback, array( $target, $target_index, $this->data ) );
+			} catch ( Exception $e ) {
+				$success = false;
+			}
+
+			if ( true !== $success ) {
+				$failures[] = $target;
+			}
+		}
+
+		// to avoid iterating over failing elements the failed ones are moved at the end of the qeueue
+		$this->remaining = array_merge( $this->remaining, $failures );
+
+		if ( empty( $this->remaining ) ) {
+			$this->status = self::DONE;
+		} else {
+			$this->status = self::WORKING;
+		}
+
+		return $this->save();
+	}
+
+	/**
+	 * Returns an array of the remaining targets the worker should work on.
+	 *
+	 * @return array
+	 */
+	public function get_remaining() {
+		return $this->remaining;
+	}
+
+	/**
+	 * Returns the worker id.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Returns the name of the transient the worker saves and reads its status from.
+	 *
+	 * @return string
+	 */
+	public function get_transient_name() {
+		return $this->build_transient_name();
+	}
+
+	/**
+	 * Reads the worker status from the database.
+	 *
+	 * This is not in sync with save to allow for undo!
+	 *
+	 * @return array|mixed
+	 */
+	public function read() {
+
+		$read = json_decode( get_transient( $this->build_transient_name() ) );
+
+		return ! empty( $read ) ? $read : array();
+	}
+
+	/**
+	 * @param $callback
+	 *
+	 * @return bool
+	 */
+	protected function is_container_callback( $callback ) {
+		return is_array( $callback ) && count( $callback ) === 3 && 'tribe' === $callback[0];
+	}
+}

--- a/tests/wpunit/Tribe/Queue/WorkerTest.php
+++ b/tests/wpunit/Tribe/Queue/WorkerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tribe\Queue;
+
+use Tribe__Queue__Worker as Worker;
+use function GuzzleHttp\json_encode;
+
+class WorkerTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @test
+	 * it should throw if adding non callable callback
+	 */
+	public function it_should_throw_if_adding_non_callable_callback() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new Worker( [], [], 'foo' );
+	}
+
+	/**
+	 * @test
+	 * it should throw if passing non well formed tribe container callback
+	 */
+	public function it_should_throw_if_passing_non_well_formed_tribe_container_callback() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		new Worker( [], [], [ 'tribe', 'foo' ] );
+	}
+
+	/**
+	 * @test
+	 * it should save its state in a transient
+	 */
+	public function it_should_save_its_state_in_a_transient() {
+		$worker = new Worker( [ 'a', 'b', 'c' ], [ 'a', 'b' ], 'trailingslashit', [ 'foo' => 'bar' ], Worker::DONE );
+
+		$worker->save();
+
+		$expected = json_decode( json_encode( [
+			'targets'    => [ 'a', 'b', 'c' ],
+			'remaining'  => [ 'a', 'b' ],
+			'callback'   => 'trailingslashit',
+			'data'       => [ 'foo' => 'bar' ],
+			'status'     => Worker::DONE,
+			'batch_size' => 10,
+		] ) );
+		$this->assertEquals( $expected, $worker->read() );
+	}
+
+	/**
+	 * @test
+	 * it should work on all targets if batch size is bigger then the count
+	 */
+	public function it_should_work_on_all_targets_if_batch_size_is_bigger_then_the_count() {
+		$worker = new Worker( [ 'a', 'b', 'c', 'd' ], [ 'a', 'b', 'c', 'd' ], 'trailingslashit' );
+		$worker->set_batch_size( 10 );
+		$worker->work();
+
+		$expected = [
+			'targets'    => [ 'a', 'b', 'c', 'd' ],
+			'remaining'  => [],
+			'callback'   => 'trailingslashit',
+			'data'       => '',
+			'status'     => Worker::DONE,
+			'batch_size' => 10,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+	}
+
+	/**
+	 * @test
+	 * it should work on a subset of targets if count is larger than batch size
+	 */
+	public function it_should_work_on_a_subset_of_targets_if_count_is_larger_than_batch_size() {
+		$worker = new Worker( [ 'a', 'b', 'c', 'd' ], [ 'a', 'b', 'c', 'd' ], 'trailingslashit' );
+		$worker->set_batch_size( 2 );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => [ 'a', 'b', 'c', 'd' ],
+			'remaining'  => [ 'c', 'd' ],
+			'callback'   => 'trailingslashit',
+			'data'       => '',
+			'status'     => Worker::WORKING,
+			'batch_size' => 2,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => [ 'a', 'b', 'c', 'd' ],
+			'remaining'  => [],
+			'callback'   => 'trailingslashit',
+			'data'       => '',
+			'status'     => Worker::DONE,
+			'batch_size' => 2,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+	}
+
+	/**
+	 * @test
+	 * it should move failed at the end of the queue
+	 */
+	public function it_should_move_failed_at_the_end_of_the_queue() {
+		$targets = [ 'a', 'b', 'c', 'd', 'e' ];
+		$worker = new Worker( $targets, $targets, array( __CLASS__, 'callback_one' ) );
+		$worker->set_batch_size( 3 );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => $targets,
+			'remaining'  => [ 'd', 'e', 'c' ],
+			'callback'   => array( __CLASS__, 'callback_one' ),
+			'data'       => '',
+			'status'     => Worker::WORKING,
+			'batch_size' => 3,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => $targets,
+			'remaining'  => [ 'c' ],
+			'callback'   => array( __CLASS__, 'callback_one' ),
+			'data'       => '',
+			'status'     => Worker::WORKING,
+			'batch_size' => 3,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+	}
+
+	/**
+	 * @test
+	 * it should move exception raising at the end of the queue
+	 */
+	public function it_should_move_exception_raising_at_the_end_of_the_queue() {
+		$targets = [ 'a', 'b', 'c', 'd', 'e' ];
+		$worker = new Worker( $targets, $targets, array( __CLASS__, 'callback_two' ) );
+		$worker->set_batch_size( 3 );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => $targets,
+			'remaining'  => [ 'd', 'e', 'c' ],
+			'callback'   => array( __CLASS__, 'callback_two' ),
+			'data'       => '',
+			'status'     => Worker::WORKING,
+			'batch_size' => 3,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+
+		$worker->work();
+
+		$expected = [
+			'targets'    => $targets,
+			'remaining'  => [ 'c' ],
+			'callback'   => array( __CLASS__, 'callback_two' ),
+			'data'       => '',
+			'status'     => Worker::WORKING,
+			'batch_size' => 3,
+		];
+		$this->assertEquals( $expected, $worker->to_array() );
+	}
+
+	public static function callback_one( $_, $index ) {
+		return 2 === $index ? false : true;
+	}
+
+	public static function callback_two( $_, $index ) {
+		if ( 2 === $index ) {
+			throw new \RuntimeException();
+		}
+
+		return true;
+	}
+}

--- a/tests/wpunit/Tribe/Queue/WorkerTest.php
+++ b/tests/wpunit/Tribe/Queue/WorkerTest.php
@@ -32,7 +32,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 	 * it should save its state in a transient
 	 */
 	public function it_should_save_its_state_in_a_transient() {
-		$worker = new Worker( [ 'a', 'b', 'c' ], [ 'a', 'b' ], 'trailingslashit', [ 'foo' => 'bar' ], Worker::DONE );
+		$worker = new Worker( [ 'a', 'b', 'c' ], [ 'a', 'b' ], 'trailingslashit', [ 'foo' => 'bar' ], Worker::$done );
 
 		$worker->save();
 
@@ -41,7 +41,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'a', 'b' ],
 			'callback'   => 'trailingslashit',
 			'data'       => [ 'foo' => 'bar' ],
-			'status'     => Worker::DONE,
+			'status'     => Worker::$done,
 			'batch_size' => 10,
 			'priority' => 10,
 		] ) );
@@ -62,7 +62,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [],
 			'callback'   => 'trailingslashit',
 			'data'       => '',
-			'status'     => Worker::DONE,
+			'status'     => Worker::$done,
 			'batch_size' => 10,
 			'priority'   => 10,
 		];
@@ -84,7 +84,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'c', 'd' ],
 			'callback'   => 'trailingslashit',
 			'data'       => '',
-			'status'     => Worker::WORKING,
+			'status'     => Worker::$working,
 			'batch_size' => 2,
 			'priority'   => 10,
 		];
@@ -97,7 +97,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [],
 			'callback'   => 'trailingslashit',
 			'data'       => '',
-			'status'     => Worker::DONE,
+			'status'     => Worker::$done,
 			'batch_size' => 2,
 			'priority'   => 10,
 		];
@@ -120,7 +120,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'd', 'e', 'c' ],
 			'callback'   => array( __CLASS__, 'callback_one' ),
 			'data'       => '',
-			'status'     => Worker::WORKING,
+			'status'     => Worker::$working,
 			'batch_size' => 3,
 			'priority'   => 10,
 		];
@@ -133,7 +133,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'c' ],
 			'callback'   => array( __CLASS__, 'callback_one' ),
 			'data'       => '',
-			'status'     => Worker::WORKING,
+			'status'     => Worker::$working,
 			'batch_size' => 3,
 			'priority'   => 10,
 		];
@@ -156,7 +156,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'd', 'e', 'c' ],
 			'callback'   => array( __CLASS__, 'callback_two' ),
 			'data'       => '',
-			'status'     => Worker::WORKING,
+			'status'     => Worker::$working,
 			'batch_size' => 3,
 			'priority'   => 10,
 		];
@@ -169,7 +169,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'remaining'  => [ 'c' ],
 			'callback'   => array( __CLASS__, 'callback_two' ),
 			'data'       => '',
-			'status'     => Worker::WORKING,
+			'status'     => Worker::$working,
 			'batch_size' => 3,
 			'priority'   => 10,
 		];

--- a/tests/wpunit/Tribe/Queue/WorkerTest.php
+++ b/tests/wpunit/Tribe/Queue/WorkerTest.php
@@ -43,6 +43,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => [ 'foo' => 'bar' ],
 			'status'     => Worker::DONE,
 			'batch_size' => 10,
+			'priority' => 10,
 		] ) );
 		$this->assertEquals( $expected, $worker->read() );
 	}
@@ -63,6 +64,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::DONE,
 			'batch_size' => 10,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 	}
@@ -84,6 +86,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::WORKING,
 			'batch_size' => 2,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 
@@ -96,6 +99,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::DONE,
 			'batch_size' => 2,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 	}
@@ -118,6 +122,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::WORKING,
 			'batch_size' => 3,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 
@@ -130,6 +135,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::WORKING,
 			'batch_size' => 3,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 	}
@@ -152,6 +158,7 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::WORKING,
 			'batch_size' => 3,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
 
@@ -164,8 +171,46 @@ class WorkerTest extends \Codeception\TestCase\WPTestCase {
 			'data'       => '',
 			'status'     => Worker::WORKING,
 			'batch_size' => 3,
+			'priority'   => 10,
 		];
 		$this->assertEquals( $expected, $worker->to_array() );
+	}
+
+	/**
+	 * @test
+	 * it should set the default priority of a work to 10
+	 */
+	public function it_should_set_the_default_priority_of_a_work_to_10() {
+		$targets = [ 'a', 'b', 'c', 'd', 'e' ];
+		$worker = new Worker( $targets, $targets, array( __CLASS__, 'callback_two' ) );
+
+		$this->assertEquals( 10, $worker->get_priority() );
+
+	}
+
+	/**
+	 * @test
+	 * it should throw if trying to set the priority of a work to non integer value
+	 */
+	public function it_should_throw_if_trying_to_set_the_priority_of_a_work_to_non_integer_value() {
+		$this->expectException( \InvalidArgumentException::class );
+
+		$targets = [ 'a', 'b', 'c', 'd', 'e' ];
+		$worker = new Worker( $targets, $targets, array( __CLASS__, 'callback_two' ) );
+		$worker->set_batch_size( 3 );
+		$worker->set_priority( 'foo' );
+	}
+
+	/**
+	 * @test
+	 * it should allow setting the priority for the work
+	 */
+	public function it_should_allow_setting_the_priority_for_the_work() {
+		$targets = [ 'a', 'b', 'c', 'd', 'e' ];
+		$worker = new Worker( $targets, $targets, array( __CLASS__, 'callback_two' ) );
+		$worker->set_priority( '23' );
+
+		$this->assertEquals( 23, $worker->get_priority() );
 	}
 
 	public static function callback_one( $_, $index ) {

--- a/tests/wpunit/Tribe/QueueTest.php
+++ b/tests/wpunit/Tribe/QueueTest.php
@@ -40,7 +40,7 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		$work_id = $sut->queue_work( [], 'trailingslashit' )->save();
 
-		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$done, $sut->get_work_status( $work_id ) );
 	}
 
 	/**
@@ -56,11 +56,11 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$working, $sut->get_work_status( $work_id ) );
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$done, $sut->get_work_status( $work_id ) );
 	}
 
 	/**
@@ -76,12 +76,12 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$working, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$done, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
 	}
 
@@ -100,12 +100,12 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$working, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$done, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
 	}
 
@@ -123,12 +123,12 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$working, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( $targets, $sut->get_work( $work_id )->get_remaining() );
 
 		$sut->work_on( $work_id );
 
-		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( Worker::$working, $sut->get_work_status( $work_id ) );
 		$this->assertEquals( $targets, $sut->get_work( $work_id )->get_remaining() );
 	}
 
@@ -156,54 +156,54 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$working, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
-		$expected_list = [ $work_one => Worker::WORKING, $work_two => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$expected_list = [ $work_one => Worker::$working, $work_two => Worker::$queued, $work_three => Worker::$queued ];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
-		$expected_list = [ $work_two => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$expected_list = [ $work_two => Worker::$queued, $work_three => Worker::$queued ];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$working, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/', get_option( 'foo' ) );
-		$expected_list = [ $work_two => Worker::WORKING, $work_three => Worker::QUEUED ];
+		$expected_list = [ $work_two => Worker::$working, $work_three => Worker::$queued ];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$queued, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/', get_option( 'foo' ) );
-		$expected_list = [ $work_three => Worker::QUEUED ];
+		$expected_list = [ $work_three => Worker::$queued ];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$working, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/john/paul/', get_option( 'foo' ) );
-		$expected_list = [ $work_three => Worker::WORKING ];
+		$expected_list = [ $work_three => Worker::$working ];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
 
 		do_action( 'some_action' );
 
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
-		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::$done, $check_factory->get_work_status( $work_three ) );
 		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/john/paul/george/ringo/', get_option( 'foo' ) );
 		$expected_list = [];
 		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
@@ -221,12 +221,12 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * @test
-	 * it should return NOT_FOUND when trying to get status of non existing job
+	 * it should return self::$not_found when trying to get status of non existing job
 	 */
 	public function it_should_return_not_found_when_trying_to_get_status_of_non_existing_job() {
 		$sut = $this->make_instance();
 
-		$this->assertEquals( Worker::NOT_FOUND, $sut->get_work_status( 'bada.boom' ) );
+		$this->assertEquals( Worker::$not_found, $sut->get_work_status( 'bada.boom' ) );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 	 * it should return empty array if list option is not set
 	 */
 	public function it_should_return_empty_array_if_list_option_is_not_set() {
-		delete_option( Queue::WORKS_OPTION );
+		delete_option( Queue::$works_option );
 
 		$sut = $this->make_instance();
 
@@ -252,7 +252,7 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 		$work_two = $sut->queue_work( [ 'a', 'b', 'c', 'e' ], [ __CLASS__, 'callback_one' ] )->set_priority( 1 )->save();
 		$work_three = $sut->queue_work( [ 'a', 'b', 'c', 'f' ], [ __CLASS__, 'callback_one' ] )->set_priority( 10 )->save();
 
-		$expected = [ $work_two => Worker::QUEUED, $work_one => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$expected = [ $work_two => Worker::$queued, $work_one => Worker::$queued, $work_three => Worker::$queued ];
 		$list = $sut->get_work_list();
 		$this->assertSame( $expected, $list );
 	}

--- a/tests/wpunit/Tribe/QueueTest.php
+++ b/tests/wpunit/Tribe/QueueTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tribe;
+
+use Tribe__Queue as Queue;
+use Tribe__Queue__Worker as Worker;
+
+class QueueTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		// before
+		parent::setUp();
+
+		// your set up methods here
+	}
+
+	public function tearDown() {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * it should be instantiatable
+	 */
+	public function it_should_be_instantiatable() {
+		$sut = $this->make_instance();
+
+		$this->assertInstanceOf( Queue::class, $sut );
+	}
+
+	/**
+	 * @test
+	 * it should mark a job with no targets as done
+	 */
+	public function it_should_mark_a_job_with_no_targets_as_done() {
+		$sut = $this->make_instance();
+
+		$work_id = $sut->queue_work( [], 'trailingslashit' )->save();
+
+		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+	}
+
+	/**
+	 * @test
+	 * it should allow setting the batch size on a per-work base
+	 */
+	public function it_should_allow_setting_the_batch_size_on_a_per_work_base() {
+		$sut = $this->make_instance();
+
+		$work_id = $sut->queue_work( [ 'a', 'b', 'c', 'd', 'e', 'f' ], 'trailingslashit' )
+		               ->set_batch_size( 3 )
+		               ->save();
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+	}
+
+	/**
+	 * @test
+	 * it should allow setting a static method as callback
+	 */
+	public function it_should_allow_setting_a_static_method_as_callback() {
+		$sut = $this->make_instance();
+
+		$work_id = $sut->queue_work( [ 'a', 'b', 'c', 'd', 'e', 'f' ], [ __CLASS__, 'callback_two' ] )
+		               ->set_batch_size( 3 )
+		               ->save();
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
+	}
+
+	/**
+	 * @test
+	 * it should allow setting a container alias and method as callback
+	 */
+	public function it_should_allow_setting_a_container_alias_and_method_as_callback() {
+		$sut = $this->make_instance();
+
+		tribe_register( 'foo', $this );
+
+		$work_id = $sut->queue_work( [ 'a', 'b', 'c', 'd', 'e', 'f' ], [ 'tribe', 'foo', 'callback_one' ] )
+		               ->set_batch_size( 3 )
+		               ->save();
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::DONE, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
+	}
+
+	/**
+	 * @test
+	 * it should mark callbacks raising exceptions as not successful
+	 */
+	public function it_should_mark_callbacks_raising_exceptions_as_not_successful() {
+		$sut = $this->make_instance();
+
+		$targets = [ 'a', 'b', 'c', 'd', 'e', 'f' ];
+		$work_id = $sut->queue_work( $targets, [ __CLASS__, 'callback_three' ] )
+		               ->set_batch_size( 10 )
+		               ->save();
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( $targets, $sut->get_work( $work_id )->get_remaining() );
+
+		$sut->work_on( $work_id );
+
+		$this->assertEquals( Worker::WORKING, $sut->get_work_status( $work_id ) );
+		$this->assertEquals( $targets, $sut->get_work( $work_id )->get_remaining() );
+	}
+
+	/**
+	 * @test
+	 * it should run scheduled works on action hook
+	 */
+	public function it_should_run_scheduled_works_on_action_hook() {
+		tribe_register( 'foo', $this );
+		$setup_factory = $this->make_instance();
+		$work_one = $setup_factory->queue_work( [ 'a', 'b', 'c', 'd', 'e', 'f' ], [ __CLASS__, 'callback_two' ] )
+		                          ->set_batch_size( 3 )
+		                          ->save();
+		$work_two = $setup_factory->queue_work( [ 'foo', 'baz', 'bar' ], [ __CLASS__, 'callback_two' ] )
+		                          ->set_batch_size( 2 )
+		                          ->save();
+		$the_beatles = [ 'john', 'paul', 'george', 'ringo' ];
+		$work_three = $setup_factory->queue_work( $the_beatles, [ 'tribe', 'foo', 'callback_one' ] )
+		                            ->set_batch_size( 2 )
+		                            ->save();
+
+		add_action( 'some_action', [ 'Tribe__Queue', 'work' ] );
+
+		$check_factory = $this->make_instance();
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/', get_option( 'foo' ) );
+		$expected_list = [ $work_one => Worker::WORKING, $work_two => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/d/e/f/', get_option( 'foo' ) );
+		$expected_list = [ $work_two => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/', get_option( 'foo' ) );
+		$expected_list = [ $work_two => Worker::WORKING, $work_three => Worker::QUEUED ];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::QUEUED, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/', get_option( 'foo' ) );
+		$expected_list = [ $work_three => Worker::QUEUED ];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::WORKING, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/john/paul/', get_option( 'foo' ) );
+		$expected_list = [ $work_three => Worker::WORKING ];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+
+		do_action( 'some_action' );
+
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_one ) );
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_two ) );
+		$this->assertEquals( Worker::DONE, $check_factory->get_work_status( $work_three ) );
+		$this->assertEquals( 'a/b/c/d/e/f/foo/baz/bar/john/paul/george/ringo/', get_option( 'foo' ) );
+		$expected_list = [];
+		$this->assertEquals( $expected_list, $check_factory->get_work_list() );
+	}
+
+	/**
+	 * @test
+	 * it should return false if trying to work on non existing work
+	 */
+	public function it_should_return_false_if_trying_to_work_on_non_existing_work() {
+		$sut = $this->make_instance();
+
+		$this->assertFalse( $sut->work_on( 'bada.boom' ) );
+	}
+
+	/**
+	 * @test
+	 * it should return NOT_FOUND when trying to get status of non existing job
+	 */
+	public function it_should_return_not_found_when_trying_to_get_status_of_non_existing_job() {
+		$sut = $this->make_instance();
+
+		$this->assertEquals( Worker::NOT_FOUND, $sut->get_work_status( 'bada.boom' ) );
+	}
+
+	/**
+	 * @test
+	 * it should return empty array if list option is not set
+	 */
+	public function it_should_return_empty_array_if_list_option_is_not_set() {
+		delete_option( Queue::WORKS_OPTION );
+
+		$sut = $this->make_instance();
+
+		$this->assertEquals( [], $sut->get_work_list() );
+	}
+
+	/**
+	 * @return Queue
+	 */
+	private function make_instance() {
+		return new Queue();
+	}
+
+	public function callback_one( $string ) {
+		return update_option( 'foo', get_option( 'foo' ) . trailingslashit( $string ) );
+	}
+
+	public static function callback_two( $string ) {
+		return update_option( 'foo', get_option( 'foo' ) . trailingslashit( $string ) );
+	}
+
+	public function callback_three() {
+		throw new \RuntimeException();
+	}
+}

--- a/tests/wpunit/Tribe/QueueTest.php
+++ b/tests/wpunit/Tribe/QueueTest.php
@@ -242,6 +242,21 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * @test
+	 * it should allow prepending works to the work queue
+	 */
+	public function it_should_allow_prepending_works_to_the_work_queue() {
+		$sut = $this->make_instance();
+
+		$work_one = $sut->queue_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
+		$work_two = $sut->queue_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
+		$work_three = $sut->prepend_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
+
+		$expected = [ $work_three => Worker::QUEUED, $work_one => Worker::QUEUED, $work_two => Worker::QUEUED ];
+		$this->assertEquals( $expected, $sut->get_work_list() );
+	}
+
+	/**
 	 * @return Queue
 	 */
 	private function make_instance() {

--- a/tests/wpunit/Tribe/QueueTest.php
+++ b/tests/wpunit/Tribe/QueueTest.php
@@ -243,17 +243,18 @@ class QueueTest extends \Codeception\TestCase\WPTestCase {
 
 	/**
 	 * @test
-	 * it should allow prepending works to the work queue
+	 * it should sort works by priority when getting the list
 	 */
-	public function it_should_allow_prepending_works_to_the_work_queue() {
+	public function it_should_sort_works_by_priority_when_getting_the_list() {
 		$sut = $this->make_instance();
 
-		$work_one = $sut->queue_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
-		$work_two = $sut->queue_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
-		$work_three = $sut->prepend_work( [ 'a', 'b', 'c' ], [ __CLASS__, 'callback_one' ] )->save();
+		$work_one = $sut->queue_work( [ 'a', 'b', 'c', 'd' ], [ __CLASS__, 'callback_one' ] )->set_priority( 5 )->save();
+		$work_two = $sut->queue_work( [ 'a', 'b', 'c', 'e' ], [ __CLASS__, 'callback_one' ] )->set_priority( 1 )->save();
+		$work_three = $sut->queue_work( [ 'a', 'b', 'c', 'f' ], [ __CLASS__, 'callback_one' ] )->set_priority( 10 )->save();
 
-		$expected = [ $work_three => Worker::QUEUED, $work_one => Worker::QUEUED, $work_two => Worker::QUEUED ];
-		$this->assertEquals( $expected, $sut->get_work_list() );
+		$expected = [ $work_two => Worker::QUEUED, $work_one => Worker::QUEUED, $work_three => Worker::QUEUED ];
+		$list = $sut->get_work_list();
+		$this->assertSame( $expected, $list );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/70889

This PR adds a `Tribe_Queue` class to put in place a queueing system we can reuse:

- it's made to try to run anytime it can from `admin_head` to `wp_ajax_` events
- it will run on the `tribe_queue_work` action
- said action is scheduled each 30"

The use boils down to this:

```php
// file My_Object.php

class My_Object() {
    public function set_post_title( $id, $index, $data ){
        $title = $data[$index];

        $updated = wp_update_post( array( 'ID' => $id, 'post_title' => $title ) );

        return !empty( $updated );
    }
}

// elsewhere in code
tribe_singleton('my_object', 'My_Object');
$queue = tribe( 'queue' );

$targets = array( 2, 3, 4, 5, 6 );

// to avoid using (untestable) static methods (due to cron) the q will use the container to build stuff
// in plain English: "build `my_object` and call `set_post_title` on each target"
$callback = array( 'tribe', 'my_object', 'set_post_title');

// this can be anything
$data = array( 'foo', 'baz', 'bar', 'foo', 'baz' );

$queue->queue_work( $targets, $callback, $data)
    ->set_batch_size(3) // on how many targets per run?
    ->set_priority( 5 ) // same as WP priority system, lowest is first
    ->save(); // actually commit to queue this
```

If the callback function returns anyting "truthy" then the queue will deem the work on the single target done else it will move the target at the end of  the queue and try again later.