### PR TITLE
Spotfix - add filter to customize list of states

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [4.5.12] TBD =
 
 * Fix - Added check to see if log directory is readable before listing logs within it (thank you @rodrigochallengeday-org and @richmondmom for reporting this) [86091]
+* Tweak - Added a filter to customize the list of states in the USA that are available to drop-downs when creating or editing venues.
 
 = [4.5.11] 2017-08-24 =
 

--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -318,7 +318,7 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 		 * @return array The states array.
 		 */
 		public static function loadStates() {
-			return array(
+			$states = array(
 				'AL' => esc_html__( 'Alabama', 'tribe-common' ),
 				'AK' => esc_html__( 'Alaska', 'tribe-common' ),
 				'AZ' => esc_html__( 'Arizona', 'tribe-common' ),
@@ -371,6 +371,8 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 				'WI' => esc_html__( 'Wisconsin', 'tribe-common' ),
 				'WY' => esc_html__( 'Wyoming', 'tribe-common' ),
 			);
+
+			return apply_filters( 'tribe_get_state_options', $states );
 		}
 
 		/**

--- a/src/Tribe/View_Helpers.php
+++ b/src/Tribe/View_Helpers.php
@@ -372,6 +372,13 @@ if ( ! class_exists( 'Tribe__View_Helpers' ) ) {
 				'WY' => esc_html__( 'Wyoming', 'tribe-common' ),
 			);
 
+			/**
+			 * Enables filtering the list of states in the USA available to venues.
+			 *
+			 * @since 4.5.12
+			 *
+			 * @param array $states The list of states.
+			 */
 			return apply_filters( 'tribe_get_state_options', $states );
 		}
 


### PR DESCRIPTION
Tweak - Added a filter to customize the list of states in the USA that are available to drop-downs when creating or editing venues.

Use case documented at https://theeventscalendar.com/support/forums/topic/restrict-location-options/