### PR TITLE
When testing if a file exists, ensure it's a local file on the filesystem

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,3 +3,4 @@
 = [4.5.6] TBD =
 
 * Fix - Resolved issue where the Meta Chunker attempted to inappropriately chunk meta for post post_types [80857]
+* Fix - Avoid notices during plugin update and installation checks [80492]

--- a/src/Tribe/PUE/Package_Handler.php
+++ b/src/Tribe/PUE/Package_Handler.php
@@ -70,9 +70,9 @@ class Tribe__PUE__Package_Handler {
 	 * @return bool
 	 */
 	protected function is_mt_package( $package ) {
-		if ( empty( $package )
-		     || ! preg_match( '!^(http|https|ftp)://!i', $package )
-		     || ( is_file( $package ) && file_exists( $package ) )
+		if (
+			empty( $package )
+			|| ! preg_match( '!^(http|https|ftp)://!i', $package )
 		) {
 			return false;
 		}

--- a/src/Tribe/PUE/Package_Handler.php
+++ b/src/Tribe/PUE/Package_Handler.php
@@ -72,7 +72,7 @@ class Tribe__PUE__Package_Handler {
 	protected function is_mt_package( $package ) {
 		if ( empty( $package )
 		     || ! preg_match( '!^(http|https|ftp)://!i', $package )
-		     || file_exists( $package )
+		     || ( is_file( $package ) && file_exists( $package ) )
 		) {
 			return false;
 		}


### PR DESCRIPTION
Avoids a potential notice level error where the HTTP(S)/FTP stream wrapper isn't available by simplifying a check.

If `$package` is empty, or is not a remote URL, returns false. Seems there's need to do a further confirmation check by testing if the file exists (which tries to use stream wrappers when available).

:ticket: [#80492](https://central.tri.be/issues/80492)