### PR TITLE
Event Cost no longer forced to numeric

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [TBD] TBD =
 
 * Fix - Fixed Event Cost field causing an error if it did not contain any numeric characters [95400]
+* Fix - Fixed Event Cost field forcing non-numeric strings into a number and therefore a currency amount [95403]
 
 = [4.7.3] 2017-12-07 =
 

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -321,8 +321,14 @@ class Tribe__Cost_Utils {
 
 		foreach ( $costs as &$cost ) {
 			// Get the required parts
+			$cost_wo_separators = $cost;
+
+			foreach ( $this->get_separators() as $separator ) {
+				$cost_wo_separators = str_replace( $separator, '', $cost_wo_separators );
+			}
+
 			if (
-				is_numeric( $cost )
+				is_numeric( $cost_wo_separators )
 				&& preg_match_all( '/' . $price_regex . '/', $cost, $matches )
 			) {
 				$cost = reset( $matches );

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -321,7 +321,10 @@ class Tribe__Cost_Utils {
 
 		foreach ( $costs as &$cost ) {
 			// Get the required parts
-			if ( preg_match_all( '/' . $price_regex . '/', $cost, $matches ) ) {
+			if (
+				is_numeric( $cost )
+				&& preg_match_all( '/' . $price_regex . '/', $cost, $matches )
+			) {
 				$cost = reset( $matches );
 			} else {
 				$cost = array( $cost );


### PR DESCRIPTION
https://central.tri.be/issues/95403

Note that '17,000,100.53' is non-numeric (comma-separated thousands) and therefore will be passed as the raw Event Cost string instead of displaying with a currency symbol in front of it.

I believe this is acceptable.