### PR TITLE
Add filters to allow customization on countries names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@
 * Tweak - Added the `Tribe__Process__Post_Thumbnail_Setter` class to handle post thumbnail download and creation in an asynchronous manner [102323]
 * Tweak - Deprecated the `Tribe__Main::doing_ajax()` method and moved it to the `Tribe__Context::doing_ajax()` method [102323]
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
-* Tweak - Add new filters: `tribe_common_countries` and `tribe_common_us_states` to allow easier extensibility on the names used for each country [79880]
+* Tweak - Add new filters: `tribe_countries` and `tribe_us_states` to allow easier extensibility on the names used for each country [79880]
 
 = [4.7.10] 2018-03-28 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,12 +6,15 @@
 
 * Fix - Restore "type" attribute to some inline `<script>` tags to ensure proper character encoding in Customizer-generated CSS [103167]
 * Tweak - Allow to register the same ID of a post if has multiple types for JSON-LD `<script>` tag [94989]
-* Tweak - Adjusted app shop text in relation to Modern Tribe's ticketing solutions [101655]
-* Tweak - Added wrapper function around use of `tribe_events_get_the_excerpt` for safety [95034]
 * Tweak - Added the `a5hleyrich/wp-background-processing` package and the asynchronous process handling base [102323]
 * Tweak - Added the `Tribe__Process__Post_Thumbnail_Setter` class to handle post thumbnail download and creation in an asynchronous manner [102323]
 * Tweak - Deprecated the `Tribe__Main::doing_ajax()` method and moved it to the `Tribe__Context::doing_ajax()` method [102323]
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
+
+= [4.7.10] 2018-03-28 =
+
+* Tweak - Adjusted app shop text in relation to Modern Tribe's ticketing solutions [101655]
+* Tweak - Added wrapper function around use of `tribe_events_get_the_excerpt` for safety [95034]
 
 = [4.7.9] 2018-03-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,7 @@
 * Tweak - Added the `Tribe__Process__Post_Thumbnail_Setter` class to handle post thumbnail download and creation in an asynchronous manner [102323]
 * Tweak - Deprecated the `Tribe__Main::doing_ajax()` method and moved it to the `Tribe__Context::doing_ajax()` method [102323]
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
+* Tweak - Add new filters: `tribe_common_countries` and `tribe_common_us_states` to allow easier extensibility on the names used for each country [79880]
 
 = [4.7.10] 2018-03-28 =
 

--- a/src/Tribe/Languages/Locations.php
+++ b/src/Tribe/Languages/Locations.php
@@ -300,7 +300,14 @@ class Tribe__Languages__Locations {
 		// Perform a natural sort, ensures the countries are in the expected order even once translated.
 		natsort( $countries );
 
-		return $countries;
+		/**
+		 * Filter that allows to change the list and the output of the countries names.
+		 *
+		 * @since TBD
+		 *
+		 * @param array associative array with: Country Code => Country Name
+		 */
+		return (array) apply_filters( 'tribe_common_countries', $countries );
 	}
 
 	/**
@@ -370,6 +377,13 @@ class Tribe__Languages__Locations {
 		// Perform a natural sort, ensures the states are in the expected order even once translated.
 		natsort( $states );
 
-		return $states;
+		/**
+		 * Filter that allows to change the names of US states before output.
+		 *
+		 * @since TBD
+		 *
+		 * @param array Associative array with the format: State Code => State Name
+		 */
+		return (array) apply_filters( 'tribe_common_us_states', $states );
 	}
 }

--- a/src/Tribe/Languages/Locations.php
+++ b/src/Tribe/Languages/Locations.php
@@ -307,7 +307,7 @@ class Tribe__Languages__Locations {
 		 *
 		 * @param array associative array with: Country Code => Country Name
 		 */
-		return (array) apply_filters( 'tribe_common_countries', $countries );
+		return (array) apply_filters( 'tribe_countries', $countries );
 	}
 
 	/**
@@ -384,6 +384,6 @@ class Tribe__Languages__Locations {
 		 *
 		 * @param array Associative array with the format: State Code => State Name
 		 */
-		return (array) apply_filters( 'tribe_common_us_states', $states );
+		return (array) apply_filters( 'tribe_us_states', $states );
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/79880

First step in a series of making sure users can have multiple customization
on the names specially on the country names as they can be named different
or they might have multiple names know as "local names".