### PR TITLE
Use URL functions instead of undocumented constants

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -216,8 +216,8 @@ class Tribe__Assets {
 	public static function maybe_get_min_file( $url ) {
 		$urls = array();
 		$wpmu_plugin_url = set_url_scheme( WPMU_PLUGIN_URL );
-		$wp_plugin_url = set_url_scheme( WP_PLUGIN_URL );
-		$wp_content_url = set_url_scheme( WP_CONTENT_URL );
+		$wp_plugin_url = set_url_scheme( plugins_url() );
+		$wp_content_url = set_url_scheme( content_url() );
 
 		if ( 0 === strpos( $url, $wpmu_plugin_url ) ) {
 			// URL inside WPMU plugin dir.


### PR DESCRIPTION
`WP_CONTENT_URL` and `WP_PLUGINS_URL` can cause issues when sites use domain mapping or have http front-end and https admin. These functions prevent those issues by running them through the proper filters and scheme checks.

See: https://wordpress.org/support/topic/support-for-domain-mapping/

You could probably also support mu-plugins in the same way, but there isn't a function that wraps `WPMU_PLUGIN_URL` neatly like there is for the other two constants. 