### PR TITLE
Remove the dependency check in order to avoid EventAgreggator issues

### DIFF
--- a/src/resources/js/dependency.js
+++ b/src/resources/js/dependency.js
@@ -98,9 +98,6 @@
 		}
 
 		$dependents.each( function( k, dependent ) {
-			if ( dependent.completed ) {
-				return;
-			}
 			var $dependent         = $( dependent );
 			var hasDependentParent = $dependent.is( '[data-dependent-parent]' );
 
@@ -191,7 +188,6 @@
 				}
 			}
 
-			dependent.completed = true;
 			var $dependent_childs = $dependent.find( selectors.dependency );
 			if ( $dependent_childs.length > 0 ) {
 				// Checks if any child elements have dependencies


### PR DESCRIPTION
This need to be executed multiple times in order to allow event
agreggator UI behave correctly.