### PR TITLE
Allow empty multichoice fields

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [4.5.8] TBD =
 
 * Fix - Fixes to the plugin upgrade notice parser including support for environments where the data stream wrapper is unavailable [69486]
+* Fix - Ensure the multichoice settings configured to allow no selection work as expected [73183]
 * Tweak - Add helper to retrieve anonymous objects using the class name, hook and callback priority [74938]
 
 = [4.5.7] 2017-06-28 =

--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -86,7 +86,7 @@ class Tribe__Settings_Manager {
 		$options = self::get_options();
 
 		$option = $default;
-		if ( isset( $options[ $option_name ] ) ) {
+		if ( array_key_exists( $option_name, $options ) ) {
 			$option = $options[ $option_name ];
 		} elseif ( is_multisite() && isset( self::$tribe_events_mu_defaults ) && is_array( self::$tribe_events_mu_defaults ) && in_array( $option_name, array_keys( self::$tribe_events_mu_defaults ) ) ) {
 			$option = self::$tribe_events_mu_defaults[ $option_name ];


### PR DESCRIPTION
If an option has been _saved,_ don't assume the default value should be returned just because the saved value is null or empty.

:ticket: [#73183](https://central.tri.be/issues/73183)