### PR TITLE
Ensure that minified asset detection is SSL-friendly.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -216,18 +216,22 @@ class Tribe__Assets {
 	public static function maybe_get_min_file( $url ) {
 		$urls = array();
 
-		if ( 0 === strpos( $url, WPMU_PLUGIN_URL ) ) {
+		$wpmu_plugin_url = set_url_scheme( WPMU_PLUGIN_URL );
+		$wp_plugin_url = set_url_scheme( WP_PLUGIN_URL );
+		$wp_content_url = set_url_scheme( WPMU_CONTENT_URL );
+
+		if ( 0 === strpos( $url, $wpmu_plugin_url ) ) {
 			// URL inside WPMU plugin dir.
 			$base_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
-			$base_url = WPMU_PLUGIN_URL;
-		} elseif ( 0 === strpos( $url, WP_PLUGIN_URL ) ) {
+			$base_url = $wpmu_plugin_url;
+		} elseif ( 0 === strpos( $url, $wp_plugin_url ) ) {
 			// URL inside WP plugin dir.
 			$base_dir = wp_normalize_path( WP_PLUGIN_DIR );
-			$base_url = WP_PLUGIN_URL;
-		} elseif ( 0 === strpos( $url, WP_CONTENT_URL ) ) {
+			$base_url = $wp_plugin_url;
+		} elseif ( 0 === strpos( $url, $wp_content_url ) ) {
 			// URL inside WP content dir.
 			$base_dir = wp_normalize_path( WP_CONTENT_DIR );
-			$base_url = WP_CONTENT_URL;
+			$base_url = $wp_content_url;
 		} else {
 			// Resource needs to be inside a wp-content or a plugins dir.
 			return false;


### PR DESCRIPTION
I ran into a problem with The Events Calendar where JS assets were not loading on post-new.php?post_type=tribe_events. After a great deal of debugging, I traced it down to the problem that was previously quite thoroughly explained in this wordpress.org ticket by @earnjam : https://wordpress.org/support/topic/use-of-wp_content_url-breaks-plugin-on-admin-ssl-only-sites/ As he notes there, the problem arises on `FORCE_SSL_ADMIN`, but it's not only there: any time `get_option( 'home' )` is http:// but the current URL is https://, the problem arises. (SSL-optional sites, server-level rewrites/redirects, etc.)

Basically, when performing string comparisons on URL, you must ensure that your needle shares the scheme with the current haystack URL. There's a number of ways to do this. For greatest consistency and compatibility with mu-plugins, I chose to run everything through `set_url_scheme()` in this PR.

If for some reason you choose not to implement something like this, please provide a filter that I can use to work around the problem without forking the plugin :-)