### PR TITLE
Change how we handle uc_first_letter()

### DIFF
--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -88,7 +88,7 @@ class Tribe__Utils__Post_Root_Pool {
 	 * @return string
 	 */
 	protected function uc_first_letter( $string ) {
-		return is_numeric( $string ) ? $string : strtoupper( $string[0] );
+		return is_numeric( $string ) ? $string : mb_strtoupper( $string[0], mb_detect_encoding( $string[0] ) );
 	}
 
 	/**


### PR DESCRIPTION
🎫 https://central.tri.be/issues/70379

Allows for international characters in ticket ID (sku)

related: https://github.com/moderntribe/event-tickets/pull/784
https://github.com/moderntribe/event-tickets-plus/pull/580