### PR TITLE
Add ArrayAccess support to the Tribe_Cache class

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -492,5 +492,6 @@ class Tribe__Main {
 		tribe_singleton( 'tribe.asset.data', 'Tribe__Asset__Data', array( 'hook' ) );
 		tribe_singleton( 'tracker', 'Tribe__Tracker', array( 'hook' ) );
 		tribe_singleton( 'chunker', 'Tribe__Meta__Chunker', array( 'set_post_types', 'hook' ) );
+		tribe_singleton( 'cache', 'Tribe__Cache' );
 	}
 }

--- a/tests/wpunit/Tribe/CacheTest.php
+++ b/tests/wpunit/Tribe/CacheTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tribe;
+
+use Tribe__Cache as Cache;
+
+class CacheTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * It should be instantiatable
+	 *
+	 * @test
+	 */
+	public function be_instantiatable() {
+		$this->assertInstanceOf( Cache::class, $this->make_instance() );
+	}
+
+	/**
+	 * @return Cache
+	 */
+	protected function make_instance() {
+		return new Cache();
+	}
+
+	/**
+	 * It should allow storing value using ArrayAccess API
+	 *
+	 * @test
+	 */
+	public function it_should_allow_storing_value_using_array_access_api() {
+		$cache = $this->make_instance();
+
+		$this->assertFalse( isset( $cache['foo'] ) );
+
+		$cache['foo'] = 'bar';
+
+		$this->assertTrue( isset( $cache['foo'] ) );
+		$this->assertEquals( 'bar', $cache['foo'] );
+	}
+
+	/**
+	 * It should correctly fabricate keys
+	 *
+	 * @test
+	 */
+	public function it_should_correctly_fabricate_keys() {
+		$components_1 = [ __FILE__, [ 23, 89 ], [ 'foo' => 'bar', 'bar' => 'baz' ] ];
+		$components_2 = [ __FILE__, [ 23, 89 ], [ 'bar' => 'baz', 'foo' => 'bar' ] ];
+
+		$cache = $this->make_instance();
+
+		$this->assertEquals( $cache->make_key( $components_1 ), $cache->make_key( $components_2 ) );
+		$this->assertEquals( $cache->make_key( $components_1, 'pre' ), $cache->make_key( $components_2, 'pre' ) );
+		$this->assertNotEquals( $cache->make_key( $components_1, 'foo' ), $cache->make_key( $components_2, 'pre' ) );
+		$this->assertNotEquals( $cache->make_key( $components_1, '', false ), $cache->make_key( $components_2, '', false ) );
+	}
+
+	/**
+	 * It should correctly handle long keys
+	 *
+	 * @test
+	 */
+	public function it_should_correctly_handle_long_keys() {
+		$components = [ __FILE__, [ 23, 89 ], [ 'foo' => 'bar', 'bar' => 'baz' ] ];
+
+		$cache = $this->make_instance();
+
+		$long_prefix = 'some very long prefix that should trigger some kind of minification on the key creation or so I hope';
+		$key = $cache->make_key( $components, $long_prefix );
+		$cache[ $key ] = 'bar';
+
+		$this->assertTrue( isset( $cache[ $key ] ) );
+		$this->assertEquals('bar',$cache[$key]);
+	}
+}

--- a/tests/wpunit/Tribe/CacheTest.php
+++ b/tests/wpunit/Tribe/CacheTest.php
@@ -71,4 +71,21 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertTrue( isset( $cache[ $key ] ) );
 		$this->assertEquals('bar',$cache[$key]);
 	}
+
+	/**
+	 * It should correctly generate key for numeric array components
+	 *
+	 * @test
+	 */
+	public function it_should_correctly_generate_key_for_numeric_array_components() {
+		$components_1 = [ __FILE__, [ 23, 89 ], [ 1 => 'bar', 23 => 'baz', 89 => 'bar' ] ];
+		$components_2 = [ __FILE__, [ 23, 89 ], [ 89 => 'bar', 23 => 'baz', 1 => 'bar' ] ];
+
+		$cache = $this->make_instance();
+
+		$this->assertEquals( $cache->make_key( $components_1 ), $cache->make_key( $components_2 ) );
+		$this->assertEquals( $cache->make_key( $components_1, 'pre' ), $cache->make_key( $components_2, 'pre' ) );
+		$this->assertNotEquals( $cache->make_key( $components_1, 'foo' ), $cache->make_key( $components_2, 'pre' ) );
+		$this->assertNotEquals( $cache->make_key( $components_1, '', false ), $cache->make_key( $components_2, '', false ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67581

This PR modifies the `Tribe__Cache` class implementation adding support for an `ArrayAccess` API and array cache like behaviour.
It also fixes the non persistent caching behaviour: it  would always return the cache as non-existent.

I'm PRing to `master` but am open to suggestion about the correct branch to use.