### PR TITLE
use get_post to resolve numerics only

### DIFF
--- a/src/Tribe/Change_Authority/Post_Base.php
+++ b/src/Tribe/Change_Authority/Post_Base.php
@@ -97,16 +97,12 @@ abstract class Tribe__Change_Authority__Post_Base extends Tribe__Change_Authorit
 	 * @return array
 	 */
 	protected function cast_to_objects( $from, $to ) {
-		if ( is_object( $from ) && ! $from instanceof WP_Post ) {
-			$from = (array) $from;
+		if ( is_numeric( $from ) ) {
+			$from = get_post( $from );
+		} elseif ( ! is_object( $from ) ) {
+			$from = (object) $from;
 		}
 
-		$from_post = get_post( $from );
-		if ( null !== $from_post ) {
-			$from = $from_post;
-		} else {
-			$from = is_array( $from ) || is_object( $from ) ? (object) $from : null;
-		}
 		$to = get_post( $to );
 
 		return array( $from, $to );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/84806

Fix the use of get post that would yield to using the first available post as template base.