### PR TITLE
Cleanup country list logic, avoid translation faux pas | #72113

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.5.9] TBD =
 
+* Tweak - Cleanup logic responsible for handling the default country option and remove confusing translation calls (our thanks to Oliver for flagging this!) [72113]
 * Tweak - Added period "." separator to datepicker formats [65282]
 * Tweak - Avoid noise relating to PUE checks during WP CLI requests
 

--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -295,8 +295,8 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 				if ( $defaultCountry && $defaultCountry[0] != '' ) {
 					$selectCountry = array_shift( $countries );
 					asort( $countries );
-					$countries = array( $defaultCountry[0] => __( $defaultCountry[1], 'tribe-common' ) ) + $countries;
-					$countries = array( '' => __( $selectCountry, 'tribe-common' ) ) + $countries;
+					$countries = array( $defaultCountry[0] => $defaultCountry[1] ) + $countries;
+					$countries = array( '' => $selectCountry ) + $countries;
 					array_unique( $countries );
 				}
 


### PR DESCRIPTION
Stops us from translating a variable, which is a translation no-no. In this case, it was also unnecessary as the string had already been passed through `__()`.

:ticket: [#72113](https://central.tri.be/issues/72113)