### PR TITLE
Make sure JSON strings are single lines

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 
 * Feature - Added new `tribe_get_global_query_object()` template tag for accessing the $wp_query global without triggering errors if other software has directly manipulated the global [100199]
 * Fix - Remove unnecessary timezone-abbreviation caching approach to improve accuracy of timezone abbreviations and better reflect DST changes [97344]
+* Fix - Make sure JSON strings are always a single line of text [99089]
 
 = [4.7.7.1] 2018-02-16 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -266,9 +266,11 @@ if ( ! function_exists( 'tribe_prepare_for_json' ) ) {
 	 * @return string
 	 */
 	function tribe_prepare_for_json( $string ) {
-
 		$value = trim( htmlspecialchars( $string, ENT_QUOTES, 'UTF-8' ) );
 		$value = str_replace( '&quot;', '"', $value );
+		// &amp;#013; is same as \r and JSON strings should be a single line not multiple lines.
+		$removable_values = array( '\r', '\n', '\t', '&amp;#013;' );
+		$value = str_replace( $removable_values, '', $value );
 
 		return $value;
 	}


### PR DESCRIPTION
**Ticket** https://central.tri.be/issues/99089

JSON Strings should be a single line string otherwise when there are multiple
carry returns in the middle will fail to parse the string to JSON.