### PR TITLE
Change render method's return parameter to false

### DIFF
--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -329,7 +329,7 @@ class Tribe__PUE__Notices {
 				<div class="notice-content">' . $inner_html . '</div>
 			</div>';
 
-		Tribe__Admin__Notices::instance()->render( $slug, $html );
+		Tribe__Admin__Notices::instance()->render( $slug, $html, false );
 	}
 
 	/**


### PR DESCRIPTION
## M18.14

Looks like we can get this merged as part of Maintenance Release 14. Thanks a ton, tryann0us!

I will submit another PR to add a readme entry for this.

**Ticket:** [**⌗113660**](http://central.tri.be/issues/113660)

---

`render_notice()` gets called from i.a. `render_invalid_key()`:
https://github.com/moderntribe/tribe-common/blob/6129187cd3d28d5c35f373ca1a85c52641ac9e2b/src/Tribe/PUE/Notices.php#L248

`render_invalid_key()` gets called here:
https://github.com/moderntribe/tribe-common/blob/6129187cd3d28d5c35f373ca1a85c52641ac9e2b/src/Tribe/Admin/Notices.php#L134

which translates to (pseudo code):
`add_action('admin_notices', 'render_invalid_key', 10);`.

Since `add_action('admin_notices', function() {});` expects the callback to `echo` something (see https://codex.wordpress.org/Plugin_API/Action_Reference/admin_notices),
https://github.com/moderntribe/tribe-common/blob/6129187cd3d28d5c35f373ca1a85c52641ac9e2b/src/Tribe/PUE/Notices.php#L332
should have `$return` parameter set to `false`. Otherwise the notice will never be printed.

_At least this is what I had to change to show the "invalid key" notice._