### PR TITLE
Use constant() because older versions of PHP no likey $class_name::CONSTANT

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -770,8 +770,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				if ( $class_name ) {
 					$class_name .= 'PUE__Helper';
 
-					if ( ! empty( $class_name::DATA ) ) {
-						$license_key = $class_name::DATA;
+					if ( constant( $class_name . '::DATA' ) ) {
+						$license_key = constant( $class_name . '::DATA' );
 
 						$license_origin = 'e';
 					}


### PR DESCRIPTION
Fixes PHP fatals