### PR TITLE
Add safety check

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,7 @@
 * Fix - Restored functionality to the "currency position" options in Events Settings, and in the per-event cost settings (props @schola and many others!) [89918] 
 * Fix - Added safety checks to reduce the potential for errors stemming from our logging facilities (shout out to Brandon Stiner and Russell Todd for highlighting some remaining issues here) [90436, 90544]
 * Fix - Added checks to avoid the generation of warnings when rendering the customizer CSS template (props: @aristath) [91070]
+* Fix - Added safety checks to the Tribe__Post_Transient class to avoid errors when an array is expected but not available [91258]
 * Tweak - Added new tribe_is_wpml_active() function for unified method of checking (as its name implies) if WPML is active [82286]
 * Tweak - Removed call to deprecated screen_icon() function [90985]
 

--- a/src/Tribe/Post_Transient.php
+++ b/src/Tribe/Post_Transient.php
@@ -125,7 +125,7 @@ class Tribe__Post_Transient {
 				$value = get_post_meta( $post_id, $meta, false );
 
 				// if there aren't any values, communicate that it did not fetch data from post transient
-				if ( 0 === count( $value ) ) {
+				if ( 0 === count( $value ) || false === $value ) {
 					return false;
 				}
 

--- a/src/Tribe/Post_Transient.php
+++ b/src/Tribe/Post_Transient.php
@@ -125,7 +125,7 @@ class Tribe__Post_Transient {
 				$value = get_post_meta( $post_id, $meta, false );
 
 				// if there aren't any values, communicate that it did not fetch data from post transient
-				if ( 0 === count( $value ) || false === $value ) {
+				if ( ! is_array( $value ) || 0 === count( $value ) ) {
 					return false;
 				}
 


### PR DESCRIPTION
Tightens things up when checking to see if we have a non-empty array (by itself `0 === count()` is insufficient, as a fun facet of [count()](http://php.net/manual/en/function.count.php) is that it returns `1` for non-arrays/non-iterables).

:ticket: [#91258](https://central.tri.be/issues/91258)