### PR TITLE
Fix issue with Site URL not matching WP URL

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.5.11] TBD =
 
-
+* Fix - Fixed issue with JS/CSS files not loading when WordPress URL is HTTPS but Site URL is not (our thanks to @carcal1 for first reporting this) [85017]
 
 = [4.5.10] 2017-08-09 =
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -215,21 +215,24 @@ class Tribe__Assets {
 	 */
 	public static function maybe_get_min_file( $url ) {
 		$urls = array();
+		$wpmu_plugin_url = set_url_scheme( WPMU_PLUGIN_URL );
+		$wp_plugin_url = set_url_scheme( WP_PLUGIN_URL );
+		$wp_content_url = set_url_scheme( WP_CONTENT_URL );
 
-		if ( 0 === strpos( $url, WPMU_PLUGIN_URL ) ) {
+		if ( 0 === strpos( $url, $wpmu_plugin_url ) ) {
 			// URL inside WPMU plugin dir.
 			$base_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
-			$base_url = WPMU_PLUGIN_URL;
-		} elseif ( 0 === strpos( $url, WP_PLUGIN_URL ) ) {
+			$base_url = $wpmu_plugin_url;
+		} elseif ( 0 === strpos( $url, $wp_plugin_url ) ) {
 			// URL inside WP plugin dir.
 			$base_dir = wp_normalize_path( WP_PLUGIN_DIR );
-			$base_url = WP_PLUGIN_URL;
-		} elseif ( 0 === strpos( $url, WP_CONTENT_URL ) ) {
+			$base_url = $wp_plugin_url;
+		} elseif ( 0 === strpos( $url, $wp_content_url ) ) {
 			// URL inside WP content dir.
 			$base_dir = wp_normalize_path( WP_CONTENT_DIR );
-			$base_url = WP_CONTENT_URL;
+			$base_url = $wp_content_url;
 		} else {
-			// Resource needs to be inside a wp-content or a plugins dir.
+			// Resource needs to be inside wp-content or a plugins dir.
 			return false;
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/85017

When the site URL and WP URL don't match, the constant here could be a different protocol from the `$url` and thus strpos would not work as expected. 