### PR TITLE
Fix issue with network admin pages throwing _doing_it_wrong unnecessarily

### DIFF
--- a/src/Tribe/App_Shop.php
+++ b/src/Tribe/App_Shop.php
@@ -101,6 +101,10 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 		 * @return bool
 		 */
 		public function is_current_page() {
+			if ( ! Tribe__Settings::instance()->should_setup_pages() || ! did_action( 'admin_menu' ) ) {
+				return false;
+			}
+
 			if ( is_null( $this->admin_page ) ) {
 				_doing_it_wrong(
 					__FUNCTION__,


### PR DESCRIPTION
https://central.tri.be/issues/83181

The `admin_menu` action only runs in main admin area, not the network admin, which then causes `is_current_page` to trigger the `_doing_it_wrong` function in debug mode.

We could run our method on the `network_admin_menu` action too, however the admin page / submenu code isn't setup for that case.

Either way, the `! Tribe__Settings::instance()->should_setup_pages()` check still needs to be called here, even if network admin menu support is added.