### PR TITLE
pass the requested URL, not the mock, to the callback

### DIFF
--- a/tests/_support/Traits/Http_API_Requests.php
+++ b/tests/_support/Traits/Http_API_Requests.php
@@ -37,7 +37,7 @@ trait Http_API_Requests {
 			$method = $args['method'];
 			if ( isset( $mocks[ $method ] ) ) {
 				if ( is_callable( $mocks[ $method ] ) ) {
-					return call_user_func_array( $mocks[ $method ], [ $url, $args, $test_case ] );
+					return call_user_func_array( $mocks[ $method ], [ $requested_url, $args, $test_case ] );
 				}
 
 				return $mocks[ $method ];


### PR DESCRIPTION
Ticket (context): https://central.tri.be/issues/84695

Small fix to hte HTTP API class