### PR TITLE
Remove screen_icon() call | #90985

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * New - Added new tribe_is_wpml_active() function for unified method of checking (as its name implies) if WPML is active [82286]
 * Fix - Restored functionality to the "currency position" options in Events Settings, and in the per-event cost settings (props @schola and many others!) [89918] 
 * Fix - Added safety checks to reduce the potential for errors stemming from our logging facilities (shout out to Brandon Stiner and Russell Todd for highlighting some remaining issues here) [90436, 90544]
+* Tweak - Removed call to deprecated screen_icon() function [90985]
 
 = [4.6.1] 2017-10-04 =
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -333,7 +333,6 @@ if ( ! class_exists( 'Tribe__Settings' ) ) {
 		public function generatePage() {
 			do_action( 'tribe_settings_top' );
 			echo '<div class="tribe_settings wrap">';
-			screen_icon();
 			echo '<h1>';
 			printf( esc_html__( '%s Settings', 'tribe-common' ), $this->menuName );
 			echo '</h1>';


### PR DESCRIPTION
Remove `screen_icon()` call - it no longer does anything and triggers deprecation notices under WP 4.9 beta.

:ticket: [#90985](https://central.tri.be/issues/90985)