### PR TITLE
Ensure proper ordering of country list, even when translated | #69550

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@
 = [4.5.9] 2017-007-26 =
 
 * Fix - Avoid accidental overwrite of options when settings are saved in a multisite context [79728]
-* Fix - Provide a well sorted list of countries even when this list is translated [
+* Fix - Provide a well sorted list of countries even when this list is translated [69550]
 * Tweak - Cleanup logic responsible for handling the default country option and remove confusing translation calls (our thanks to Oliver for flagging this!) [72113]
 * Tweak - Added period "." separator to datepicker formats [65282]
 * Tweak - Avoid noise relating to PUE checks during WP CLI requests

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@
 = [4.5.9] 2017-007-26 =
 
 * Fix - Avoid accidental overwrite of options when settings are saved in a multisite context [79728]
-* Fix - Provide a well sorted list of countries even when this list is translated [69550]
+* Fix - Provide a well sorted list of countries even when this list is translated (our thanks to Johannes in the forums for highlighting this) [69550]
 * Tweak - Cleanup logic responsible for handling the default country option and remove confusing translation calls (our thanks to Oliver for flagging this!) [72113]
 * Tweak - Added period "." separator to datepicker formats [65282]
 * Tweak - Avoid noise relating to PUE checks during WP CLI requests

--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,7 @@
 = [4.5.9] 2017-007-26 =
 
 * Fix - Avoid accidental overwrite of options when settings are saved in a multisite context [79728]
+* Fix - Provide a well sorted list of countries even when this list is translated [
 * Tweak - Cleanup logic responsible for handling the default country option and remove confusing translation calls (our thanks to Oliver for flagging this!) [72113]
 * Tweak - Added period "." separator to datepicker formats [65282]
 * Tweak - Avoid noise relating to PUE checks during WP CLI requests

--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -22,9 +22,7 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 		public static function constructCountries( $postId = '', $useDefault = true ) {
 
 			if ( tribe_get_option( 'tribeEventsCountries' ) != '' ) {
-				$countries = array(
-					'' => esc_html__( 'Select a Country:', 'tribe-common' ),
-				);
+				$countries = array();
 
 				$country_rows = explode( "\n", tribe_get_option( 'tribeEventsCountries' ) );
 				foreach ( $country_rows as $crow ) {
@@ -42,7 +40,6 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 
 			if ( ! isset( $countries ) || ! is_array( $countries ) || count( $countries ) == 1 ) {
 				$countries = array(
-					''   => esc_html__( 'Select a Country:', 'tribe-common' ),
 					'US' => esc_html__( 'United States', 'tribe-common' ),
 					'AF' => esc_html__( 'Afghanistan', 'tribe-common' ),
 					'AL' => esc_html__( 'Albania', 'tribe-common' ),
@@ -285,6 +282,15 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 					'ZW' => esc_html__( 'Zimbabwe', 'tribe-common' ),
 				);
 			}
+
+			// Perform a natural sort: this maintains the key -> index associations but ensures the countries
+			// are in the expected order, even once translated
+			natsort( $countries );
+
+			// Placeholder option ('Select a Country') first by default
+			$select_country = array( '' => esc_html__( 'Select a Country:', 'tribe-common' ) );
+			$countries = $select_country + $countries;
+
 			if ( ( $postId || $useDefault ) ) {
 				$countryValue = get_post_meta( $postId, '_EventCountry', true );
 				if ( $countryValue ) {


### PR DESCRIPTION
Solves a problem with ordering when the country list is translated, best illustrated by the following example:

> For example Yemen translates to Jemen in German.
> Yet, it is found at the end of the country list dropdown (e.g.: when creating or editing a venue).

:ticket: [#69550](https://central.tri.be/issues/69550)