### PR TITLE
Fix/76411 get link ld

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [4.5.10] TBD =
 
 * Fix - Added support to tribe_asset() for altering plugin dir or using WPMU plugins. Thanks to @squirrelandnnuts for reporting this [82809]
+* Fix - Made JSON LD permalinks overrideable by all post types, so they can be filtered [76411]
 
 = [4.5.9] 2017-007-26 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 = [4.5.10] TBD =
 
 * Fix - Added support to tribe_asset() for altering plugin dir or using WPMU plugins. Thanks to @squirrelandnnuts for reporting this [82809]
-* Fix - Made JSON LD permalinks overrideable by all post types, so they can be filtered [76411]
+* Fix - Made JSON LD permalinks overridable by all post types, so they can be filtered [76411]
 
 = [4.5.9] 2017-007-26 =
 

--- a/src/Tribe/JSON_LD/Abstract.php
+++ b/src/Tribe/JSON_LD/Abstract.php
@@ -186,7 +186,6 @@ abstract class Tribe__JSON_LD__Abstract {
 	 * @return false|string Link to the post or false
 	 */
 	protected function get_link( $post ) {
-		$test = get_permalink( $post );
 		return get_permalink( $post );
 	}
 

--- a/src/Tribe/JSON_LD/Abstract.php
+++ b/src/Tribe/JSON_LD/Abstract.php
@@ -181,6 +181,8 @@ abstract class Tribe__JSON_LD__Abstract {
 	 * Children of this class are likely to override it with their
 	 * own functions that only work with their designated post type.
 	 *
+	 * @since TBD
+	 *
 	 * @param  int|WP_Post  $post The Post Object or ID
 	 *
 	 * @return false|string Link to the post or false

--- a/src/Tribe/JSON_LD/Abstract.php
+++ b/src/Tribe/JSON_LD/Abstract.php
@@ -95,7 +95,7 @@ abstract class Tribe__JSON_LD__Abstract {
 			$data->image = wp_get_attachment_url( get_post_thumbnail_id( $post ) );
 		}
 
-		$data->url = esc_url_raw( get_permalink( $post ) );
+		$data->url = esc_url_raw( $this->get_link( $post ) );
 
 		// Index by ID: this will allow filter code to identify the actual event being referred to
 		// without injecting an additional property
@@ -173,6 +173,21 @@ abstract class Tribe__JSON_LD__Abstract {
 		$html = apply_filters( 'tribe_json_ld_markup', $html );
 
 		echo $html;
+	}
+
+	/**
+	 * Get a link to the post
+	 *
+	 * Children of this class are likely to override it with their
+	 * own functions that only work with their designated post type.
+	 *
+	 * @param  int|WP_Post  $post The Post Object or ID
+	 *
+	 * @return false|string Link to the post or false
+	 */
+	protected function get_link( $post ) {
+		$test = get_permalink( $post );
+		return get_permalink( $post );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/76411

Giving classes that extend this the ability to override the get_permalink() function with one of their own choosing. Related PR will actually override it in those various other classes.