### PR TITLE
Improve translatability of dropdowns | #84926

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 = [4.6.4] TBD =
 
 * New - Added new `tribe_is_site_using_24_hour_time()` function to easily check if the site is using a 24-hour time format [78621]
-* Fix - Added support for translatable placeholders when dropdown selectors are waiting on results being returned via ajax [84926]
+* Fix - Added support for translatable placeholder text when dropdown selectors are waiting on results being returned via ajax [84926]
 * Tweak - Removed restrictions imposed on taxonomy queries by Tribe__Ajax__Dropdown (our thanks to Ian in the forums for flagging this issue) [91762]
 
 = [4.6.3] 2017-11-02 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [4.6.4] TBD =
 
 * New - Added new `tribe_is_site_using_24_hour_time()` function to easily check if the site is using a 24-hour time format [78621]
+* Fix - Added support for translatable placeholders when dropdown selectors are waiting on results being returned via ajax [84926]
 * Tweak - Removed restrictions imposed on taxonomy queries by Tribe__Ajax__Dropdown (our thanks to Ian in the forums for flagging this issue) [91762]
 
 = [4.6.3] 2017-11-02 =

--- a/src/resources/js/dropdowns.js
+++ b/src/resources/js/dropdowns.js
@@ -216,6 +216,11 @@ var tribe_dropdowns = tribe_dropdowns || {};
 			args.allowClear = false;
 		}
 
+		// Pass the "Searching..." placeholder if specified
+		if ( $select.is( '[data-searching-placeholder]' ) ) {
+			args.formatSearching = $select.data( 'searching-placeholder' );
+		}
+
 		// If we are dealing with a Input Hidden we need to set the Data for it to work
 		if ( $select.is( '[data-options]' ) ) {
 			args.data = $select.data( 'options' );


### PR DESCRIPTION
If a piece of text is supplied to use as the _"Searching..."_ placeholder, use it! This makes it easier for that piece of text to be translated and customized.

:ticket: [#84926](https://central.tri.be/issues/84926)