### PR TITLE
Fix the license validation colors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [TBD] TBD =
 
 * Fix - Fixed Event Cost field causing an error if it did not contain any numeric characters [95400]
+* Fix - Fixed the color of the license key validation messages [91890]
 
 = [4.7.3] 2017-12-07 =
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -622,9 +622,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 							$validity_msg.html(data.message);
 
 							switch ( data.status ) {
-								case 1: $validity_msg.addClass( 'valid-key' ); break;
+								case 1: $validity_msg.addClass( 'valid-key' ).removeClass( 'invalid-key' ); break;
 								case 2: $validity_msg.addClass( 'valid-key service-msg' ); break;
-								default: $validity_msg.addClass( 'invalid-key' ); break;
+								default: $validity_msg.addClass( 'invalid-key' ).removeClass( 'valid-key' ); break;
 							}
 						});
 					}


### PR DESCRIPTION
Ticket (context): https://central.tri.be/issues/91890

Without this fix the AJAX validation of keys would not mutate the message color, no matter the result of the validation; the correct color would be applied after a page refresh: https://cl.ly/2f1w3k0v0d07

This fixes it: https://cl.ly/1s0E1v0o1N1i