### PR TITLE
#45569 | Add proposed tribe_events_set_notice filter

### DIFF
--- a/src/Tribe/Notices.php
+++ b/src/Tribe/Notices.php
@@ -16,6 +16,17 @@ class Tribe__Notices {
 	 * @return bool
 	 */
 	public static function set_notice( $key, $notice ) {
+
+		/**
+		 * Make notices filterable.
+		 *
+		 * @param string $notice The notice text.
+		 * @param string $key The key of the notice being filtered.
+		 *
+		 * @return string.
+		 */
+		$notice = apply_filters( 'tribe_events_set_notice', $notice, $key );
+
 		self::instance()->notices[ $key ] = $notice;
 
 		return true;

--- a/src/Tribe/Notices.php
+++ b/src/Tribe/Notices.php
@@ -18,7 +18,9 @@ class Tribe__Notices {
 	public static function set_notice( $key, $notice ) {
 
 		/**
-		 * Make notices filterable.
+		 * Provides an opportunity to alter the text of admin notices.
+		 *
+		 * @since 4.5.5
 		 *
 		 * @param string $notice The notice text.
 		 * @param string $key The key of the notice being filtered.


### PR DESCRIPTION
_Ref:_ [C#45569](http://central.tri.be/issues/45569)

Lets you more easily customize the inner text of `Tribe__Notice` notices — current filters and methods require customizing much of the wrapping HTML in addition to that text.

An example of how you could use this filter is as follows:

```
add_filter( 'tribe_events_set_notice', 'tribe_45569_example', 10, 2 );

function tribe_45569_example( $notice, $key ) {

	if ( 'event-search-no-results' === $key ) {

                $example_url = 'something'; // Just an example here.

		$notice = sprintf( __( 'Oh no, nothing was found! <a href="%s">Back to the main events page</a>.', 'example' ), $example_url );
	}

	return $notice;
}
```