### PR TITLE
Readme parser fixes: support "[x.y.z]" and "x.y.z" version formats, d…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.5.8] TBD =
 
-* ...
+* Fix - Fixes to the plugin upgrade notice parser including support for environments where the data stream wrapper is unavailable [69486]
 
 = [4.5.7] 2017-06-28 =
 

--- a/src/Tribe/Admin/Notice/Plugin_Upgrade_Notice.php
+++ b/src/Tribe/Admin/Notice/Plugin_Upgrade_Notice.php
@@ -171,9 +171,9 @@ class Tribe__Admin__Notice__Plugin_Upgrade_Notice {
 	protected function parse_for_upgrade_notice( $readme ) {
 		$in_upgrade_notice = false;
 		$in_version_notice = false;
-		$readme_text       = fopen( "data:://text/plain,$readme", 'r' );
+		$readme_lines      = explode( "\n", $readme );
 
-		while ( $line = fgets( $readme_text ) ) {
+		foreach ( $readme_lines as $line ) {
 			// Once we leave the Upgrade Notice section (ie, we encounter a new section header), bail
 			if ( $in_upgrade_notice && 0 === strpos( $line, '==' ) ) {
 				break;
@@ -190,7 +190,7 @@ class Tribe__Admin__Notice__Plugin_Upgrade_Notice {
 			}
 
 			// Look out for the first applicable version-specific note within the Upgrade Notice section
-			if ( $in_upgrade_notice && ! $in_version_notice && preg_match( '/^=\s*([0-9\.]{3,})\s*=/', $line, $matches ) ) {
+			if ( $in_upgrade_notice && ! $in_version_notice && preg_match( '/^=\s*\[?([0-9\.]{3,})\]?\s*=/', $line, $matches ) ) {
 				// Is this a higher version than currently installed?
 				if ( version_compare( $matches[1], $this->current_version, '>' ) ) {
 					$in_version_notice = true;
@@ -199,7 +199,7 @@ class Tribe__Admin__Notice__Plugin_Upgrade_Notice {
 
 			// Copy the details of the upgrade notice for the first higher version we find
 			if ( $in_upgrade_notice && $in_version_notice ) {
-				$this->upgrade_notice .= $line;
+				$this->upgrade_notice .= $line . "\n";
 			}
 		}
 	}


### PR DESCRIPTION
Fixes to the upgrade notice parser:

* Don't assume the data stream wrapper is available (`allow_url_include` may be disabled)
* Update the version section regex to support version numbers wrapped in square brackets, which is the normal style we now use

:ticket: [#69486](https://central.tri.be/issues/69486)