### PR TITLE
Handle the case where post_date and post_date_gmt are not coherent

### DIFF
--- a/src/Tribe/Change_Authority/Post_Base.php
+++ b/src/Tribe/Change_Authority/Post_Base.php
@@ -266,6 +266,17 @@ abstract class Tribe__Change_Authority__Post_Base extends Tribe__Change_Authorit
 			return $result;
 		}
 
+		/**
+		 * If `post_date` and `post_date_gmt` both are set we assume the farthest away of the two is correct.
+		 */
+		if ( isset( $this->batched_post_fields['post_date'], $this->batched_post_fields['post_date_gmt'] ) ) {
+			if ( get_gmt_from_date( $this->batched_post_fields['post_date'] ) < $this->batched_post_fields['post_date_gmt'] ) {
+				unset( $this->batched_post_fields['post_date'] );
+			} else {
+				unset( $this->batched_post_fields['post_date_gmt'] );
+			}
+		}
+
 		$post_updated = (bool) wp_update_post( $this->batched_post_fields );
 
 		// remove some "utility" variables


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/103828

When propagating post fields `post_date` and `post_date_gmt` might both be set but be discordant.
In that case let's use the farthest one.