### PR TITLE
Added support to tribe_asset() for altering plugin dir or using WPMU …

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.5.10] TBD =
 
-
+* Fix - Added support to tribe_asset() for altering plugin dir or using WPMU plugins. Thanks to @squirrelandnnuts for reporting this [82809]
 
 = [4.5.9] 2017-007-26 =
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -218,14 +218,18 @@ class Tribe__Assets {
 
 		if ( 0 === strpos( $url, WPMU_PLUGIN_URL ) ) {
 			// URL inside WPMU plugin dir.
-			$plugins_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
-			$base_url   = WPMU_PLUGIN_URL;
+			$base_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
+			$base_url = WPMU_PLUGIN_URL;
 		} elseif ( 0 === strpos( $url, WP_PLUGIN_URL ) ) {
 			// URL inside WP plugin dir.
-			$plugins_dir = wp_normalize_path( WP_PLUGIN_DIR );
-			$base_url   = WP_PLUGIN_URL;
+			$base_dir = wp_normalize_path( WP_PLUGIN_DIR );
+			$base_url = WP_PLUGIN_URL;
+		} elseif ( 0 === strpos( $url, WP_CONTENT_URL ) ) {
+			// URL inside WP content dir.
+			$base_dir = wp_normalize_path( WP_CONTENT_DIR );
+			$base_url = WP_CONTENT_URL;
 		} else {
-			// Resource needs to be inside a plugins dir, if not we can't check if it exists.
+			// Resource needs to be inside a wp-content or a plugins dir.
 			return false;
 		}
 
@@ -247,10 +251,10 @@ class Tribe__Assets {
 		$urls[] = $relative_location;
 
 		// Check for all Urls added to the array.
-		foreach ( $urls as $relative_location ) {
-			$file_path = wp_normalize_path( $plugins_dir . $relative_location );
+		foreach ( $urls as $partial_path ) {
+			$file_path = wp_normalize_path( $base_dir . $partial_path );
 			$file_url  = plugins_url( basename( $file_path ), $file_path );
-			// If file exists return url.
+
 			if ( file_exists( $file_path ) ) {
 				return $file_url;
 			}

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -207,46 +207,52 @@ class Tribe__Assets {
 	 * If the file does not exist, returns false.
 	 *
 	 * @since 4.3
+	 * @since TBD Removed ability to pass a filepath as $url
 	 *
-	 * @param string $url   The path or URL to the un-minified file.
+	 * @param string $url The absolute URL to the un-minified file.
 	 *
-	 * @return string|false The path/url to minified version or false, if file not found.
+	 * @return string|false The url to the minified version or false, if file not found.
 	 */
 	public static function maybe_get_min_file( $url ) {
 		$urls = array();
-		// If need add the Min Files
+
+		if ( 0 === strpos( $url, WPMU_PLUGIN_URL ) ) {
+			// URL inside WPMU plugin dir.
+			$plugins_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
+			$base_url   = WPMU_PLUGIN_URL;
+		} elseif ( 0 === strpos( $url, WP_PLUGIN_URL ) ) {
+			// URL inside WP plugin dir.
+			$plugins_dir = wp_normalize_path( WP_PLUGIN_DIR );
+			$base_url   = WP_PLUGIN_URL;
+		} else {
+			// Resource needs to be inside a plugins dir, if not we can't check if it exists.
+			return false;
+		}
+
+		// Strip the plugin URL and make this relative.
+		$relative_location = str_replace( $base_url, '', $url );
+
+		// If needed add the Min Files.
 		if ( ! defined( 'SCRIPT_DEBUG' ) || SCRIPT_DEBUG === false ) {
-			if ( substr( $url, - 3, 3 ) === '.js' ) {
-				$urls[] = substr_replace( $url, '.min', - 3, 0 );
+			if ( substr( $relative_location, - 3, 3 ) === '.js' ) {
+				$urls[] = substr_replace( $relative_location, '.min', - 3, 0 );
 			}
 
-			if ( substr( $url, - 4, 4 ) === '.css' ) {
-				$urls[] = substr_replace( $url, '.min', - 4, 0 );
+			if ( substr( $relative_location, - 4, 4 ) === '.css' ) {
+				$urls[] = substr_replace( $relative_location, '.min', - 4, 0 );
 			}
 		}
 
-		// Add the actual url after having the Min file added
-		$urls[] = $url;
+		// Add the actual url after having the min file added.
+		$urls[] = $relative_location;
 
-		// Check for all Urls added to the array
-		foreach ( $urls as $key => $url ) {
-			//set path to file for Windows
-			$file = $url;
-			//Set variable for content normalized directory
-			$normalized_content_dir = wp_normalize_path( WP_CONTENT_DIR );
-
-			//Detect if $url is actually a file path
-			if ( false !== strpos( $url, $normalized_content_dir ) ) {
-				// Turn file Path to URL in Windows
-				$url = str_replace( $normalized_content_dir, content_url(), $url );
-			} else {
-				// Turn URL into file Path
-				$file = str_replace( content_url(), $normalized_content_dir, $url );
-			}
-
-			//if file exists return url
-			if ( file_exists( $file ) ) {
-				return $url;
+		// Check for all Urls added to the array.
+		foreach ( $urls as $relative_location ) {
+			$file_path = wp_normalize_path( $plugins_dir . $relative_location );
+			$file_url  = plugins_url( basename( $file_path ), $file_path );
+			// If file exists return url.
+			if ( file_exists( $file_path ) ) {
+				return $file_url;
 			}
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/82809

Per conversation with @bordoni we decided to remove the ability to pass a filepath to this method. It is doubtful anyone was doing this, none of our code is. It simplifies our logic quite a bit to just accept URLs, and it's not hard to convert a path to a URL before passing it.

Original bug report noted that if the plugins dir is not inside the wp-content dir, this method fails. I noted the same thing if the wpmu plugins dir isn't inside wp-content. This should address both.