### PR TITLE
Try to handle urlencoded strings

### DIFF
--- a/src/Tribe/Utils/Post_Root_Pool.php
+++ b/src/Tribe/Utils/Post_Root_Pool.php
@@ -38,6 +38,9 @@ class Tribe__Utils__Post_Root_Pool {
 	public function generate_unique_root( WP_Post $post ) {
 		$post_name = $post->post_name;
 
+		// A lot fo these get urlencoded, so let's try to fix that first
+		$post_name = tribe_maybe_urldecode( $post_name );
+
 		$this->current_post = $post;
 		$flipped_pool       = array_flip( $this->fetch_pool() );
 

--- a/src/functions/multibyte.php
+++ b/src/functions/multibyte.php
@@ -21,6 +21,27 @@ if ( ! function_exists( 'tribe_detect_encoding' ) ) {
 	}
 }
 
+if ( ! function_exists( 'tribe_maybe_urldecode' ) ) {
+	/**
+	 * Detects urlencoded strings if the function is available, and converts them.
+	 * Returns false if not able to detect
+	 * @since TBD
+	 *
+	 * @param  string       $string the string to detect encoding of
+	 * @return string|bool         the urldecoded string
+	 *          the original string if the function is not available or the encoding cannot be determined
+	 */
+	function tribe_maybe_urldecode( $string ) {
+		$encoding = function_exists( 'mb_detect_encoding' ) ? mb_detect_encoding( $string ) : $string;
+
+		if ( 'ASCII' === $encoding ) {
+			return urldecode( $string );
+		}
+
+		return $string;
+	}
+}
+
 if ( ! function_exists( 'tribe_strlen' ) ) {
 	/**
 	 * Get the length of a string, uses mb_strlen when available
@@ -32,6 +53,7 @@ if ( ! function_exists( 'tribe_strlen' ) ) {
 	function tribe_strlen( $string ) {
 		if ( function_exists( 'mb_strlen' ) ) {
 			$encoding = tribe_detect_encoding( $string );
+			$string = tribe_maybe_urldecode( $string );
 			// we test for encoding and pass it if we get it
 			if ( $encoding ) {
 				return mb_strlen( $string, $encoding );
@@ -80,6 +102,7 @@ if ( ! function_exists( 'tribe_strtoupper' ) ) {
 
 		if ( function_exists( 'mb_strtoupper' ) ) {
 			$encoding = tribe_detect_encoding( $string );
+			$string = tribe_maybe_urldecode( $string );
 			// we test for encoding and pass it if we get it
 			if ( $encoding ) {
 				return mb_strtoupper( $string, $encoding );
@@ -108,6 +131,7 @@ if ( ! function_exists( 'tribe_strtolower' ) ) {
 
 		if ( function_exists( 'mb_strtolower' ) ) {
 			$encoding = tribe_detect_encoding( $string );
+			$string = tribe_maybe_urldecode( $string );
 			// we test for encoding and pass it if we get it
 			if ( $encoding ) {
 				return mb_strtolower( $string, $encoding );


### PR DESCRIPTION
🎫 https://central.tri.be/issues/70379

In the process of stripping down the PR earlier, I removed the `urldecode` functionality - added it back.