### PR TITLE
Improve JSON printing in admin environment (ensure theme customizer s…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 
 * Fix - Added some more specification to our jquery-ui-datepicker CSS to limit conflicts with other plugins and themes [90577]
 * Fix - Fixed compatibility issue with Internet Explorer 10 & 11 when selecting a venue from the dropdown (thanks (@acumenconsulting for reporting this) [72924]
+* Fix - Improved process for sharing JSON data in the admin environment so that it also works within the theme customizer screen [72127]
 * Tweak - Obfuscated the API key for the google_maps_js_api_key field in the "System Information" screen [89795]
 * Tweak - Updated the list of countries used in the country dropdown [75769]
 * Tweak - Added additional timezone handling facilities [78233]

--- a/src/Tribe/Asset/Data.php
+++ b/src/Tribe/Asset/Data.php
@@ -20,6 +20,7 @@ class Tribe__Asset__Data {
 	public function hook() {
 		if ( is_admin() ) {
 			add_action( 'admin_footer', array( $this, 'render_json' ) );
+			add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_json' ) );
 		} else {
 			add_action( 'wp_footer', array( $this, 'render_json' ) );
 		}


### PR DESCRIPTION
Our admin JS expects to have access to the `tribe_l10n_datatables` object even in the customizer screen. This change enables that by printing the data during `customize_controls_print_footer_scripts` and not just `admin_footer` (which doesn't fire in the context of the theme customizer screen).

:ticket: [#72127](https://central.tri.be/issues/72127)