### PR TITLE
Adds safety check before calling EA methods from tribe-common

### DIFF
--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -208,7 +208,7 @@ class Tribe__Admin__Help_Page {
 			'title' => esc_html__( 'Event Aggregator', 'tribe-common' ),
 			'link'  => 'http://m.tri.be/19mk',
 			'plugin' => array( 'the-events-calendar' ),
-			'is_active' => tribe( 'events-aggregator.main' )->is_service_active(),
+			'is_active' => class_exists( 'Tribe__Events__Aggregator' ) && tribe( 'events-aggregator.main' )->is_service_active(),
 		);
 
 		$addons['events-filter-bar'] = array(


### PR DESCRIPTION
Great find by @niconerd: we were doing `tribe( 'events-aggregator.main' )->is_service_active()` from within tribe-common without knowing that `Tribe__Events__Aggregator` was defined (such as if ET is running without TEC), which could result in fatal errors.
