### PR TITLE
Prefer 'local' over 'site' when referring to license key types

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.5.11] TBD =
 
-
+* Fix - Ensure valid license keys save as expected [84966]
 
 = [4.5.10] 2017-08-09 =
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -915,7 +915,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$response['message'] = $this->get_api_message( $plugin_info );
 				$response['api_invalid'] = true;
 			} else {
-				$key_type = 'site';
+				$key_type = 'local';
 
 				if ( $network ) {
 					$key_type = 'network';
@@ -1462,7 +1462,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$network_option = (boolean) $validated_field->field['network_option'];
 			}
 
-			$key_type = 'site';
+			$key_type = 'local';
 
 			if ( $network_option ) {
 				$key_type = 'network';


### PR DESCRIPTION
Within the `get_key()` and `update_key()` methods we use `'local'` to refer to non-network keys, but outside of those methods we were using the term `'site'`. This corrects them, should restore automatic saving of valid license keys.

:ticket: [#84966](https://central.tri.be/issues/84966)