### PR TITLE
more robust checks on the context

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -44,7 +44,7 @@ class Tribe__Context {
 		}
 
 		if ( null !== $post_or_type ) {
-			$current_post = get_post();
+			$current_post = Tribe__Utils__Array::get( $_REQUEST, 'post', get_post() );
 
 			if ( is_numeric( $post_or_type ) ) {
 

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -44,22 +44,24 @@ class Tribe__Context {
 		}
 
 		if ( null !== $post_or_type ) {
+			$current_post = get_post();
+
 			if ( is_numeric( $post_or_type ) ) {
 
 				$post = $is_post ? get_post( $post_or_type ) : null;
 
-				return ! empty( $post ) && $post == get_post();
+				return ! empty( $post ) && $post == $current_post;
 			}
 
 			$post_types = is_array( $post_or_type ) ? $post_or_type : array( $post_or_type );
 
-			$post = $is_post ? get_post() : null;
+			$post = $is_post ? $current_post : null;
 
 			if ( count( array_filter( $post_types, 'is_numeric' ) ) === count( $post_types ) ) {
 				return ! empty( $post ) && in_array( $post->ID, $post_types );
 			}
 
-			if ( $is_post ) {
+			if ( $is_post && $post instanceof WP_Post ) {
 				$post_type = $post->post_type;
 			} else {
 				$post_type = Tribe__Utils__Array::get( $_GET, 'post_type', 'post' );

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -44,7 +44,9 @@ class Tribe__Context {
 		}
 
 		if ( null !== $post_or_type ) {
-			$current_post = Tribe__Utils__Array::get( $_REQUEST, 'post', get_post() );
+			$lookup = array( $_GET, $_POST, $_REQUEST );
+
+			$current_post = Tribe__Utils__Array::get_in_any( $lookup, 'post', get_post() );
 
 			if ( is_numeric( $post_or_type ) ) {
 
@@ -64,7 +66,7 @@ class Tribe__Context {
 			if ( $is_post && $post instanceof WP_Post ) {
 				$post_type = $post->post_type;
 			} else {
-				$post_type = Tribe__Utils__Array::get( $_GET, 'post_type', 'post' );
+				$post_type = Tribe__Utils__Array::get_in_any( $lookup, 'post_type', 'post' );
 			}
 
 			return (bool) count( array_intersect( $post_types, array( $post_type ) ) );

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -87,6 +87,32 @@ class Tribe__Utils__Array {
 	}
 
 	/**
+	 * Find a value inside a list of array or objects, including one nested a few levels deep.
+	 *
+	 * @since TBD
+	 *
+	 * Example: get( [$a, $b, $c], [ 0, 1, 2 ] ) returns the value of $a[0][1][2] found in $a, $b or $c
+	 * or the default.
+	 *
+	 * @param  array        $variables Array of arrays or objects to search within.
+	 * @param  array|string $indexes   Specify each nested index in order.
+	 *                                 Example: array( 'lvl1', 'lvl2' );
+	 * @param  mixed        $default   Default value if the search finds nothing.
+	 *
+	 * @return mixed The value of the specified index or the default if not found.
+	 */
+	public static function get_in_any( array $variables, $indexes, $default = null ) {
+		foreach ( $variables as $variable ) {
+			$found = self::get( $variable, $indexes, '__not_found__' );
+			if ( '__not_found__' !== $found ) {
+				return $found;
+			}
+		}
+
+		return $default;
+	}
+
+	/**
 	 * Behaves exactly like the native strpos(), but accepts an array of needles.
 	 *
 	 * @see strpos()


### PR DESCRIPTION
Ticket: #99046

This PR:
1. adds the `Tribe__Utils__Array::get_in_any` method to get the specified indexes in any one of the specified values
2. updates the code of the `Tribe__Context` class to avoid notices in those cases where the post or post type might not be as expected