### PR TITLE
Set the timezone when the `DateTime` object is created

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,8 @@
 
 = [4.7.11] TBD =
 
+* Fix - Make sure `Timezone` is provided during the creation of the date to avoid usage of UTC as initial timezone [98654]
+
 = [4.7.9] 2018-03-12 =
 
 = [4.7.8] 2018-03-06 =

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -20,6 +20,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		const DBDATETIMEFORMAT      = 'Y-m-d H:i:s';
 		const DBTIMEFORMAT          = 'H:i:s';
 		const DBYEARMONTHTIMEFORMAT = 'Y-m';
+		const UNIX_TIMESTAMP        = 'U';
 
 		private static $localized_months_full  = array();
 		private static $localized_months_short = array();

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -424,16 +424,14 @@ class Tribe__Timezones {
 
 			if ( Tribe__Date_Utils::is_timestamp( $date ) ) {
 				$date = new DateTime( "@{$date}" );
+				$date->setTimezone( $timezone_object );
 			} else {
-				$date = new DateTime( $date );
+				$date = new DateTime( $date, $timezone_object );
 			}
+			return $date->format( $format );
 		} catch ( Exception $e ) {
 			return false;
 		}
-
-		$date->setTimezone( $timezone_object );
-
-		return $date->format( $format );
 	}
 
 	/**

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -420,7 +420,11 @@ class Tribe__Timezones {
 		}
 
 		try {
-			$timezone_object = new DateTimeZone( $timezone );
+			if ( $timezone instanceof DateTimeZone ) {
+				$timezone_object = $timezone;
+			} else {
+				$timezone_object = new DateTimeZone( $timezone );
+			}
 
 			if ( Tribe__Date_Utils::is_timestamp( $date ) ) {
 				$date = new DateTime( "@{$date}" );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98654

If the Timezone is provided and the `$date` is not a UNIX Timestamp format
the timezone object should be set on initial value instead as if not UTC is
used as default.

For UNIX timestamps it can't be provided on Object creation only once
object is already created.