### PR TITLE
fixes PHP warning

### DIFF
--- a/src/Tribe/Customizer.php
+++ b/src/Tribe/Customizer.php
@@ -427,6 +427,9 @@ final class Tribe__Customizer {
 		$search = array();
 		$replace = array();
 		foreach ( $sections as $section => $settings ) {
+			if ( ! is_array( $settings ) ) {
+				continue;
+			}
 			foreach ( $settings as $setting => $value ) {
 				$index = array( $section, $setting );
 


### PR DESCRIPTION
My error log is filled with messages like this:

`PHP Warning: Invalid argument supplied for foreach() in wp-content/plugins/the-events-calendar/common/src/Tribe/Customizer.php on line 430`

I don't know if this is specific to WPEngine or not, but this extra check fixes the issue.