### PR TITLE
Create DateTimeZone from string descriptions of UTC offsets | #78233

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,7 @@
 * Fix - Fixed compatibility issue with Internet Explorer 10 & 11 when selecting a venue from the dropdown (thanks (@acumenconsulting for reporting this) [72924]
 * Tweak - Obfuscated the API key for the google_maps_js_api_key field in the "System Information" screen [89795]
 * Tweak - Updated the list of countries used in the country dropdown [75769]
+* Tweak - Added additional timezone handling facilities [78233]
 
 = [4.6.2] 2017-10-18 =
 

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -485,5 +485,41 @@ class Tribe__Timezones {
 
 		return true;
 	}
+
+	/**
+	 * Given a string in the form "UTC+2.5" returns the corresponding DateTimeZone object.
+	 *
+	 * If this is not possible or if $utc_offset_string does not match the expected pattern,
+	 * boolean false is returned.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $utc_offset_string
+	 *
+	 * @return DateTimeZone | bool
+	 */
+	public static function timezone_from_utc_offset( $utc_offset_string ) {
+		// Test for strings looking like "UTC-2" or "UTC+5.25" etc
+		if ( ! preg_match( '/^UTC[\-\+]{1}[0-9\.]{1,4}$/', $utc_offset_string ) ) {
+			return false;
+		}
+
+		// Breakdown into polarity, hours and minutes
+		$parts    = explode( '.', substr( $utc_offset_string, 4 ) );
+		$hours    = (int) $parts[ 0 ];
+		$fraction = isset( $parts[ 1 ] ) ? '0.' . (int) $parts[ 1 ] : 0;
+		$minutes  = $fraction * 60;
+		$polarity = substr( $utc_offset_string, 3, 1 );
+
+		// Reassemble in the form +/-hhmm (ie "-0200" or "+0930")
+		$utc_offset = sprintf( $polarity . "%'.02d%'.02d", $hours, $minutes );
+
+		// Use this to build a new DateTimeZone
+		try {
+			return new DateTimeZone( $utc_offset );
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
 }
 


### PR DESCRIPTION
Provides the ability to take a string such as `'UTC+5'` and convert it to a `DateTimeZone` object representing that same offset.

:ticket: [#78233](https://central.tri.be/issues/78233)