### PR TITLE
Adjust the `Tribe__PUE__Checker` $stats creation regarding WordPress multisite installs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.7.13] TBD =
+
+* Fix - Adjust the `Tribe__PUE__Checker` $stats creation regarding WordPress multisite installs [84231]
+
 = [4.7.12] 2018-05-09 =
 
 * Fix - Updated datatables.js to its most recent version to prevent conflicts [102465]

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -682,9 +682,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 						AND `deleted` = '0'
 				";
 
-				$stats['multisite']         = 1;
-				$stats['network_activated'] = (int) $this->is_plugin_active_for_network();
-				$stats['active_sites']      = (int) $wpdb->get_var( $sql_count );
+				$stats['network']['multisite']         = 1;
+				$stats['network']['network_activated'] = (int) $this->is_plugin_active_for_network();
+				$stats['network']['active_sites']      = (int) $wpdb->get_var( $sql_count );
 			}
 
 			self::$stats = $stats;


### PR DESCRIPTION
https://central.tri.be/issues/84231

Be sure to initialize and send the correct $stats to PUE