### PR TITLE
Prevent DST on UTC conversion of date times

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 
 * Tweak - Improve the performance of dropdown and recurrent events by using caching on objects (our thanks to Gilles in the forums for flagging this problem) [81993]
 * Tweak - Add the `tribe_transient_notice` and `tribe_transient_notice_remove` functions to easily create and remove fire-and-forget admin notices.
+* Fix - Prevent a change on the dates when DST happens on an event by avoding DST changes on UTC conversion [69784]
 
 = [4.7.6] 2018-01-23 =
 

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -279,10 +279,29 @@ class Tribe__Timezones {
 		$new_datetime = date_create( $datetime, $local );
 
 		if ( $new_datetime ) {
-			$new_datetime->setTimezone( $utc );
-			$format = ! empty( $format ) ? $format : Tribe__Date_Utils::DBDATETIMEFORMAT;
-
-			return $new_datetime->format( $format );
+			if ( empty ( $format ) ) {
+				/**
+				 * In order to avoid problems with dates that fall into DST for local timeszones we need to split into: date & time
+				 * doing this we convert to UTC each in order to avoid a DST conversion based on date and time.
+				 *
+				 * This is important specially for recurring events as some of them might fall inside or outside of DST periods and as the conversion
+				 * might fall into timezones with DST PHP will automatically convert an hour from normal to DST or viceversa
+				 * in most cases the event that was supposed to be started at 12:00pm should remain at the same time
+				 * regardless if is DST or not.
+				 */
+				$date = date_create( $new_datetime->format( Tribe__Date_Utils::DBDATEFORMAT ), $local );
+				$time = date_create( $new_datetime->format( Tribe__Date_Utils::DBTIMEFORMAT ), $local );
+				$date->setTimezone( $utc );
+				$time->setTimezone( $utc );
+				return sprintf(
+					'%s %s',
+					$date->format( Tribe__Date_Utils::DBDATEFORMAT ),
+					$time->format( Tribe__Date_Utils::DBTIMEFORMAT )
+				);
+			} else {
+				$new_datetime->setTimezone( $utc );
+				return $new_datetime->format( $format );
+			}
 		}
 
 		// Fallback to the unmodified datetime if there was a failure during conversion

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -300,7 +300,6 @@ class Tribe__Timezones {
 						$time->format( Tribe__Date_Utils::DBTIMEFORMAT )
 					);
 				} catch( Exception $e ) {
-					error_log( 'There was an error while date_create() was called.' );
 					return $datetime;
 				}
 			} else {

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -289,15 +289,20 @@ class Tribe__Timezones {
 				 * in most cases the event that was supposed to be started at 12:00pm should remain at the same time
 				 * regardless if is DST or not.
 				 */
-				$date = date_create( $new_datetime->format( Tribe__Date_Utils::DBDATEFORMAT ), $local );
-				$time = date_create( $new_datetime->format( Tribe__Date_Utils::DBTIMEFORMAT ), $local );
-				$date->setTimezone( $utc );
-				$time->setTimezone( $utc );
-				return sprintf(
-					'%s %s',
-					$date->format( Tribe__Date_Utils::DBDATEFORMAT ),
-					$time->format( Tribe__Date_Utils::DBTIMEFORMAT )
-				);
+				try {
+					$date = date_create( $new_datetime->format( Tribe__Date_Utils::DBDATEFORMAT ), $local );
+					$time = date_create( $new_datetime->format( Tribe__Date_Utils::DBTIMEFORMAT ), $local );
+					$date->setTimezone( $utc );
+					$time->setTimezone( $utc );
+					return sprintf(
+						'%s %s',
+						$date->format( Tribe__Date_Utils::DBDATEFORMAT ),
+						$time->format( Tribe__Date_Utils::DBTIMEFORMAT )
+					);
+				} catch( Exception $e ) {
+					error_log( 'There was an error while date_create() was called.' );
+					return $datetime;
+				}
 			} else {
 				$new_datetime->setTimezone( $utc );
 				return $new_datetime->format( $format );


### PR DESCRIPTION
Ticket => https://central.tri.be/issues/69784

Split dates before a UTC conversion in order to avoid a change on the
initial time.