### PR TITLE
Test to see if var is array before using count() | #95527

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.7.5] TBD =
+
+* Fix - Added safety check to avoid errors surrounding the use of count() (our thanks to daftdog for highlighting this issue) [95527]
+
 = [4.7.4] 2017-12-18 =
 
 * Fix - Fixed Event Cost field causing an error if it did not contain any numeric characters [95400]

--- a/src/Tribe/Customizer/Section.php
+++ b/src/Tribe/Customizer/Section.php
@@ -206,7 +206,7 @@ abstract class Tribe__Customizer__Section {
 			return $settings;
 		}
 
-		if ( count( $search ) === 1 ) {
+		if ( is_array( $search ) && count( $search ) === 1 ) {
 			$settings = $this->create_ghost_settings( $settings );
 		} else {
 			$settings[ $this->ID ] = $this->create_ghost_settings( $settings[ $this->ID ] );


### PR DESCRIPTION
As of PHP 7.2, we need to be more careful about our use of `count()` if it's possible the var is not going to be an array or countable object.

:ticket: [#95527](https://central.tri.be/issues/95527)