### PR TITLE
Add `tribe_set_time_limit()` wrapper function to prevent errors/warnings.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * Tweak - Added the `Tribe__Process__Queue` class to handle background processing operations
 * Tweak - Changed 'forums' for 'help desk' in the Help content [104561]
 * Tweak - Updated datatables.js to most recent version, to prevent conflicts [102465]
+* Tweak - Add `tribe_set_time_limit()` wrapper function to prevent errors from `set_time_limit()`.
 
 = [4.7.11] 2018-04-18 =
 

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -704,3 +704,22 @@ if ( ! function_exists( 'tribe_is_frontend' ) ) {
 		return (bool) apply_filters( 'tribe_doing_frontend', false );
 	}
 }
+
+if ( ! function_exists( 'tribe_set_time_limit' ) ) {
+	/**
+	 * Wrapper for set_time_limit to suppress errors
+	 *
+	 * @since 4.7.12
+	 *
+	 * @param int $limit Time limit.
+	 */
+	function tribe_set_time_limit( $limit = 0 ) {
+		if (
+			function_exists( 'set_time_limit' )
+			&& false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' )
+			&& ! ini_get( 'safe_mode' )
+		) {
+			@set_time_limit( $limit );
+		}
+	}
+}


### PR DESCRIPTION
https://central.tri.be/issues/64183

Add `tribe_set_time_limit()` wrapper function to prevent errors from `set_time_limit()`.