### PR TITLE
#78621 Better Accommodate 24-hr Time Format in Options

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.6.4] TBD =
+
+* New - Added new `tribe_is_site_using_24_hour_time()` function to easily check if the site is using a 24-hour time format [78621]
+
 = [4.6.3] 2017-11-02 =
 
 * Fix - Added some more specification to our jquery-ui-datepicker CSS to limit conflicts with other plugins and themes [90577]

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -407,3 +407,17 @@ if ( ! function_exists( 'tribe_wp_locale_month' ) ) {
 		return Tribe__Date_Utils::wp_locale_month( $month, $format );
 	}
 }
+
+if ( ! function_exists( 'tribe_is_site_using_24_hour_time' ) ) {
+	/**
+	 * Handy function for easily detecting if this site's using the 24-hour time format.
+	 *
+	 * @since TBD
+	 *
+	 * @return boolean
+	 */
+	function tribe_is_site_using_24_hour_time() {
+		$time_format = get_option( 'time_format' );
+		return strpos( $time_format, 'H' ) !== false;
+	}
+}


### PR DESCRIPTION
**Ticket:** [**#78621**](http://central.tri.be/issues/78621)

**Related PR:** https://github.com/moderntribe/the-events-calendar/pull/1658

---

### Code Review Note

- I created this function because I originally thought that checking for the 24-hour time directly would be a good solution for #78621.
- But then I noticed that the site's `time_format` option wasn't being respected for the "End of Day Cutoff" option _period_, not **just** when it was a 24-hour time format, so I switched approaches and used `date_i18n()` to get the right format regardless of what it was. [(_See the TEC PR for more info._)](https://github.com/moderntribe/the-events-calendar/pull/1658)
- **I still think this function could be useful though**, so submitted this PR here anyways; **is that cool, or should I pull this because it's not yet being used?**