### PR TITLE
97344 Show Correct Timezone Abbreviation Regardless of Timezone Mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "homepage": "http://tri.be/shop/wordpress-events-calendar/",
   "license": "GPL-2.0",
   "require-dev": {
-    "lucatume/wp-browser": "^1.22.1",
+    "lucatume/wp-browser": "1.22.6.1",
     "vlucas/phpdotenv": "^2.4",
     "lucatume/function-mocker-le": "^1.0",
     "wp-cli/checksum-command": "1.0.5"

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,8 @@
 
 = [4.7.8] TBD =
 
+* Fix - Remove unnecessary timezone-abbreviation caching approach to improve accuracy of timezone abbreviations and better reflect DST changes [97344]
+
 = [4.7.7.1] 2018-02-16 =
 
 * Fix - Rollback changes introduced in version 4.7.7 to allow month view to render correctly.

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -54,17 +54,10 @@ class Tribe__Timezones {
 	 * @return string
 	 */
 	public static function wp_timezone_abbr( $date ) {
-		$abbr = get_transient( 'tribe_events_wp_timezone_abbr' );
+		$timezone_string = self::wp_timezone_string();
+		$abbr            = self::abbr( $date, $timezone_string );
 
-		if ( empty( $abbr ) ) {
-			$timezone_string = self::wp_timezone_string();
-			$abbr = self::abbr( $date, $timezone_string );
-			set_transient( 'tribe_events_wp_timezone_abbr', $abbr );
-		}
-
-		return empty( $abbr )
-			? $timezone_string
-			: $abbr;
+		return empty( $abbr ) ? $timezone_string : $abbr;
 	}
 
 	/**


### PR DESCRIPTION
**Ticket:** [**#97344**](http://central.tri.be/issues/97344)

Removing this caching resolves the bug—Barry and I discussed this on a call and determined that there wasn't really anything _gained_ by the caching in the first place, so we're removing it now. 👍 