### PR TITLE
Fix PHP warning in Help page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 == Changelog ==
 
 = [4.7.16] TBD =
-
+* Fix - Fixed a PHP warning related to the RSS feed in the Help page [108398]
 
 = [4.7.15] 2018-06-04 =
 * Add - Method to parse the Global ID string [104379]

--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -346,7 +346,7 @@ class Tribe__Admin__Help_Page {
 			 */
 			$maxitems  = $news_rss->get_item_quantity( apply_filters( 'tribe_help_rss_max_items', 5 ) );
 			$rss_items = $news_rss->get_items( 0, $maxitems );
-			if ( count( $maxitems ) > 0 ) {
+			if ( $maxitems > 0 ) {
 				foreach ( $rss_items as $item ) {
 					$item        = array(
 						'title' => esc_html( $item->get_title() ),


### PR DESCRIPTION
https://central.tri.be/issues/108398

We were using count with an int as a parameter. Not sure why this issue didn't surface earlier.