### PR TITLE
#65286 | Prevent Empty dateTimeSeparator Value from Breaking Date Output

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,4 +7,5 @@
 * Fix - Made the App Shop and help pages work on Windows. [77975]
 * Fix - Resolved issue where the Meta Chunker attempted to inappropriately chunk meta for post post_types [80857]
 * Fix - Avoid notices during plugin update and installation checks [80492]
+* Fix - Ensure an empty dateTimeSeparator option value doesn't break tribe_get_start_date output anymore. [65286]
 * Tweak - Textual corrections (with thanks to @garrett-eclipse) [77196]

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -181,14 +181,28 @@ if ( ! function_exists( 'tribe_get_datetime_format' ) ) {
 	 * @return mixed|void
 	 */
 	function tribe_get_datetime_format( $with_year = false ) {
-		$separator = (array) str_split( tribe_get_option( 'dateTimeSeparator', ' @ ' ) );
+
+		$raw_separator = tribe_get_option( 'dateTimeSeparator', ' @ ' );
+		$separator     = (array) str_split( $raw_separator );
+
+		if ( empty( $raw_separator ) ) {
+		    /**
+			 * Filterable fallback for when the dateTimeSeparator is an empty string. Defaults to a space.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $fallback The string to use as the fallback.
+			 * @param string $raw_separator The raw value of the dateTimeSeparator option.
+			 * @return string
+			 */	
+			$separator[0] = apply_filters( 'tribe_empty_datetime_separator_fallback', ' ', $raw_separator );
+		}
 
 		$format = tribe_get_date_format( $with_year );
 		$format .= ( ! empty( $separator ) ? '\\' : '' ) . implode( '\\', $separator );
 		$format .= get_option( 'time_format' );
 
 		return apply_filters( 'tribe_datetime_format', $format );
-
 	}
 }//end if
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -189,12 +189,12 @@ if ( ! function_exists( 'tribe_get_datetime_format' ) ) {
 		    /**
 			 * Filterable fallback for when the dateTimeSeparator is an empty string. Defaults to a space.
 			 *
-			 * @since TBD
+			 * @since 4.5.6
 			 *
 			 * @param string $fallback The string to use as the fallback.
 			 * @param string $raw_separator The raw value of the dateTimeSeparator option.
 			 * @return string
-			 */	
+			 */
 			$separator[0] = apply_filters( 'tribe_empty_datetime_separator_fallback', ' ', $raw_separator );
 		}
 


### PR DESCRIPTION
_Ref:_ [C#65286](http://central.tri.be/issues/65286)