### PR TITLE
Increase flexibility of Tribe__Ajax__Dropdown | #91762

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.6.4] TBD =
+
+* Tweak - Removed restrictions imposed on taxonomy queries by Tribe__Ajax__Dropdown (our thanks to Ian in the forums for flagging this issue) [91762]
+
 = [4.6.3] 2017-11-02 =
 
 * Fix - Added some more specification to our jquery-ui-datepicker CSS to limit conflicts with other plugins and themes [90577]

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -37,9 +37,10 @@ class Tribe__Ajax__Dropdown {
 		if ( empty( $args['taxonomy'] ) ) {
 			$this->error( esc_attr__( 'Cannot look for Terms without a taxonomy', 'tribe-common' ) );
 		}
+
 		// We always want all the fields so we overwrite it
-		$args['fields'] = 'all';
-		$args['get']    = 'all';
+		$args['fields'] = isset( $args['fields'] ) ? $args['fields'] : 'all';
+		$args['hide_empty'] = isset( $args['hide_empty'] ) ? $args['hide_empty'] : false;
 
 		if ( ! empty( $search ) ) {
 			$args['search'] = $search;
@@ -54,8 +55,12 @@ class Tribe__Ajax__Dropdown {
 
 		$results = array();
 
+		// Respect the parent/child_of argument if set
+		$parent = ! empty( $args['child_of'] ) ? (int) $args['child_of'] : 0;
+		$parent = ! empty( $args['parent'] ) ? (int) $args['parent'] : $parent;
+
 		if ( empty( $args['search'] ) ) {
-			$this->sort_terms_hierarchically( $terms, $results );
+			$this->sort_terms_hierarchically( $terms, $results, $parent );
 			$results = $this->convert_children_to_array( $results );
 		} else {
 			foreach ( $terms as $term ) {


### PR DESCRIPTION
Loosens up `Tribe__Ajax__Dropdown::search_terms()`:

* Should be no difference under default usage
* Does now allow the query to be narrowed to a subset of categories if `child_of` or `parent` is passed in the query args

:ticket: [#91762](https://central.tri.be/issues/91762)