### PR TITLE
Added condition for log dir not being readable

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.5.11] TBD =
+
+* Fix - Added check to see if log directory is readable before listing logs within it (thank you @rodrigochallengeday-org and @richmondmom for reporting this) [86091]
+
 = [4.5.10.1] 2017-08-16 =
 
 * Fix - Fixed issue with JS/CSS files not loading when WordPress URL is HTTPS but Site URL is not (our thanks to @carcal1 for first reporting this) [85017]

--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -211,10 +211,20 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 	 */
 	public function list_available_logs() {
 		$logs = array();
+
+		// This could be called when the log dir is not accessible.
+		if ( ! $this->is_available() ) {
+			return $logs;
+		}
+
 		$basename = $this->get_log_file_basename();
 
 		// Look through the log storage directory
 		foreach ( new DirectoryIterator( $this->log_dir ) as $node ) {
+			if ( ! $node->isReadable() ) {
+				continue;
+			}
+
 			$name = $node->getFilename();
 
 			// DirectoryIterator::getExtension() is only available on 5.3.6


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/86091

A couple users are getting this error:

```
PHP Fatal error: Uncaught exception ‘UnexpectedValueException’ with message ‘DirectoryIterator::__construct(/tmp): failed to open dir: Permission denied’ in .../common/src/Tribe/Log/File_Logger.php:217
Stack trace:
#0 .../common/src/Tribe/Log/File_Logger.php(217): DirectoryIterator->_construct(‘/tmp’)
#1 .../common/src/Tribe/Log/Admin.php(129): Tribe_Log__File_Logger->list_available_logs()
#2 .../common/src/Tribe/Log/Admin.php(16): Tribe__Log__Admin->get_available_logs()
#3 .../common/src/admin-views/tribe-options-help.php(49): Tribe__Log__Admin->display_log()
#4 .../common/src/Tribe/Settings_Manager.php(264): include_once( in .../common/src/Tribe/Log/File_Logger.php on line 217
```

We already have checks before writing/reading individual logs. However, we appear to lack one within this listing method. I added one, and as a bonus checked if each node within is readable.

❗️ Note: I do not plan to have this QA'd beyond asking the users if the fix worked for them, and having QA confirm that logging still works in ordinary environments. I think it will be too time consuming to try and help QA misconfigure a server enough to generate this error. So please give this a thorough code review if you don't ind.