### PR TITLE
Moar Array utils

### DIFF
--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -241,7 +241,9 @@ class Tribe__Utils__Array {
 	/**
 	 * Extracts and merges the values from an array, associative array or array of arrays.
 	 *
-	 * This method will only go one level deep.
+	 * This method will only go one level deep to extract values.
+	 *
+	 * @since TBD
 	 *
 	 * @param array $array
 	 *

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -250,10 +250,7 @@ class Tribe__Utils__Array {
 	 * @return array
 	 */
 	public static function extract_values( array $array ) {
-		$all = array_map( array(
-			'Tribe__Utils__Array',
-			'arrayize'
-		), array_values( $array ) );
+		$all = array_map( array( __CLASS__, 'arrayize' ), array_values( $array ) );
 
 		return ! empty( $all ) ? array_values( call_user_func_array( 'array_merge', $all ) ) : [];
 	}

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -176,14 +176,14 @@ class Tribe__Utils__Array {
 		}
 
 		$filtered = array();
-		foreach ( $value as $v ) {
+		foreach ( $value as $k => $v ) {
 			if ( '' === $v ) {
 				continue;
 			}
-			$filtered[] = is_numeric( $v ) ? $v + 0 : $v;
+			$filtered[ $k ] = is_numeric( $v ) ? $v + 0 : $v;
 		}
 
-		return $filtered;
+		return self::is_associative( $filtered ) ? $filtered : array_values( $filtered );
 	}
 
 	/**
@@ -206,5 +206,53 @@ class Tribe__Utils__Array {
 		}
 
 		return $list;
+	}
+
+	/**
+	 * Whether the provided array is associative or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $arr
+	 *
+	 * @return bool
+	 */
+	public static function is_associative( $array ) {
+		if ( ! is_array( $array ) ) {
+			return false;
+		}
+
+		return count( array_filter( array_keys( $array ), 'is_numeric' ) ) < count( $array );
+	}
+
+	/**
+	 * Encapsulates a non array object in an array.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $element
+	 *
+	 * @return array
+	 */
+	public static function arrayize( $element ) {
+		return is_array( $element ) ? $element : array( $element );
+	}
+
+	/**
+	 * Extracts and merges the values from an array, associative array or array of arrays.
+	 *
+	 * This method will only go one level deep.
+	 *
+	 * @param array $array
+	 *
+	 * @return array
+	 */
+	public static function extract_values( array $array ) {
+		$all = array_map( array(
+			'Tribe__Utils__Array',
+			'arrayize'
+		), array_values( $array ) );
+
+		return ! empty( $all ) ? array_values( call_user_func_array( 'array_merge', $all ) ) : [];
 	}
 }

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -252,6 +252,6 @@ class Tribe__Utils__Array {
 	public static function extract_values( array $array ) {
 		$all = array_map( array( __CLASS__, 'arrayize' ), array_values( $array ) );
 
-		return ! empty( $all ) ? array_values( call_user_func_array( 'array_merge', $all ) ) : [];
+		return ! empty( $all ) ? array_values( call_user_func_array( 'array_merge', $all ) ) : array();
 	}
 }

--- a/tests/wpunit/Tribe/Utils/ArrayTest.php
+++ b/tests/wpunit/Tribe/Utils/ArrayTest.php
@@ -67,4 +67,59 @@ class ArrayTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, Arr::get_any( $input, $indexes, $default ) );
 	}
+
+	public function associative_arrays() {
+		return [
+			[ [], false ],
+			[ '', false ],
+			[ 'foo', false ],
+			[ 'foo,bar', false ],
+			[ new \stdClass(), false ],
+			[ [ 23, 89 ], false ],
+			[ [ 'foo' => 23, 'baz' => 89 ], true ],
+			[ [ 'foo' => 23 ], true ],
+			[ [ 'foo' => '' ], true ],
+			[ [ '0' => '', '1' => 'bar' ], false ],
+			[ [ 0 => '', 1 => 'bar', 5 => 'baz' ], false ],
+		];
+	}
+
+	/**
+	 * It should correctly mark associative arrays
+	 *
+	 * @test
+	 *
+	 * @dataProvider associative_arrays
+	 */
+	public function should_correctly_mark_associative_arrays( $arr, $is_assoc ) {
+		$this->assertEquals( $is_assoc, Arr::is_associative( $arr ) );
+	}
+
+	public function extract_values_input() {
+		return [
+			[ [], [] ],
+			[ [ '' ], [ '' ] ],
+			[ [ '', 'foo' ], [ '', 'foo' ] ],
+			[ [ '', 'foo' => 'bar' ], [ '', 'bar' ] ],
+			[ [ 'foo' => 'bar', 'baz' => 23 ], [ 'bar', 23 ] ],
+			[ [ 'foo' => [ 'bar' ], 'baz' => 23 ], [ 'bar', 23 ] ],
+			[ [ 'foo' => [ 'bar' ], 'baz' => [ 23 ] ], [ 'bar', 23 ] ],
+			[ [ 'foo' => [ 'bar', 89 ], 'baz' => [ 23 ] ], [ 'bar', 89, 23 ] ],
+			[ [ 'foo' => [ 'bar', 89 ], 'baz' => [ 23, 54 ] ], [ 'bar', 89, 23, 54 ] ],
+			[ [ 'foo' => 'bar', 'baz' => [ 23, 54 ] ], [ 'bar', 23, 54 ] ],
+			// one level deep
+			[ [ 'foo' => 'bar', 'baz' => [ 'sub1' => 23, 'sub2' => 19 ] ], [ 'bar', 23, 19 ] ],
+			// two levels deep
+			[ [ 'foo' => 'bar', 'baz' => [ 'sub1' => [ 23, 89 ], 'sub2' => 19 ] ], [ 'bar', [ 23, 89 ], 19 ] ],
+		];
+	}
+
+	/**
+	 * Test extract_values
+	 *
+	 * @dataProvider extract_values_input
+	 */
+	public function test_extract_values( $input, $expected ) {
+		$this->assertEquals( $expected, \Tribe__Utils__Array::extract_values( $input ) );
+	}
 }


### PR DESCRIPTION
Ticket: n/a

This PR adds the `is_associative`, `arrayize` and `extract_values` methods to the array Utils class. See tests to understand what they do.