### PR TITLE
When fetching from post transients, if no data set, return false

### DIFF
--- a/src/Tribe/Post_Transient.php
+++ b/src/Tribe/Post_Transient.php
@@ -122,7 +122,16 @@ class Tribe__Post_Transient {
 			} else {
 				$meta_timeout = '_transient_timeout_' . $transient;
 				$meta = '_transient_' . $transient;
-				$value = get_post_meta( $post_id, $meta, true );
+				$value = get_post_meta( $post_id, $meta, false );
+
+				// if there aren't any values, communicate that it did not fetch data from post transient
+				if ( 0 === count( $value ) ) {
+					return false;
+				}
+
+				// grab the first value, because that's all we care about
+				$value = current( $value );
+
 				if ( $value && ! defined( 'WP_INSTALLING' ) ) {
 					if ( get_post_meta( $post_id, $meta_timeout, true ) < time() ) {
 						$this->delete( $post_id, $transient );


### PR DESCRIPTION
In order to properly react to the state of post transients and deciding whether or not to perform logic, we need to know if there were values found in get_post_meta for the transient. If nothing was found, we should return `false` to match the state when the transient has expired.

Related: https://github.com/moderntribe/event-tickets/pull/340

See: https://central.tri.be/issues/70485