### PR TITLE
remove leading slash from REST namespace

### DIFF
--- a/src/Tribe/REST/Main.php
+++ b/src/Tribe/REST/Main.php
@@ -15,7 +15,7 @@ abstract class Tribe__REST__Main {
 	 *
 	 * @var string
 	 */
-	protected $namespace = '/tribe';
+	protected $namespace = 'tribe';
 
 	/**
 	 * Returns the namespace of Modern Tribe REST APIs.


### PR DESCRIPTION
to avoid 404s when hitting the API root