### PR TITLE
When validating .min assets, check `plugins_url()`.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -218,6 +218,7 @@ class Tribe__Assets {
 		$wpmu_plugin_url = set_url_scheme( WPMU_PLUGIN_URL );
 		$wp_plugin_url = set_url_scheme( WP_PLUGIN_URL );
 		$wp_content_url = set_url_scheme( WP_CONTENT_URL );
+		$plugins_url = plugins_url();
 
 		if ( 0 === strpos( $url, $wpmu_plugin_url ) ) {
 			// URL inside WPMU plugin dir.
@@ -231,6 +232,9 @@ class Tribe__Assets {
 			// URL inside WP content dir.
 			$base_dir = wp_normalize_path( WP_CONTENT_DIR );
 			$base_url = $wp_content_url;
+		} elseif ( 0 === strpos( $url, $plugins_url ) ) {
+			$base_dir = wp_normalize_path( WP_PLUGIN_DIR );
+			$base_url = $plugins_url;
 		} else {
 			// Resource needs to be inside wp-content or a plugins dir.
 			return false;


### PR DESCRIPTION
Previously: https://github.com/moderntribe/tribe-common/pull/495

Plugins like the-events-calendar load JS assets like this:
* `Tribe__Assets::register()` calls `tribe_resource_url()` generate an expected URL for the asset
* `tribe_resource_url()` builds an asset URL using `plugins_url()`
* This generated URL is then validated in `Tribe__Assets::maybe_get_min_file()`, which uses (among other things) `WP_PLUGIN_URL`

When `WP_PLUGIN_URL` and `plugins_url()` diverge, Tribe cannot find the assets, and they're not loaded. In my case, the divergence is because of the wordpress-mu-domain-mapping plugin (`plugins_url()` returns the mapped domain, while `WP_PLUGIN_URL` uses the primary URL of the installation), but it can happen whenever `plugins_url` is filtered.

This PR contains an ugly but simple workaround: Yet Another String Comparison, this one using `plugins_url()`. It's homely, but it works.

More generally, I wonder if `maybe_get_min_file()` is too aggressive in its validation. By simply returning false when it can't validate a file, it creates situations that are really hard to debug. It seems like it might be easier if the URLs were simply allowed to pass through, so that WP would enqueue the assets, which would then 404.

Alternatively, it may be useful to refactor `maybe_get_min_file()` so that, instead of simply bailing, any return value - `false` or a URL - is passed through a filter. This way, unorthodox setups could override the otherwise binding decisions of tribe-common :)

Thanks for considering!