### PR TITLE
Helper to retrieve anonymous objects registered as callbacks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.5.8] TBD =
 
-* ...
+* Tweak - Add helper to retrieve anonymous objects using the class name, hook and callback priority [74938]
 
 = [4.5.7] 2017-06-28 =
 

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -262,3 +262,49 @@ if ( ! function_exists( 'tribe_is_error' ) ) {
 		return ( $thing instanceof Tribe__Error || is_wp_error( $thing ) );
 	}
 }
+
+if ( ! function_exists( 'tribe_retrieve_object_by_hook' ) ) {
+	/**
+	 * Attempts to find and return an object of the specified type that is associated
+	 * with a specific hook.
+	 *
+	 * This is useful when third party code registers callbacks that belong to anonymous
+	 * objects and it isn't possible to obtain the reference any other way.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $class_name
+	 * @param string   $hook
+	 * @param int      $priority
+	 *
+	 * @return object|false
+	 */
+	function tribe_retrieve_object_by_hook( $class_name, $hook, $priority ) {
+		global $wp_filter;
+
+		// Not such hook/no callbacks registered for this hook?
+		if ( ! isset( $wp_filter[ $hook ] ) ) {
+			return false;
+		}
+
+		// Otherwise iterate through the registered callbacks at the specified priority
+		foreach ( $wp_filter[ $hook ]->callbacks[ $priority ] as $callback ) {
+			// Skip if this callback isn't an object method
+			if (
+				! is_array( $callback['function'] )
+				|| ! is_object( $callback['function'][ 0 ] )
+			) {
+				continue;
+			}
+
+			// If this isn't the callback we're looking for let's skip ahead
+			if ( $class_name !== get_class( $callback['function'][ 0 ] ) ) {
+				continue;
+			}
+
+			return $callback['function'][ 0 ];
+		}
+
+		return false;
+	}
+}

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -282,8 +282,11 @@ if ( ! function_exists( 'tribe_retrieve_object_by_hook' ) ) {
 	function tribe_retrieve_object_by_hook( $class_name, $hook, $priority ) {
 		global $wp_filter;
 
-		// Not such hook/no callbacks registered for this hook?
-		if ( ! isset( $wp_filter[ $hook ] ) ) {
+		// No callbacks registered for this hook and priority?
+		if (
+			! isset( $wp_filter[ $hook ] )
+			|| ! isset( $wp_filter[ $hook ][ $priority ] )
+		) {
 			return false;
 		}
 
@@ -292,17 +295,17 @@ if ( ! function_exists( 'tribe_retrieve_object_by_hook' ) ) {
 			// Skip if this callback isn't an object method
 			if (
 				! is_array( $callback['function'] )
-				|| ! is_object( $callback['function'][ 0 ] )
+				|| ! is_object( $callback['function'][0] )
 			) {
 				continue;
 			}
 
 			// If this isn't the callback we're looking for let's skip ahead
-			if ( $class_name !== get_class( $callback['function'][ 0 ] ) ) {
+			if ( $class_name !== get_class( $callback['function'][0] ) ) {
 				continue;
 			}
 
-			return $callback['function'][ 0 ];
+			return $callback['function'][0];
 		}
 
 		return false;


### PR DESCRIPTION
Sometimes callbacks belonging to anonymous objects are registered, leaving us in a tricky position if we want to unhook them. This helper provides a means of grabbing the needed object reference.

:ticket: [#74938](https://central.tri.be/issues/74938)