### PR TITLE
fix validation callback behaviour

### DIFF
--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -75,8 +75,6 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 				$this->result->valid = false;
 				$this->result->error = esc_html__( 'Invalid or incomplete field passed', 'tribe-common' );
 				$this->result->error .= ( isset( $this->field['id'] ) ) ? ' (' . esc_html__( 'Field ID:', 'tribe-common' ) . ' ' . $this->field['id'] . ' )' : '';
-
-				return $this->result;
 			}
 
 			// call validation callback if a validation callback function is set
@@ -84,10 +82,12 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 				if ( function_exists( $this->field['validation_callback'] ) ) {
 					if ( ( ! isset( $_POST[ $field_id ] ) || ! $_POST[ $field_id ] || $_POST[ $field_id ] == '' ) && isset( $this->field['can_be_empty'] ) && $this->field['can_be_empty'] ) {
 						$this->result->valid = true;
-
-						return $this->result;
 					} else {
-						return call_user_func( $validation_callback );
+						$this->result->valid = call_user_func( $this->field['validation_callback'], $value );
+						if ( ! $this->result->valid ) {
+							$this->result->error = esc_html__( 'Invalid or incomplete field passed', 'tribe-common' );
+							$this->result->error .= ( isset( $this->field['id'] ) ) ? ' (' . esc_html__( 'Field ID:', 'tribe-common' ) . ' ' . $this->field['id'] . ' )' : '';
+						}
 					}
 				}
 			}
@@ -100,8 +100,6 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 					$this->label = isset( $this->field['label'] ) ? $this->field['label'] : $this->field['id'];
 					if ( ( ! isset( $_POST[ $field_id ] ) || ! $_POST[ $field_id ] || $_POST[ $field_id ] == '' ) && isset( $this->field['can_be_empty'] ) && $this->field['can_be_empty'] ) {
 						$this->result->valid = true;
-
-						return $this->result;
 					} else {
 						call_user_func( array( $this, $this->type ) ); // run the validation
 					}
@@ -117,9 +115,6 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 				$this->result->error = esc_html__( 'Invalid or incomplete field passed', 'tribe-common' );
 				$this->result->error .= ( isset( $this->field['id'] ) ) ? ' (' . esc_html__( 'Field ID:', 'tribe-common' ) . ' ' . $this->field['id'] . ' )' : '';
 			}
-
-			// return the result
-			return $this->result;
 		}
 
 		/**

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -58,8 +58,6 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 		 * @param string $field_id The field ID to validate
 		 * @param array  $field    The field object to validate
 		 * @param mixed  $value    The value to validate
-		 *
-		 * @return array $result The result of the validation
 		 */
 		public function __construct( $field_id, $field, $value, $additional_args = array() ) {
 


### PR DESCRIPTION
Ticket: n/a

Make sure our code does not return any value from `__construct` and that `validation_callback` is correctly used and supported.
  
  