### PR TITLE
Added check if the log file is writable

### DIFF
--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -64,7 +64,12 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 			touch( $this->log_file );
 		}
 
-		if ( is_readable( $this->log_file ) && is_writable( $this->log_file ) ) {
+		// Bail if we're attempting to write but don't have permission.
+		if ( 'r' !== $this->context && ! is_writable( $this->log_file ) ) {
+			return;
+		}
+
+		if ( is_readable( $this->log_file ) ) {
 			$this->handle = fopen( $this->log_file, $this->context );
 		}
 	}

--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -64,7 +64,7 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 			touch( $this->log_file );
 		}
 
-		if ( is_readable( $this->log_file ) ) {
+		if ( is_readable( $this->log_file ) && is_writable( $this->log_file ) ) {
 			$this->handle = fopen( $this->log_file, $this->context );
 		}
 	}


### PR DESCRIPTION
Per [this forum topic](https://theeventscalendar.com/support/forums/topic/error-when-activating-events-calendar-pro/page/2/#post-1231901) let's check if the log file is writable as well as readable. In some server configs this will prevent errors.