### PR TITLE
Add test and source classes to avoid image duplication

### DIFF
--- a/src/Tribe/Image/Uploader.php
+++ b/src/Tribe/Image/Uploader.php
@@ -1,0 +1,152 @@
+<?php
+
+
+class Tribe__Image__Uploader {
+	/**
+	 * @var bool|array
+	 */
+	protected static $original_urls_cache = false;
+	/**
+	 * @var bool|array
+	 */
+	protected static $attachment_guids_cache = false;
+	/**
+	 * @var string|int Either an absolute URL to an image file or a media attachment post ID.
+	 */
+	protected $featured_image;
+
+	/**
+	 * Tribe__Events__Importer__Featured_Image_Uploader constructor.
+	 *
+	 * @var array A single importing file row.
+	 */
+	public function __construct( $featured_image = null ) {
+
+		$this->featured_image = $featured_image;
+	}
+
+	/**
+	 * Resets the static "cache" of the class.
+	 */
+	public static function reset_cache() {
+		self::$attachment_guids_cache = false;
+		self::$original_urls_cache = false;
+	}
+
+	/**
+	 * Uploads a file and creates the media attachment or simply returns the attachment ID if existing.
+	 *
+	 * @return int|bool The attachment post ID if the uploading and attachment is successful or the ID refers to an attachment;
+	 *                  `false` otherwise.
+	 */
+	public function upload_and_get_attachment_id() {
+		if ( empty( $this->featured_image ) ) {
+			return false;
+		}
+
+		if ( is_string( $this->featured_image ) && ! is_numeric( $this->featured_image ) ) {
+			$existing = $this->get_attachment_ID_from_url( $this->featured_image );
+			$id = $existing ? $existing : $this->upload_file( $this->featured_image );
+		} elseif ( $post = get_post( $this->featured_image ) ) {
+			$id = $post && $post->post_type === 'attachment' ? $this->featured_image : false;
+		} else {
+			$id = false;
+		}
+
+		return $id;
+	}
+
+	/**
+	 * @param strin $file_url
+	 *
+	 * @return int
+	 */
+	protected function upload_file( $file_url ) {
+		if ( ! filter_var( $file_url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		$contents = @file_get_contents( $file_url );
+		if ( $contents === false ) {
+			return false;
+		}
+
+		$upload = wp_upload_bits( basename( $file_url ), null, $contents );
+
+		if ( isset( $upload['error'] ) && $upload['error'] ) {
+			return false;
+		}
+
+		$type = '';
+		if ( ! empty( $upload['type'] ) ) {
+			$type = $upload['type'];
+		} else {
+			$mime = wp_check_filetype( $upload['file'] );
+			if ( $mime ) {
+				$type = $mime['type'];
+			}
+		}
+
+		$attachment = array(
+			'post_title'     => basename( $upload['file'] ),
+			'post_content'   => '',
+			'post_type'      => 'attachment',
+			'post_mime_type' => $type,
+			'guid'           => $upload['url'],
+		);
+
+		$id = wp_insert_attachment( $attachment, $upload['file'] );
+		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
+		update_post_meta( $id, '_tribe_importer_original_url', $file_url );
+
+		$this->maybe_init_attachment_guids_cache();
+		$this->maybe_init_attachment_original_urls_cache();
+
+		self::$attachment_guids_cache[ get_post( $id )->guid ] = $id;
+		self::$original_urls_cache[ $file_url ] = $id;
+
+		return $id;
+	}
+
+	protected function get_attachment_ID_from_url( $featured_image ) {
+		$this->maybe_init_attachment_guids_cache();
+		$this->maybe_init_attachment_original_urls_cache();
+
+		$guids_cache = self::$attachment_guids_cache;
+		$original_urls_cache = self::$original_urls_cache;
+		if ( isset( $guids_cache[ $featured_image ] ) ) {
+			return $guids_cache[ $featured_image ];
+		} elseif ( isset( $original_urls_cache[ $featured_image ] ) ) {
+			return $original_urls_cache[ $featured_image ];
+		}
+
+		return false;
+	}
+
+	protected function maybe_init_attachment_guids_cache() {
+		if ( self::$attachment_guids_cache === false ) {
+			/** @var \wpdb $wpdb */
+			global $wpdb;
+			$guids = $wpdb->get_results( "SELECT ID, guid FROM $wpdb->posts where post_type = 'attachment'" );
+
+			self::$attachment_guids_cache = $guids ?
+				array_combine( wp_list_pluck( $guids, 'guid' ), wp_list_pluck( $guids, 'ID' ) )
+				: array();
+		}
+	}
+
+	protected function maybe_init_attachment_original_urls_cache() {
+		if ( self::$original_urls_cache === false ) {
+			/** @var \wpdb $wpdb */
+			global $wpdb;
+			$original_urls = $wpdb->get_results( "SELECT p.ID, pm.meta_value FROM $wpdb->posts p
+					JOIN $wpdb->postmeta pm
+					ON p.ID = pm.post_id
+					WHERE p.post_type = 'attachment' AND pm.meta_key = '_tribe_importer_original_url'" );
+
+			self::$original_urls_cache = $original_urls ?
+				array_combine( wp_list_pluck( $original_urls, 'meta_value' ), wp_list_pluck( $original_urls, 'ID' ) )
+				: array();
+		}
+	}
+}

--- a/src/Tribe/Image/Uploader.php
+++ b/src/Tribe/Image/Uploader.php
@@ -18,10 +18,9 @@ class Tribe__Image__Uploader {
 	/**
 	 * Tribe__Events__Importer__Featured_Image_Uploader constructor.
 	 *
-	 * @var array A single importing file row.
+	 * @var string A single importing file row.
 	 */
 	public function __construct( $featured_image = null ) {
-
 		$this->featured_image = $featured_image;
 	}
 
@@ -57,7 +56,7 @@ class Tribe__Image__Uploader {
 	}
 
 	/**
-	 * @param strin $file_url
+	 * @param string $file_url
 	 *
 	 * @return int
 	 */
@@ -143,10 +142,13 @@ class Tribe__Image__Uploader {
 		if ( false === self::$original_urls_cache ) {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
-			$original_urls = $wpdb->get_results( "SELECT p.ID, pm.meta_value FROM $wpdb->posts p
-					JOIN $wpdb->postmeta pm
-					ON p.ID = pm.post_id
-					WHERE p.post_type = 'attachment' AND pm.meta_key = '_tribe_importer_original_url'" );
+			$original_urls = $wpdb->get_results( "
+				SELECT p.ID, pm.meta_value FROM $wpdb->posts p
+				JOIN $wpdb->postmeta pm
+				ON p.ID = pm.post_id
+				WHERE p.post_type = 'attachment'
+				AND pm.meta_key = '_tribe_importer_original_url'
+			" );
 
 			if ( $original_urls ) {
 				$keys = wp_list_pluck( $original_urls, 'meta_value' );

--- a/src/Tribe/Image/Uploader.php
+++ b/src/Tribe/Image/Uploader.php
@@ -48,7 +48,7 @@ class Tribe__Image__Uploader {
 			$existing = $this->get_attachment_ID_from_url( $this->featured_image );
 			$id = $existing ? $existing : $this->upload_file( $this->featured_image );
 		} elseif ( $post = get_post( $this->featured_image ) ) {
-			$id = $post && $post->post_type === 'attachment' ? $this->featured_image : false;
+			$id = $post && 'attachment' === $post->post_type ? $this->featured_image : false;
 		} else {
 			$id = false;
 		}
@@ -67,7 +67,7 @@ class Tribe__Image__Uploader {
 		}
 
 		$contents = @file_get_contents( $file_url );
-		if ( $contents === false ) {
+		if ( false === $contents ) {
 			return false;
 		}
 
@@ -124,19 +124,23 @@ class Tribe__Image__Uploader {
 	}
 
 	protected function maybe_init_attachment_guids_cache() {
-		if ( self::$attachment_guids_cache === false ) {
+		if ( false === self::$attachment_guids_cache ) {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
 			$guids = $wpdb->get_results( "SELECT ID, guid FROM $wpdb->posts where post_type = 'attachment'" );
 
-			self::$attachment_guids_cache = $guids ?
-				array_combine( wp_list_pluck( $guids, 'guid' ), wp_list_pluck( $guids, 'ID' ) )
-				: array();
+			if ( $guids ) {
+				$keys = wp_list_pluck( $guids, 'guid' );
+				$values = wp_list_pluck( $guids, 'ID' );
+				self::$attachment_guids_cache = array_combine( $keys, $values );
+			} else {
+				self::$attachment_guids_cache = array();
+			}
 		}
 	}
 
 	protected function maybe_init_attachment_original_urls_cache() {
-		if ( self::$original_urls_cache === false ) {
+		if ( false === self::$original_urls_cache ) {
 			/** @var \wpdb $wpdb */
 			global $wpdb;
 			$original_urls = $wpdb->get_results( "SELECT p.ID, pm.meta_value FROM $wpdb->posts p
@@ -144,9 +148,13 @@ class Tribe__Image__Uploader {
 					ON p.ID = pm.post_id
 					WHERE p.post_type = 'attachment' AND pm.meta_key = '_tribe_importer_original_url'" );
 
-			self::$original_urls_cache = $original_urls ?
-				array_combine( wp_list_pluck( $original_urls, 'meta_value' ), wp_list_pluck( $original_urls, 'ID' ) )
-				: array();
+			if ( $original_urls ) {
+				$keys = wp_list_pluck( $original_urls, 'meta_value' );
+				$values = wp_list_pluck( $original_urls, 'ID' );
+				self::$original_urls_cache = array_combine( $keys, $values );
+			} else {
+				self::$original_urls_cache = array();
+			}
 		}
 	}
 }

--- a/tests/_support/Data.php
+++ b/tests/_support/Data.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Tribe\Tests;
+
+
+class Data implements \ArrayAccess {
+	/**
+	 * @var array The array that contains the data.
+	 */
+	protected $data;
+
+	/**
+	 * @var The default value returned when a value is not found in the data
+	 */
+	protected $default;
+
+	public function __construct( $data, $default = false ) {
+		$this->data = (array) $data;
+		$this->default = $default;
+	}
+
+	/**
+	 * Whether a offset exists
+	 *
+	 * @link  http://php.net/manual/en/arrayaccess.offsetexists.php
+	 * @param mixed $offset <p>
+	 *                      An offset to check for.
+	 *                      </p>
+	 * @return boolean true on success or false on failure.
+	 *                      </p>
+	 *                      <p>
+	 *                      The return value will be casted to boolean if non-boolean was returned.
+	 * @since 5.0.0
+	 */
+	public function offsetExists( $offset ) {
+		return isset( $this->data[ $offset ] );
+	}
+
+	/**
+	 * Offset to retrieve
+	 *
+	 * @link  http://php.net/manual/en/arrayaccess.offsetget.php
+	 * @param mixed $offset <p>
+	 *                      The offset to retrieve.
+	 *                      </p>
+	 * @return mixed Can return all value types.
+	 * @since 5.0.0
+	 */
+	public function offsetGet( $offset ) {
+		return isset( $this->data[ $offset ] )
+			? $this->data[ $offset ]
+			: $this->default;
+	}
+
+	/**
+	 * Offset to set
+	 *
+	 * @link  http://php.net/manual/en/arrayaccess.offsetset.php
+	 * @param mixed $offset <p>
+	 *                      The offset to assign the value to.
+	 *                      </p>
+	 * @param mixed $value  <p>
+	 *                      The value to set.
+	 *                      </p>
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetSet( $offset, $value ) {
+		$this->data[ $offset ] = $value;
+	}
+
+	/**
+	 * Offset to unset
+	 *
+	 * @link  http://php.net/manual/en/arrayaccess.offsetunset.php
+	 * @param mixed $offset <p>
+	 *                      The offset to unset.
+	 *                      </p>
+	 * @return void
+	 * @since 5.0.0
+	 */
+	public function offsetUnset( $offset ) {
+		unset( $this->data[ $offset ] );
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/78281

This PR:

* cherry picks the `Tribe__Image__Uploader` class from the `bucket/full-rest-api` branch (I've not cherry picked tests though, but they are in place)
* adds the `Tribe\Tests\Data` class to our test support classes to provide us with something that will avoid endless `isset` calls