### PR TITLE
Make sure to merge the settings with the defaults

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,9 @@
 
 == Changelog ==
 
+= [] TBD =
+* Fix - Make sure to apply `$settings` to each section with the initial values in the customizer [96821]
+
 = [4.7.5] 2018-01-10 =
 
 * Fix - Added safety check to avoid errors surrounding the use of count() (our thanks to daftdog for highlighting this issue) [95527]

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 == Changelog ==
 
-= [] TBD =
+= [4.7.6] TBD =
 * Fix - Make sure to apply `$settings` to each section with the initial values in the customizer [96821]
 
 = [4.7.5] 2018-01-10 =

--- a/src/Tribe/Customizer.php
+++ b/src/Tribe/Customizer.php
@@ -281,8 +281,8 @@ final class Tribe__Customizer {
 			 *
 			 * @param array $defaults
 			 */
-			$defaults[ $section->ID ] = apply_filters( "tribe_customizer_section_{$section->ID}_defaults", array() );
 			$settings = isset( $sections[ $section->ID ] ) ? $sections[ $section->ID ] : array();
+			$defaults[ $section->ID ] = apply_filters( "tribe_customizer_section_{$section->ID}_defaults", $settings );
 			$sections[ $section->ID ] = wp_parse_args( $settings, $defaults[ $section->ID ] );
 		}
 
@@ -423,6 +423,7 @@ final class Tribe__Customizer {
 	private function parse_css_template( $template ) {
 		$css = $template;
 		$sections = $this->get_option();
+
 
 		$search = array();
 		$replace = array();

--- a/src/Tribe/Customizer/Section.php
+++ b/src/Tribe/Customizer/Section.php
@@ -167,9 +167,9 @@ abstract class Tribe__Customizer__Section {
 	 * A way to apply filters when getting the Customizer options
 	 * @return array
 	 */
-	public function get_defaults() {
+	public function get_defaults( $settings = array() ) {
 		// Create Ghost Options
-		return $this->create_ghost_settings( $this->defaults );
+		return $this->create_ghost_settings( wp_parse_args( $settings, $this->defaults ) );
 	}
 
 	/**


### PR DESCRIPTION
This will make sure if any section has settings merge those with the default values of each section in the customizer.

See https://central.tri.be/issues/96821