### PR TITLE
Extra permissions check | #73551

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 
 * New - Added new `tribe_is_site_using_24_hour_time()` function to easily check if the site is using a 24-hour time format [78621]
 * Fix - Added support for translatable placeholder text when dropdown selectors are waiting on results being returned via ajax [84926]
+* Fix - Implemented an additional file permissions check within default error logger (our thanks to Oscar for highlighting this) [73551]
 * Tweak - Ensure the "Debug Mode" helper text in the Events Settings screen displays all of the time (it previously would vanish with certain permalinks settings) [92315]
 * Tweak - Allow for non-Latin characters to be used as the Events URL slug and the Single Event URL slug (thanks @daviddweb for originally reporting this) [61880]
 * Tweak - Removed restrictions imposed on taxonomy queries by Tribe__Ajax__Dropdown (our thanks to Ian in the forums for flagging this issue) [91762]

--- a/src/Tribe/Log/File_Logger.php
+++ b/src/Tribe/Log/File_Logger.php
@@ -60,7 +60,7 @@ class Tribe__Log__File_Logger implements Tribe__Log__Logger {
 	protected function obtain_handle() {
 		$this->close_handle();
 
-		if ( ! file_exists( $this->log_file ) ) {
+		if ( ! file_exists( $this->log_file ) && $this->is_available() ) {
 			touch( $this->log_file );
 		}
 


### PR DESCRIPTION
Test to see if the logging _directory_ is available (both readable and writeable) before trying to touch the log file.

:ticket: [♯73551](https://central.tri.be/issues/73551)