### PR TITLE
Fix validation of multi options if it cannot be empty

### DIFF
--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -300,12 +300,21 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 		}
 
 		/**
-		 * validates fields that have multiple options (checkbox list, etc.)
-		 * by making sure the value is part of the options array
+		 * Validates fields that have multiple options (checkbox list, etc.)
+		 * by making sure the value is part of the options array.
 		 *
-		 * @return stdClass validation result object
+		 * For the purpose of validation no option selected at all is a valid and
+		 * supported choice.
 		 */
 		public function options_multi() {
+			// handle the case where there are no options selected at all
+			if ( empty( $this->value ) || ! is_array( $this->value ) ) {
+				$this->value         = false;
+				$this->result->valid = true;
+
+				return;
+			}
+
 			foreach ( $this->value as $val ) {
 				if ( array_key_exists( $val, $this->field['options'] ) ) {
 					$this->value         = ( $this->value === 0 ) ? false : $this->value;

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -302,18 +302,17 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 		/**
 		 * Validates fields that have multiple options (checkbox list, etc.)
 		 * by making sure the value is part of the options array.
-		 *
-		 * For the purpose of validation no option selected at all is a valid and
-		 * supported choice.
 		 */
 		public function options_multi() {
-			// handle the case where there are no options selected at all
-			if ( empty( $this->value ) || ! is_array( $this->value ) ) {
-				$this->value         = false;
-				$this->result->valid = true;
+			// if we are here it cannot be empty
+			if ( empty( $this->value ) ) {
+				$this->result->valid = false;
+				$this->result->error = sprintf( esc_html__( "%s must have a value that's part of its options.", 'tribe-common' ), $this->label );
 
 				return;
 			}
+
+			$this->value = is_array( $this->value ) ? $this->value : array( $this->value );
 
 			foreach ( $this->value as $val ) {
 				if ( array_key_exists( $val, $this->field['options'] ) ) {


### PR DESCRIPTION
Ticket:  https://central.tri.be/issues/100275

This PR fixes the validation of the `option_multi` fields when `can_be_empty` is set to `false`.