### PR TITLE
Allow skipping activation page welcome redirection with an option

### DIFF
--- a/src/Tribe/Admin/Activation_Page.php
+++ b/src/Tribe/Admin/Activation_Page.php
@@ -47,7 +47,7 @@ class Tribe__Admin__Activation_Page {
 	 * Listen for opportunities to show update and welcome splash pages.
 	 */
 	public function hooks() {
-		if ( true === ( (bool) get_option( 'tribe_skip_welcome' ) ) ) {
+		if ( tribe_is_truthy( get_option( 'tribe_skip_welcome' ) ) ) {
 			return;
 		}
 

--- a/src/Tribe/Admin/Activation_Page.php
+++ b/src/Tribe/Admin/Activation_Page.php
@@ -47,6 +47,10 @@ class Tribe__Admin__Activation_Page {
 	 * Listen for opportunities to show update and welcome splash pages.
 	 */
 	public function hooks() {
+		if ( true === ( (bool) get_option( 'tribe_skip_welcome' ) ) ) {
+			return;
+		}
+
 		add_action( 'admin_init', array( $this, 'maybe_redirect' ), 10, 0 );
 		add_action( 'admin_menu', array( $this, 'register_page' ), 100, 0 ); // come in after the default page is registered
 

--- a/src/Tribe/Admin/Activation_Page.php
+++ b/src/Tribe/Admin/Activation_Page.php
@@ -47,7 +47,10 @@ class Tribe__Admin__Activation_Page {
 	 * Listen for opportunities to show update and welcome splash pages.
 	 */
 	public function hooks() {
-		if ( tribe_is_truthy( get_option( 'tribe_skip_welcome' ) ) ) {
+		if (
+			tribe_is_truthy( get_option( 'tribe_skip_welcome', false ) )
+			|| tribe_is_truthy( tribe_get_option( 'skip_welcome', false ) )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Ticket: n/a

This PR adds a check for the `tribe_skip_welcome` option in the activation page code to avoid redirecting after a plugin activation; the non-skippable redirection breaks all acceptance tests and appending the `tribe-skip-welcome` query var to *any* request would be an exercise in futility. Adding the set of the option *once* before the tests is, instead, way more practical and maintainable.