### PR TITLE
refine options of server mocker

### DIFF
--- a/tests/_support/ea-server-mocker/ea-service-mocker.php
+++ b/tests/_support/ea-server-mocker/ea-service-mocker.php
@@ -84,6 +84,8 @@ class Tribe__Events__Aggregator_Mocker {
 	protected function hook() {
 		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Options_Page(), 'hook' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Cleaner(), 'hook' ) );
+		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Cleaner_Options(), 'hook' ) );
 
 		if ( $this->is_disabled() ) {
 			return;
@@ -91,8 +93,6 @@ class Tribe__Events__Aggregator_Mocker {
 
 		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Service_Options(), 'hook' ) );
 		add_action( 'admin_notices', array( new Tribe__Events__Aggregator_Mocker__Notices(), 'render' ) );
-		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Cleaner(), 'hook' ) );
-		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Cleaner_Options(), 'hook' ) );
 		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__License_Options(), 'hook' ) );
 		add_action( 'init', array( new Tribe__Events__Aggregator_Mocker__Recorder_Options(), 'hook' ) );
 	}

--- a/tests/_support/ea-server-mocker/src/Service_Options.php
+++ b/tests/_support/ea-server-mocker/src/Service_Options.php
@@ -330,20 +330,6 @@ class Tribe__Events__Aggregator_Mocker__Service_Options implements Tribe__Events
         ?>
         <?php if (!$recorder_enabled) : ?>
         <tr valign="top">
-            <th scope="row">Mock the server domain</th>
-            <td>
-                <label for="ea_mocker-import_id">
-                    Enter the full URL of the server that should be hit by requests; this includes the HTTP scheme; e.g.
-                    <code>https://ea.dev</code>. Leave it blank to avoid mocking.
-                    <div class="inline">
-                        <input type="text" value="<?php echo get_option('ea_mocker-service_domain') ?>"
-                               name="ea_mocker-service_domain"
-                               id="ea_mocker-service_domain">
-                    </div>
-                </label>
-            </td>
-        </tr>
-        <tr valign="top">
             <th scope="row">Import ID generator</th>
             <td>
                 <label for="ea_mocker-import_id">


### PR DESCRIPTION
This PR:

* makes the cleaner options available even if server mocking is disabled
* removes the setting to soft-set the ea server domain to avoid confusion with the `wp-config.php` set one