### PR TITLE
Support for REST API Event deletion operations

### DIFF
--- a/src/Tribe/REST/Endpoints/DELETE_Endpoint_Interface.php
+++ b/src/Tribe/REST/Endpoints/DELETE_Endpoint_Interface.php
@@ -22,5 +22,5 @@ interface Tribe__REST__Endpoints__DELETE_Endpoint_Interface {
 	/**
 	 * @return bool Whether the current user can delete or not.
 	 */
-	public function can_delete(  );
+	public function can_delete();
 }

--- a/src/Tribe/REST/Endpoints/DELETE_Endpoint_Interface.php
+++ b/src/Tribe/REST/Endpoints/DELETE_Endpoint_Interface.php
@@ -1,0 +1,26 @@
+<?php
+
+interface Tribe__REST__Endpoints__DELETE_Endpoint_Interface {
+	/**
+	 * Handles DELETE requests on the endpoint.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_REST_Response An array containing the data of the trashed post on
+	 *                                   success or a WP_Error instance on failure.
+	 */
+	public function delete( WP_REST_Request $request );
+
+	/**
+	 * Returns the content of the `args` array that should be used to register the endpoint
+	 * with the `register_rest_route` function.
+	 *
+	 * @return array
+	 */
+	public function DELETE_args();
+
+	/**
+	 * @return bool Whether the current user can delete or not.
+	 */
+	public function can_delete(  );
+}

--- a/src/Tribe/REST/Endpoints/POST_Endpoint_Interface.php
+++ b/src/Tribe/REST/Endpoints/POST_Endpoint_Interface.php
@@ -23,5 +23,5 @@ interface Tribe__REST__Endpoints__POST_Endpoint_Interface {
 	/**
 	 * @return bool Whether the current user can post or not.
 	 */
-	public function can_post(  );
+	public function can_post();
 }


### PR DESCRIPTION
Tickets: 
* https://central.tri.be/issues/79679
* https://central.tri.be/issues/79743
* https://central.tri.be/issues/79739

This PR adds the code and the tests to support event,venue and organizer deletion (trashing actually) from the REST API.