### PR TITLE
Remove missing meta field when post is removed

### DIFF
--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -436,9 +436,10 @@ class Tribe__Tracker {
 	 *
 	 * @since TBD
 	 *
-	 * @param int Post ID
+	 * @param int  Post ID
+	 * @return bool
 	 */
 	public function cleanup_meta_fields( $post_id ) {
-		delete_post_meta( (int) $post_id, self::$field_key );
+		return delete_post_meta( (int) $post_id, self::$field_key );
 	}
 }

--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -44,6 +44,9 @@ class Tribe__Tracker {
 
 		// Track the Post term updates
 		add_action( 'set_object_terms', array( $this, 'track_taxonomy_term_changes' ), 10, 6 );
+
+		// Clean up modified fields if the post is removed.
+		add_action( 'delete_post', array( $this, 'cleanup_meta_fields' ) );
 	}
 
 	/**
@@ -425,5 +428,17 @@ class Tribe__Tracker {
 	 */
 	public function set_tracked_post_types( array $tracked_post_types ) {
 		$this->tracked_post_types = $tracked_post_types;
+	}
+
+	/**
+	 * Make sure to remove the changed field if the event is deleted to ensure there are no left meta fields when
+	 * the event is deleted.
+	 *
+	 * @since TBD
+	 *
+	 * @param int Post ID
+	 */
+	public function cleanup_meta_fields( $post_id ) {
+		delete_post_meta( (int) $post_id, self::$field_key );
 	}
 }


### PR DESCRIPTION
Makes sure to clean up the tracker meta field as the priority the meta
is not deleted by WordPress however after the action delete_post is
fired we can do another manual cleanup.

See https://central.tri.be/issues/96136