### PR TITLE
#35822 - Enable slugs instead of ids for post tags

### DIFF
--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -60,15 +60,15 @@ class Tribe__Ajax__Dropdown {
 		} else {
 			foreach ( $terms as $term ) {
 				// Prep for Select2
-				$term->id = $term->term_id;
-				$term->text = $term->name;
+				$term->id          = 'post_tag' === $term->taxonomy ? $term->slug : $term->term_id;
+				$term->text        = $term->name;
 				$term->breadcrumbs = array();
 
 				if ( 0 !== (int) $term->parent ) {
 					$ancestors = get_ancestors( $term->id, $term->taxonomy );
 					$ancestors = array_reverse( $ancestors );
 					foreach ( $ancestors as $ancestor ) {
-						$ancestor = get_term( $ancestor );
+						$ancestor            = get_term( $ancestor );
 						$term->breadcrumbs[] = $ancestor->name;
 					}
 				}
@@ -98,7 +98,7 @@ class Tribe__Ajax__Dropdown {
 		foreach ( $terms as $i => $term ) {
 			if ( $term->parent === $parent ) {
 				// Prep for Select2
-				$term->id = $term->term_id;
+				$term->id   = 'post_tag' === $term->taxonomy ? $term->slug : $term->term_id;
 				$term->text = $term->name;
 
 				$into[ $term->term_id ] = $term;


### PR DESCRIPTION
_Ref:_ [C#35822](https://central.tri.be/issues/35822)

Post tags were saving as the selected id  and create a new tag each time with that id as the tag name.

https://central.tri.be/issues/35822#note-32

wp_update_post  uses the slug to save and not the id like event categories. 

This PR along with this one:

https://github.com/moderntribe/events-community/pull/230

Changes that. 