### PR TITLE
Add the Meta Chunker class

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -84,16 +84,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "b9dd9ba89279c89134be1d7a0c62a63f78d7e622"
+                "reference": "5e4530a4e795172263648080880f65efa05c77d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b9dd9ba89279c89134be1d7a0c62a63f78d7e622",
-                "reference": "b9dd9ba89279c89134be1d7a0c62a63f78d7e622",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/5e4530a4e795172263648080880f65efa05c77d6",
+                "reference": "5e4530a4e795172263648080880f65efa05c77d6",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,7 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2017-03-23T11:32:30+00:00"
+            "time": "2017-05-03T19:01:28+00:00"
         },
         {
             "name": "bacon/bacon-string-utils",
@@ -747,16 +747,16 @@
         },
         {
             "name": "facebook/webdriver",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "3ea034c056189e11c0ce7985332a9f4b5b2b5db2"
+                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/3ea034c056189e11c0ce7985332a9f4b5b2b5db2",
-                "reference": "3ea034c056189e11c0ce7985332a9f4b5b2b5db2",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/eadb0b7a7c3e6578185197fd40158b08c3164c83",
+                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83",
                 "shasum": ""
             },
             "require": {
@@ -795,7 +795,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2017-03-22T10:56:03+00:00"
+            "time": "2017-04-28T14:54:49+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1021,7 +1021,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v5.4.17",
+            "version": "v5.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1063,16 +1063,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v5.4.17",
+            "version": "v5.4.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "c7e7c9daf5044e76b46085b8351f8235a3e979c6"
+                "reference": "b8cb37e15331c59da51c8ee5838038baa22d7955"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/c7e7c9daf5044e76b46085b8351f8235a3e979c6",
-                "reference": "c7e7c9daf5044e76b46085b8351f8235a3e979c6",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/b8cb37e15331c59da51c8ee5838038baa22d7955",
+                "reference": "b8cb37e15331c59da51c8ee5838038baa22d7955",
                 "shasum": ""
             },
             "require": {
@@ -1116,7 +1116,7 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "time": "2017-03-28T12:49:45+00:00"
+            "time": "2017-04-09T14:34:57+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1229,16 +1229,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "1.19.13",
+            "version": "1.19.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "c3de23854d53d52d3bed9f320d4dd5a223bbbf93"
+                "reference": "43f25ae61283633c43e714ceb44658a3da830b88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/c3de23854d53d52d3bed9f320d4dd5a223bbbf93",
-                "reference": "c3de23854d53d52d3bed9f320d4dd5a223bbbf93",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/43f25ae61283633c43e714ceb44658a3da830b88",
+                "reference": "43f25ae61283633c43e714ceb44658a3da830b88",
                 "shasum": ""
             },
             "require": {
@@ -1285,7 +1285,7 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2017-03-25T08:30:07+00:00"
+            "time": "2017-05-01T21:12:44+00:00"
         },
         {
             "name": "lucatume/wp-browser-commons",
@@ -1484,16 +1484,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
                 "shasum": ""
             },
             "require": {
@@ -1522,7 +1522,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2017-04-12T18:52:22+00:00"
         },
         {
             "name": "nb/oxymel",
@@ -3104,16 +3104,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.2.7",
+            "version": "v3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "2fe0caa60c1a1dfeefd0425741182687a9b382b8"
+                "reference": "9fab1ab6f77b77f3df5fc5250fc6956811699b57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/2fe0caa60c1a1dfeefd0425741182687a9b382b8",
-                "reference": "2fe0caa60c1a1dfeefd0425741182687a9b382b8",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/9fab1ab6f77b77f3df5fc5250fc6956811699b57",
+                "reference": "9fab1ab6f77b77f3df5fc5250fc6956811699b57",
                 "shasum": ""
             },
             "require": {
@@ -3157,20 +3157,20 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T09:12:04+00:00"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "35b7dfa089d7605eb1fdd46281b3070fb9f38750"
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/35b7dfa089d7605eb1fdd46281b3070fb9f38750",
-                "reference": "35b7dfa089d7605eb1fdd46281b3070fb9f38750",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0b8541d18507d10204a08384640ff6df3c739ebe",
+                "reference": "0b8541d18507d10204a08384640ff6df3c739ebe",
                 "shasum": ""
             },
             "require": {
@@ -3213,20 +3213,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-04T15:24:26+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "86407ff20855a5eaa2a7219bd815e9c40a88633e"
+                "reference": "2cfcbced8e39e2313ed4da8896fc8c59a56c0d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/86407ff20855a5eaa2a7219bd815e9c40a88633e",
-                "reference": "86407ff20855a5eaa2a7219bd815e9c40a88633e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2cfcbced8e39e2313ed4da8896fc8c59a56c0d7e",
+                "reference": "2cfcbced8e39e2313ed4da8896fc8c59a56c0d7e",
                 "shasum": ""
             },
             "require": {
@@ -3274,20 +3274,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-03T20:37:06+00:00"
+            "time": "2017-04-26T01:38:53+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.2.7",
+            "version": "v3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "a48f13dc83c168f1253a5d2a5a4fb46c36244c4c"
+                "reference": "02983c144038e697c959e6b06ef6666de759ccbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/a48f13dc83c168f1253a5d2a5a4fb46c36244c4c",
-                "reference": "a48f13dc83c168f1253a5d2a5a4fb46c36244c4c",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/02983c144038e697c959e6b06ef6666de759ccbc",
+                "reference": "02983c144038e697c959e6b06ef6666de759ccbc",
                 "shasum": ""
             },
             "require": {
@@ -3327,20 +3327,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T09:12:04+00:00"
+            "time": "2017-05-01T14:55:58+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc"
+                "reference": "344f50ce827413b3640bfcb1e37386a67d06ea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e90099a2958d4833a02d05b504cc06e1c234abcc",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/344f50ce827413b3640bfcb1e37386a67d06ea1f",
+                "reference": "344f50ce827413b3640bfcb1e37386a67d06ea1f",
                 "shasum": ""
             },
             "require": {
@@ -3384,20 +3384,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18T19:13:35+00:00"
+            "time": "2017-04-19T19:56:30+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "14b9d8ae69ac4c74e8f05fee7e0a57039b99c81e"
+                "reference": "e1c722dfe4dd04453aeb6b7a6deefb400c878394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/14b9d8ae69ac4c74e8f05fee7e0a57039b99c81e",
-                "reference": "14b9d8ae69ac4c74e8f05fee7e0a57039b99c81e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e1c722dfe4dd04453aeb6b7a6deefb400c878394",
+                "reference": "e1c722dfe4dd04453aeb6b7a6deefb400c878394",
                 "shasum": ""
             },
             "require": {
@@ -3447,20 +3447,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-03T22:14:48+00:00"
+            "time": "2017-04-26T01:38:53+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.2.7",
+            "version": "v3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "403944e294cf4ceb3b8447f54cbad88ea7b99cee"
+                "reference": "f1ad34e8af09ed17570e027cf0c58a12eddec286"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/403944e294cf4ceb3b8447f54cbad88ea7b99cee",
-                "reference": "403944e294cf4ceb3b8447f54cbad88ea7b99cee",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/f1ad34e8af09ed17570e027cf0c58a12eddec286",
+                "reference": "f1ad34e8af09ed17570e027cf0c58a12eddec286",
                 "shasum": ""
             },
             "require": {
@@ -3503,20 +3503,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21T09:12:04+00:00"
+            "time": "2017-04-12T14:13:17+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "88b65f0ac25355090e524aba4ceb066025df8bd2"
+                "reference": "7fc8e2b4118ff316550596357325dfd92a51f531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/88b65f0ac25355090e524aba4ceb066025df8bd2",
-                "reference": "88b65f0ac25355090e524aba4ceb066025df8bd2",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7fc8e2b4118ff316550596357325dfd92a51f531",
+                "reference": "7fc8e2b4118ff316550596357325dfd92a51f531",
                 "shasum": ""
             },
             "require": {
@@ -3563,20 +3563,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-03T20:37:06+00:00"
+            "time": "2017-04-26T16:56:54+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "31ab6827a696244094e6e20d77e7d404f8eb4252"
+                "reference": "dc40154e26a0116995e4f2f0c71cb9c2fe0775a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/31ab6827a696244094e6e20d77e7d404f8eb4252",
-                "reference": "31ab6827a696244094e6e20d77e7d404f8eb4252",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/dc40154e26a0116995e4f2f0c71cb9c2fe0775a3",
+                "reference": "dc40154e26a0116995e4f2f0c71cb9c2fe0775a3",
                 "shasum": ""
             },
             "require": {
@@ -3612,20 +3612,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-26T15:40:40+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "7131327eb95d86d72039fd1216226c28f36fd02a"
+                "reference": "16d55394b31547e4a8494551b85c9b9915545347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/7131327eb95d86d72039fd1216226c28f36fd02a",
-                "reference": "7131327eb95d86d72039fd1216226c28f36fd02a",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/16d55394b31547e4a8494551b85c9b9915545347",
+                "reference": "16d55394b31547e4a8494551b85c9b9915545347",
                 "shasum": ""
             },
             "require": {
@@ -3661,7 +3661,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-20T08:46:40+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -3724,16 +3724,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "41336b20b52f5fd5b42a227e394e673c8071118f"
+                "reference": "aff35fb3dee799c84a7313c576b72208b046ef8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/41336b20b52f5fd5b42a227e394e673c8071118f",
-                "reference": "41336b20b52f5fd5b42a227e394e673c8071118f",
+                "url": "https://api.github.com/repos/symfony/process/zipball/aff35fb3dee799c84a7313c576b72208b046ef8d",
+                "reference": "aff35fb3dee799c84a7313c576b72208b046ef8d",
                 "shasum": ""
             },
             "require": {
@@ -3769,20 +3769,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04T12:20:59+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "047e97a64d609778cadfc76e3a09793696bb19f1"
+                "reference": "32b7c0bffc07772cf1a902e3464ef77117fa07c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/047e97a64d609778cadfc76e3a09793696bb19f1",
-                "reference": "047e97a64d609778cadfc76e3a09793696bb19f1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/32b7c0bffc07772cf1a902e3464ef77117fa07c7",
+                "reference": "32b7c0bffc07772cf1a902e3464ef77117fa07c7",
                 "shasum": ""
             },
             "require": {
@@ -3833,20 +3833,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-21T21:39:01+00:00"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.19",
+            "version": "v2.8.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "286d84891690b0e2515874717e49360d1c98a703"
+                "reference": "93ccdde79f4b079c7558da4656a3cb1c50c68e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/286d84891690b0e2515874717e49360d1c98a703",
-                "reference": "286d84891690b0e2515874717e49360d1c98a703",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/93ccdde79f4b079c7558da4656a3cb1c50c68e02",
+                "reference": "93ccdde79f4b079c7558da4656a3cb1c50c68e02",
                 "shasum": ""
             },
             "require": {
@@ -3882,7 +3882,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-20T09:41:44+00:00"
+            "time": "2017-05-01T14:31:55+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -491,5 +491,6 @@ class Tribe__Main {
 		tribe_singleton( 'settings', 'Tribe__Settings', array( 'hook' ) );
 		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Data', array( 'hook' ) );
 		tribe_singleton( 'tracker', 'Tribe__Tracker', array( 'hook' ) );
+		tribe_singleton( 'chunker', 'Tribe__Meta__Chunker', array( 'set_post_types', 'hook' ) );
 	}
 }

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -3,10 +3,10 @@
 /**
  * Class Tribe__Meta__Chunker
  *
- * Chunks large meta to avoid kiling the database in queries.
+ * Chunks large meta to avoid killing the database in queries.
  *
  * Databases can have a `max_allowed_packet` value set as low as 1M; we often need to store large blobs of data way
- * over that and doing so would kill hte database ("MySQL server has gone away"...); registering a meta to be chunked
+ * over that and doing so would kill the database ("MySQL server has gone away"...); registering a meta to be chunked
  * if needed avoids that.
  *
  * Example usage:

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -31,6 +31,7 @@
  *          return $post_types;
  *      }
  *
+ * or filter the `tribe_meta_chunker_post_types` filter.
  */
 class Tribe__Meta__Chunker {
 	/**

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -57,7 +57,7 @@ class Tribe__Meta__Chunker {
 	/**
 	 * @var string The meta key prefix applied ot any Chunker related post meta.
 	 */
-	protected $meta_key_prefix = "_tribe_chunker_";
+	protected $meta_key_prefix = '_tribe_chunker_';
 
 	/**
 	 * @var int The largest size allowed by the Chunker.
@@ -258,7 +258,7 @@ class Tribe__Meta__Chunker {
 		global $wpdb;
 		$criteria = array(
 			'post_id'  => $object_id,
-			'meta_key' => $this->get_chunk_meta_key( $meta_key )
+			'meta_key' => $this->get_chunk_meta_key( $meta_key ),
 		);
 		$wpdb->delete( $wpdb->postmeta, $criteria );
 	}
@@ -394,7 +394,7 @@ class Tribe__Meta__Chunker {
 		$chunk_meta_key = $this->get_chunk_meta_key( $meta_key );
 		$prepared_chunks = array();
 		foreach ( $chunks as $chunk ) {
-			$prepared_chunks[] = $wpdb->prepare( "(%d, %s, %s)", $object_id, $chunk_meta_key, $chunk );
+			$prepared_chunks[] = $wpdb->prepare( '(%d, %s, %s)', $object_id, $chunk_meta_key, $chunk );
 		}
 		$query = "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES ";
 		$query .= implode( ",\n", $prepared_chunks );
@@ -500,7 +500,7 @@ class Tribe__Meta__Chunker {
 	public function glue_chunks( array $chunks ) {
 		$ordered_chunks = array();
 		foreach ( $chunks as $chunk ) {
-			preg_match( "/(\\d+)" . preg_quote( $this->chunk_separator ) . "(.*)/", $chunk, $matches );
+			preg_match( '/(\\d+)' . preg_quote( $this->chunk_separator ) . '(.*)/', $chunk, $matches );
 			$ordered_chunks[ $matches[1] ] = $matches[2];
 		}
 		ksort( $ordered_chunks );

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -61,7 +61,7 @@ class Tribe__Meta__Chunker {
 	/**
 	 * @var int The largest size allowed by the Chunker.
 	 */
-	protected $max_chunk_size = 1048576;
+	protected $max_chunk_size;
 
 	/**
 	 * Hooks the chunker on metadata operations for each supported post types.
@@ -299,21 +299,18 @@ class Tribe__Meta__Chunker {
 	}
 
 	/**
-	 * Returns the max chunk size
+	 * Returns the max chunk size in bytes.
 	 *
 	 * @return array|int|null|object
 	 */
-	protected function get_max_chunk_size() {
+	public function get_max_chunk_size() {
 		if ( ! empty( $this->max_chunk_size ) ) {
 			return $this->max_chunk_size;
 		}
 		/** @var wpdb $wpdb */
 		global $wpdb;
-		$max_size = $wpdb->get_results( "SHOW VARIABLES LIKE 'max_allowed_packet';" );
-		if ( empty( $max_size ) ) {
-			// let's assume 1M
-			$max_size = 1048576;
-		}
+		$max_size = $wpdb->get_results( "SHOW VARIABLES LIKE 'max_allowed_packet';", ARRAY_A );
+		$max_size = ! empty( $max_size[0]['Value'] ) ? $max_size[0]['Value'] : 1048576;
 
 		/**
 		 * Filters the max size of the of the chunks in bytes.

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -65,7 +65,7 @@ class Tribe__Meta__Chunker {
 	 */
 	protected $max_chunk_size;
 
-	public function __construct(  ) {
+	public function __construct() {
 		$this->id = uniqid( rand( 1, 999 ) );
 	}
 

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -86,10 +86,10 @@ class Tribe__Meta__Chunker {
 
 		$this->prime_chunked_cache();
 
-		add_filter( "update_post_metadata", array( $this, 'filter_update_metadata' ), $this->filter_p, 4 );
-		add_filter( "delete_post_metadata", array( $this, 'filter_delete_metadata' ), $this->filter_p, 3 );
-		add_filter( "add_post_metadata", array( $this, 'filter_add_metadata' ), $this->filter_p, 4 );
-		add_filter( "get_post_metadata", array( $this, 'filter_get_metadata' ), $this->filter_p, 4 );
+		add_filter( 'update_post_metadata', array( $this, 'filter_update_metadata' ), $this->filter_p, 4 );
+		add_filter( 'delete_post_metadata', array( $this, 'filter_delete_metadata' ), $this->filter_p, 3 );
+		add_filter( 'add_post_metadata', array( $this, 'filter_add_metadata' ), $this->filter_p, 4 );
+		add_filter( 'get_post_metadata', array( $this, 'filter_get_metadata' ), $this->filter_p, 3 );
 	}
 
 	/**
@@ -282,7 +282,7 @@ class Tribe__Meta__Chunker {
 	 * @return bool
 	 */
 	protected function is_chunker_canary_key( $meta_key ) {
-		return 0 === strpos($meta_key, $this->meta_key_prefix) && !preg_match( '/_chunk$/', $meta_key );
+		return 0 === strpos( $meta_key, $this->meta_key_prefix ) && ! preg_match( '/_chunk$/', $meta_key );
 	}
 
 	/**
@@ -515,7 +515,7 @@ class Tribe__Meta__Chunker {
 	 *
 	 * @see get_metadata()
 	 */
-	public function filter_get_metadata( $check, $object_id, $meta_key, $single = true ) {
+	public function filter_get_metadata( $check, $object_id, $meta_key ) {
 		if ( ! $this->applies( $object_id, $meta_key ) ) {
 			return $check;
 		}
@@ -690,7 +690,7 @@ class Tribe__Meta__Chunker {
 		$data = array(
 			'post_id'    => $object_id,
 			'meta_key'   => $meta_key,
-			'meta_value' => $meta_value
+			'meta_value' => $meta_value,
 		);
 		$wpdb->insert( $wpdb->postmeta, $data );
 	}

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -1,0 +1,340 @@
+<?php
+
+
+class Tribe__Meta__Chunker {
+	protected $chunks_cache = array();
+	protected $chunk_separator = '{{{TCSEP}}}';
+	protected $post_types = array( 'post' );
+	protected $filter_p = - 1;
+	protected $meta_key_prefix = "_tribe_chunker_";
+	protected $max_chunk_size;
+
+	public function set_post_types( array $post_types = array() ) {
+		$this->post_types = apply_filters( 'tribe_meta_chunker_post_types', $post_types );
+	}
+
+	public function hook() {
+		if ( empty( $this->post_types ) ) {
+			return;
+		}
+
+		$this->prime_chunked_cache();
+
+		foreach ( $this->post_types as $post_type ) {
+			add_filter( "update_{$post_type}_metadata", array( $this, 'filter_update_metadata' ), $this->filter_p, 4 );
+			add_filter( "delete_{$post_type}_metadata", array( $this, 'filter_delete_metadata' ), $this->filter_p, 3 );
+			add_filter( "add_{$post_type}_metadata", array( $this, 'filter_add_metadata' ), $this->filter_p, 4 );
+			add_filter( "get_{$post_type}_metadata", array( $this, 'filter_get_metadata' ), $this->filter_p, 4 );
+		}
+	}
+
+	protected function prime_chunked_cache() {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+		$query = $wpdb->prepare( "SELECT post_id, meta_key FROM {$wpdb->postmeta}
+			WHERE meta_key LIKE %s
+			AND meta_key NOT LIKE %s",
+			$this->meta_key_prefix . '%', $this->meta_key_prefix . '%_chunk'
+		);
+		$results = $wpdb->get_results( $query );
+
+		$this->chunks_cache = array();
+		foreach ( $results as $result ) {
+			$real_meta_key = str_replace( $this->meta_key_prefix, '', $result->meta_key );
+			$this->chunks_cache[ $this->get_key( $result->post_id, $real_meta_key ) ] = null;
+		}
+	}
+
+	/**
+	 * @param $post_id
+	 * @param $meta_key
+	 * @return string
+	 */
+	protected function get_key( $post_id, $meta_key ) {
+		return "{$post_id}::{$meta_key}";
+	}
+
+	public function register_chunking_for( $post_id, $meta_key, $meta_value ) {
+		$post = get_post( $post_id );
+
+		if ( empty( $post ) || ! in_array( $post->post_type, $this->post_types ) ) {
+			return false;
+		}
+
+		$should_be_chunked = $this->should_be_chunked( $post_id, $meta_key, $meta_value );
+		if ( $should_be_chunked ) {
+			$this->tag_as_chunkable( $post_id, $meta_key );
+		}
+
+		return $should_be_chunked;
+	}
+
+	//$check = apply_filters( "update_{$meta_type}_metadata", null, $object_id, $meta_key, $meta_value, $prev_value );
+
+	/**
+	 * @param $post_id
+	 * @param $meta_key
+	 * @param $meta_value
+	 * @return bool
+	 */
+	public function should_be_chunked( $post_id, $meta_key, $meta_value ) {
+		$should_be_chunked = false;
+
+		$max_allowed_packet = $this->get_max_chunk_size();
+		$serialized = maybe_serialize( $meta_value );
+		$byte_size = $this->get_byte_size( $serialized );
+		if ( $byte_size > .8 * $max_allowed_packet ) {
+			$chunk_size = ceil( $max_allowed_packet * 0.75 );
+			$key = $this->get_key( $post_id, $meta_key );
+			$this->chunks_cache[ $key ] = $this->prefix_chunks( $this->chunk( $serialized, $chunk_size ) );
+			$should_be_chunked = true;
+		}
+
+		return $should_be_chunked;
+	}
+
+	protected function get_max_chunk_size() {
+		if ( ! empty( $this->max_chunk_size ) ) {
+			return $this->max_chunk_size;
+		}
+		/** @var wpdb $wpdb */
+		global $wpdb;
+		$max_allowed_packet = $wpdb->get_results( "SHOW VARIABLES LIKE 'max_allowed_packet';" );
+		if ( empty( $max_allowed_packet ) ) {
+			// let's assume 1M
+			$max_allowed_packet = 1048576;
+		}
+		$this->max_chunk_size = $max_allowed_packet;
+
+		return $max_allowed_packet;
+	}
+
+	public function set_max_chunk_size( $max_chunk_size ) {
+		$this->max_chunk_size = $max_chunk_size;
+	}
+
+//$check = apply_filters( "add_{$meta_type}_metadata", null, $object_id, $meta_key, $meta_value, $unique );
+
+	/**
+	 * @param $data
+	 * @return int
+	 */
+	public function get_byte_size( $data ) {
+		return strlen( utf8_decode( maybe_serialize( $data ) ) );
+	}
+
+	protected function prefix_chunks( array $chunks ) {
+		$count = count( $chunks );
+		$prefixed = array();
+		for ( $i = 0; $i < $count; $i ++ ) {
+			$prefixed[] = "{$i}{$this->chunk_separator}{$chunks[$i]}";
+		}
+
+		return $prefixed;
+	}
+
+	protected function chunk( $serialized, $chunk_size ) {
+		$sep = $this->chunk_separator;
+		$chunks = array_filter( explode( $sep, chunk_split( $serialized, $chunk_size, $sep ) ) );
+
+		return $chunks;
+	}
+
+	/**
+	 * @param $post_id
+	 * @param $meta_key
+	 */
+	public function tag_as_chunkable( $post_id, $meta_key ) {
+		update_post_meta( $post_id, $this->get_chunkable_meta_key( $meta_key ), true );
+	}
+
+	/**
+	 * @param $meta_key
+	 * @return string
+	 */
+	public function get_chunkable_meta_key( $meta_key ) {
+		return $this->meta_key_prefix . $meta_key;
+	}
+
+	public function filter_add_metadata( $check, $object_id, $meta_key, $meta_value ) {
+		return $this->filter_update_metadata( $check, $object_id, $meta_key, $meta_value );
+	}
+
+	public function filter_update_metadata( $check, $object_id, $meta_key, $meta_value ) {
+		if ( $this->is_chunker_logic_meta( $meta_key ) ) {
+			return $check;
+		}
+
+		remove_filter( current_filter(), array( $this, 'filter_update_metadata' ), $this->filter_p );
+
+		if ( $this->is_chunkable( $object_id, $meta_key ) && $this->should_be_chunked( $object_id, $meta_key, $meta_value )
+		) {
+			$this->tag_as_chunkable( $object_id, $meta_key );
+			$this->delete_chunks( $object_id, $meta_key );
+			$this->insert_chunks( $object_id, $meta_key );
+
+			return true;
+		}
+
+		add_filter( current_filter(), array( $this, 'filter_update_metadata' ), $this->filter_p, 4 );
+
+		return $check;
+	}
+
+	/**
+	 * @param $meta_key
+	 * @return bool
+	 */
+	public function is_chunker_logic_meta( $meta_key ) {
+		return 0 === strpos( $meta_key, $this->meta_key_prefix );
+	}
+
+	public function is_chunkable( $post_id, $meta_key ) {
+		$key = $this->get_key( $post_id, $meta_key );
+
+		return array_key_exists( $key, $this->chunks_cache );
+	}
+
+	/**
+	 * @param $object_id
+	 * @param $meta_key
+	 */
+	public function delete_chunks( $object_id, $meta_key ) {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+		$criteria = array(
+			'post_id'  => $object_id,
+			'meta_key' => $this->get_chunk_meta_key( $meta_key )
+		);
+		$wpdb->delete( $wpdb->postmeta, $criteria );
+	}
+
+	protected function get_chunk_meta_key( $meta_key ) {
+		return $this->get_chunkable_meta_key( $meta_key ) . '_chunk';
+	}
+
+	/**
+	 * @param $object_id
+	 * @param $meta_key
+	 */
+	public function insert_chunks( $object_id, $meta_key ) {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+
+		$chunks = $this->chunks_cache[ $this->get_key( $object_id, $meta_key ) ];
+		$chunks_count = count( $chunks );
+		$chunk_meta_key = $this->chunk_meta_key( $meta_key );
+		$prepared_chunks = array();
+		$prefixed_chunks = $this->prefix_chunks( $chunks );
+		foreach ( $prefixed_chunks as $chunk ) {
+			$prepared_chunks[] = $wpdb->prepare( "(%d, %s, %s)", $object_id, $chunk_meta_key, $chunk );
+		}
+		for ( $i = 0; $i < $chunks_count; $i ++ ) {
+			$this_chunk = $prepared_chunks[ $i ];
+		}
+		$query = "INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES ";
+		$query .= implode( ",\n", $prepared_chunks );
+		$wpdb->query( $query );
+	}
+
+	/**
+	 * @param $meta_key
+	 * @return string
+	 */
+	public function chunk_meta_key( $meta_key ) {
+		return $this->get_chunk_meta_key( $meta_key );
+	}
+
+	public function filter_delete_metadata( $check, $object_id, $meta_key ) {
+		if ( $this->is_chunker_logic_meta( $meta_key ) ) {
+			return $check;
+		}
+
+		$has_chunked_meta = $this->has_chunked_meta( $object_id, $meta_key );
+		if ( ! $has_chunked_meta ) {
+			return $check;
+		}
+		$this->cache_delete( $object_id, $meta_key );
+		$this->delete_chunks( $object_id, $meta_key );
+
+		return true;
+	}
+
+	/**
+	 * @param $object_id
+	 * @param $meta_key
+	 * @return mixed
+	 */
+	public function has_chunked_meta( $object_id, $meta_key ) {
+		return array_key_exists( $this->get_key( $object_id, $meta_key ), $this->chunks_cache );
+	}
+
+	protected function cache_delete( $object_id, $meta_key ) {
+		$key = $this->get_key( $object_id, $meta_key );
+		if ( isset( $this->chunks_cache[ $key ] ) ) {
+			unset( $this->chunks_cache[ $key ] );
+		}
+	}
+
+	public function filter_get_metadata( $check, $object_id, $meta_key, $single = true ) {
+		if ( $this->is_chunker_logic_meta( $meta_key ) ) {
+			return $check;
+		}
+
+		if ( $this->has_chunked_meta( $object_id, $meta_key ) ) {
+			$chunks = $this->get_chunks_for( $object_id, $meta_key );
+			$check = maybe_unserialize( $this->glue_chunks( $chunks ) );
+
+			return $single ? $check : array( $check );
+		}
+
+		return $check;
+	}
+
+	public function get_chunks_for( $object_id, $meta_key ) {
+		$key = $this->get_key( $object_id, $meta_key );
+
+		if ( ! empty( $this->chunks_cache[ $key ] ) ) {
+			return $this->chunks_cache[ $key ];
+		}
+
+		/** @var wpdb $wpdb */
+		global $wpdb;
+
+		$chunk_meta_key = $this->get_chunk_meta_key( $meta_key );
+
+		$meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM {$wpdb->postmeta}
+			WHERE post_id = %d
+			AND meta_key = %s",
+			$object_id, $chunk_meta_key
+		) );
+
+		$meta_values = array();
+		foreach ( $meta_ids as $meta_id ) {
+			$query = $wpdb->prepare( "SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_id = %d", $meta_id );
+			$meta_values[] = $wpdb->get_var( $query );
+		}
+
+		return $meta_values;
+	}
+
+	public function glue_chunks( array $chunks ) {
+		$ordered_chunks = array();
+		foreach ( $chunks as $chunk ) {
+			preg_match( "/(\\d+)" . preg_quote( $this->chunk_separator ) . "(.*)/", $chunk, $matches );
+			$ordered_chunks[ $matches[1] ] = $matches[2];
+		}
+		ksort( $ordered_chunks );
+
+		return implode( '', array_values( $ordered_chunks ) );
+	}
+
+	public function unhook() {
+		foreach ( $this->post_types as $post_type ) {
+			remove_filter( "update_{$post_type}_metadata", array( $this, 'filter_update_metadata' ), $this->filter_p );
+			remove_filter( "delete_{$post_type}_metadata", array( $this, 'filter_delete_metadata' ), $this->filter_p );
+			remove_filter( "add_{$post_type}_metadata", array( $this, 'filter_add_metadata' ), $this->filter_p );
+			remove_filter( "get_{$post_type}_metadata", array( $this, 'filter_get_metadata' ), $this->filter_p );
+		}
+	}
+}

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -573,6 +573,11 @@ class Tribe__Meta__Chunker {
 	 * @param array $post_types
 	 */
 	public function set_post_types( array $post_types = array() ) {
+		/**
+		 * Filters the chunk-able post types.
+		 *
+		 * @param array $post_types
+		 */
 		$this->post_types = apply_filters( 'tribe_meta_chunker_post_types', $post_types );
 	}
 }

--- a/tests/wpunit/Tribe/Meta/ChunkerTest.php
+++ b/tests/wpunit/Tribe/Meta/ChunkerTest.php
@@ -354,4 +354,14 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
 		$this->assertFalse( $sut->is_chunked( $id, $meta_key ) );
 	}
+
+	/**
+	 * It should allow getting the max chunk size from the db max_allowed_packet
+	 *
+	 * @test
+	 */
+	public function it_should_allow_getting_the_max_chunk_size_from_the_db_max_allowed_packet() {
+		$sut = $this->make_instance();
+		$this->assertTrue( is_numeric( $sut->get_max_chunk_size() ) );
+	}
 }

--- a/tests/wpunit/Tribe/Meta/ChunkerTest.php
+++ b/tests/wpunit/Tribe/Meta/ChunkerTest.php
@@ -44,37 +44,20 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should mark as chunkable when meta is over max size
+	 * It should allow marking meta as chunkable
 	 *
 	 * @test
 	 */
-	public function it_should_mark_as_chunkable_when_meta_is_over_max_size() {
+	public function it_should_allow_marking_meta_as_chunkable() {
 		$id = $this->factory()->post->create();
 		$meta_key = 'foo';
 		$meta_value = str_repeat( 'foo', 20 );
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
-	}
-
-	/**
-	 * It should not mark as chunkable when data is not over max size
-	 *
-	 * @test
-	 */
-	public function it_should_not_mark_as_chunkable_when_data_is_not_over_max_size() {
-		$id = $this->factory()->post->create();
-		$meta_key = 'foo';
-		$meta_value = str_repeat( 'foo', 20 );
-
-		$sut = $this->make_instance();
-		$sut->set_max_chunk_size( 2 * $sut->get_byte_size( $meta_value ) );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
-
-		$this->assertFalse( $sut->is_chunkable( $id, $meta_key ) );
 	}
 
 	/**
@@ -89,7 +72,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		$this->assertTrue( (bool) get_post_meta( $id, $sut->get_chunkable_meta_key( $meta_key ), true ) );
 	}
@@ -107,9 +90,10 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) * 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
-		$this->assertFalse( (bool) get_post_meta( $id, $sut->get_chunkable_meta_key( $meta_key ), true ) );
+		$this->assertTrue( (bool) get_post_meta( $id, $sut->get_chunkable_meta_key( $meta_key ), true ) );
+		$this->assertFalse( (bool) get_post_meta( $id, $sut->get_chunkable_meta_key( 'bar' ), true ) );
 	}
 
 	/**
@@ -124,7 +108,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
@@ -150,7 +134,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value_1 ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value_1 );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value_1 );
 		add_post_meta( $id, $meta_key, $meta_value_2 );
@@ -174,7 +158,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
@@ -199,7 +183,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
@@ -236,11 +220,12 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) * 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
-		$this->assertFalse( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertFalse( $sut->is_chunked( $id, $meta_key ) );
 	}
 
 	/**
@@ -256,7 +241,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 		$this->post_types = [ 'page' ]; // not posts
 		$sut = $this->make_instance();
 		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) * 2 );
-		$sut->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
@@ -275,7 +260,7 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 
 		$sut_1 = $this->make_instance();
 		$sut_1->set_max_chunk_size( $sut_1->get_byte_size( $meta_value ) / 2 );
-		$sut_1->register_chunking_for( $id, $meta_key, $meta_value );
+		$sut_1->register_chunking_for( $id, $meta_key );
 
 		add_post_meta( $id, $meta_key, $meta_value );
 
@@ -289,5 +274,84 @@ class ChunkerTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertCount( 3, $sut_2->get_chunks_for( $id, $meta_key ) );
 	}
 
+	/**
+	 * It should reflect latest content of meta after updates
+	 *
+	 * @test
+	 */
+	public function it_should_reflect_latest_content_of_meta_after_updates() {
+		$id = $this->factory()->post->create();
+		$meta_key = 'foo';
+		$meta_value = str_repeat( 'foo', 20 );
 
+		$sut = $this->make_instance();
+		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
+		$sut->register_chunking_for( $id, $meta_key );
+
+		update_post_meta( $id, $meta_key, $meta_value );
+
+		$this->assertEquals( $meta_value, get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertTrue( $sut->is_chunked( $id, $meta_key ) );
+
+		update_post_meta( $id, $meta_key, 'just this' );
+
+		$this->assertEquals( 'just this', get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertFalse( $sut->is_chunked( $id, $meta_key ) );
+	}
+
+	/**
+	 * It should reflect latest state of meta after additions
+	 *
+	 * @test
+	 */
+	public function it_should_reflect_latest_state_of_meta_after_additions() {
+		$id = $this->factory()->post->create();
+		$meta_key = 'foo';
+		$meta_value = str_repeat( 'foo', 20 );
+
+		$sut = $this->make_instance();
+		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
+		$sut->register_chunking_for( $id, $meta_key );
+
+		add_post_meta( $id, $meta_key, $meta_value );
+
+		$this->assertEquals( $meta_value, get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertTrue( $sut->is_chunked( $id, $meta_key ) );
+
+		add_post_meta( $id, $meta_key, 'just this' );
+
+		$this->assertEquals( 'just this', get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertFalse( $sut->is_chunked( $id, $meta_key ) );
+	}
+
+	/**
+	 * It should reflect latest value after meta deletion
+	 *
+	 * @test
+	 */
+	public function it_should_reflect_latest_value_after_meta_deletion() {
+		$id = $this->factory()->post->create();
+		$meta_key = 'foo';
+		$meta_value = str_repeat( 'foo', 20 );
+
+		$sut = $this->make_instance();
+		$sut->set_max_chunk_size( $sut->get_byte_size( $meta_value ) / 2 );
+		$sut->register_chunking_for( $id, $meta_key );
+
+		add_post_meta( $id, $meta_key, $meta_value );
+
+		$this->assertEquals( $meta_value, get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertTrue( $sut->is_chunked( $id, $meta_key ) );
+
+		delete_post_meta( $id, $meta_key );
+
+		$this->assertEmpty(  get_post_meta( $id, $meta_key, true ) );
+		$this->assertTrue( $sut->is_chunkable( $id, $meta_key ) );
+		$this->assertFalse( $sut->is_chunked( $id, $meta_key ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/77988

This PR adds the `Tribe__Meta__Chunker` class to allow us to transparently register potentially big and DB killing meta values to avoid killing the DB itself.
Only caveat: no more than one chunked instance for each meta value;  as if any call is an update one.