### PR TITLE
Data required by tribe-common.js needs to be provided to tribe-common…

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -220,15 +220,6 @@ class Tribe__Main {
 			'admin_enqueue_scripts',
 			array(
 				'conditionals' => array( Tribe__Admin__Helpers::instance(), 'is_post_type_screen' ),
-				'localize' => (object) array(
-					'name' => 'tribe_system_info',
-					'data' => array(
-						'sysinfo_optin_nonce'   => wp_create_nonce( 'sysinfo_optin_nonce' ),
-						'clipboard_btn_text'    => __( 'Copy to clipboard', 'tribe-common' ),
-						'clipboard_copied_text' => __( 'System info copied', 'tribe-common' ),
-						'clipboard_fail_text'   => __( 'Press "Cmd + C" to copy', 'tribe-common' ),
-					),
-				),
 			)
 		);
 
@@ -239,7 +230,18 @@ class Tribe__Main {
 			'tribe-common',
 			'tribe-common.js',
 			array( 'tribe-clipboard' ),
-			'admin_enqueue_scripts'
+			'admin_enqueue_scripts',
+			array(
+				'localize' => (object) array(
+					'name' => 'tribe_system_info',
+					'data' => array(
+						'sysinfo_optin_nonce'   => wp_create_nonce( 'sysinfo_optin_nonce' ),
+						'clipboard_btn_text'    => __( 'Copy to clipboard', 'tribe-common' ),
+						'clipboard_copied_text' => __( 'System info copied', 'tribe-common' ),
+						'clipboard_fail_text'   => __( 'Press "Cmd + C" to copy', 'tribe-common' ),
+					),
+				),
+			)
 		);
 
 		tribe( 'tribe.asset.data' )->add( 'tribe_l10n_datatables', array(


### PR DESCRIPTION
`tribe-common.js` expects and needs the `tribe_system_info` object - so let's localize that script, instead of a bunch of other scripts which don't truly need that object.

:ticket: [#81456](https://central.tri.be/issues/81456)