### PR TITLE
fix PHP Warning for `count()` as $search can be null

### DIFF
--- a/src/Tribe/Customizer/Section.php
+++ b/src/Tribe/Customizer/Section.php
@@ -196,6 +196,11 @@ abstract class Tribe__Customizer__Section {
 	 * @return array
 	 */
 	public function filter_settings( $settings, $search ) {
+		// Exit early.
+		if ( null === $search ) {
+			return $settings;
+		}
+
 		// Only Apply if getting the full options or Section
 		if ( is_array( $search ) && count( $search ) > 1 ) {
 			return $settings;


### PR DESCRIPTION
I'm seeing a PHP warning for `count()` on line 204 because $seach can be null.

![screenshot_01](https://user-images.githubusercontent.com/1296790/33522683-41530616-d7a7-11e7-883c-0513ff2ccf98.png)
