### PR TITLE
Cleaner/safer handling of settings in a mu network | #79728

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.5.9] TBD =
 
+* Fix - Avoid accidental overwrite of options when settings are saved in a multisite context [79728]
 * Tweak - Added period "." separator to datepicker formats [65282]
 * Tweak - Avoid noise relating to PUE checks during WP CLI requests
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -535,10 +535,10 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 			 */
 			foreach ( $parent_options as $option_id => $new_options ) {
 				// get the old options
-				if ( $option_id == Tribe__Main::OPTIONNAME ) {
-					$old_options = (array) get_option( $option_id );
-				} else {
+				if ( is_network_admin() ) {
 					$old_options = (array) get_site_option( $option_id );
+				} else {
+					$old_options = (array) get_option( $option_id );
 				}
 
 				// set the options by parsing old + new and filter that


### PR DESCRIPTION
The decision to pull from regular options or network level options should hinge on whether we're inside the network admin environment or not.

Before this change we based the decision on whether the option being saved was `'tribe_events_calendar_options'` or not, which doesn't seem to make sense generally and even less sense if we're trying to save Community Events settings, which are stored in a different option.

:ticket: [#79728](https://central.tri.be/issues/79728)