### PR TITLE
Alter the range of admin screens in which the expired notices message…

### DIFF
--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -212,6 +212,15 @@ class Tribe__PUE__Notices {
 			return;
 		}
 
+		// Only show our invalid key messaging on the plugin admin screen and on our own admin screens
+		// @todo review and revise in MR 17.13
+		if (
+			'plugins.php' !== $pagenow
+			&& ! Tribe__Admin__Helpers::instance()->is_screen()
+		) {
+			return;
+		}
+
 		$plugin_names = $this->get_formatted_plugin_names( self::INVALID_KEY );
 
 		if ( empty( $plugin_names ) ) {


### PR DESCRIPTION
To avoid having to enqueue our assets on all admin screens, let's limit where the invalid key notice displays (to our own screens and to the plugin admin screen).

Can review and revise in the next MR.

:ticket: [#81260](https://central.tri.be/issues/81260)