### PR TITLE
Add more comprehensive Timezones::abbr() support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,7 @@
 * Tweak - Deprecated the `Tribe__Main::doing_ajax()` method and moved it to the `Tribe__Context::doing_ajax()` method [102323]
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
 * Tweak - Add new filters: `tribe_countries` and `tribe_us_states` to allow easier extensibility on the names used for each country [79880]
+* Fix - Updated Timezones::abbr() with additional support for timezone strings not covered by PHP date format "T" [102705]
 
 = [4.7.10] 2018-03-28 =
 

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -96,8 +96,6 @@ class Tribe__Timezones {
 	 * @return string
 	 */
 	public static function abbr( $date, $timezone_string ) {
-		$abbr = '';
-
 		try {
 			$abbr = date_create( $date, new DateTimeZone( $timezone_string ) )->format( 'T' );
 
@@ -113,7 +111,7 @@ class Tribe__Timezones {
 				}
 			}
 		} catch ( Exception $e ) {
-			// Do nothing
+			$abbr = '';
 		}
 
 		return $abbr;

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -99,6 +99,7 @@ class Tribe__Timezones {
 		try {
 			$abbr = date_create( $date, new DateTimeZone( $timezone_string ) )->format( 'T' );
 
+			// If PHP date "T" format is a -03 or +03, it's a bugged abbreviation, we can find it manually.
 			if ( 0 === strpos( $abbr, '-' ) || 0 === strpos( $abbr, '+' ) ) {
 				$abbreviations = timezone_abbreviations_list();
 

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -96,12 +96,27 @@ class Tribe__Timezones {
 	 * @return string
 	 */
 	public static function abbr( $date, $timezone_string ) {
+		$abbr = '';
+
 		try {
-			return date_create( $date, new DateTimeZone( $timezone_string ) )->format( 'T' );
+			$abbr = date_create( $date, new DateTimeZone( $timezone_string ) )->format( 'T' );
+
+			if ( 0 === strpos( $abbr, '-' ) || 0 === strpos( $abbr, '+' ) ) {
+				$abbreviations = timezone_abbreviations_list();
+
+				foreach ( $abbreviations as $abbreviation => $timezones ) {
+					foreach ( $timezones as $timezone ) {
+						if ( $timezone['timezone_id'] === $timezone_string ) {
+							return strtoupper( $abbreviation );
+						}
+					}
+				}
+			}
+		} catch ( Exception $e ) {
+			// Do nothing
 		}
-		catch ( Exception $e ) {
-			return '';
-		}
+
+		return $abbr;
 	}
 
 	/**


### PR DESCRIPTION
https://central.tri.be/issues/102705

Format T is bugged in PHP for certain timezones. Oddly enough, timezone_abbreviations_list() in PHP does have the right abbreviation for the timezone in question.