### PR TITLE
Don't default to Meta Chunking post post_types

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,5 @@
 === Tribe Common ===
+
+= [4.5.6] TBD =
+
+* Fix - Resolved issue where the Meta Chunker attempted to inappropriately chunk meta for post post_types [80857]

--- a/src/Tribe/Meta/Chunker.php
+++ b/src/Tribe/Meta/Chunker.php
@@ -52,7 +52,7 @@ class Tribe__Meta__Chunker {
 	/**
 	 * @var array The post types supported by the Chunker.
 	 */
-	protected $post_types = array( 'post' );
+	protected $post_types = array();
 
 	/**
 	 * @var int The filter priority at which Chunker will operate on meta CRUD operations.


### PR DESCRIPTION
Instead, let's default to nothing.

See: https://central.tri.be/issues/80857