### PR TITLE
Add a method to delete all queues of a class

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.7.19] TBD =
 * Fix - Add the following datepicker formats to the validation script: YYYY.MM.DD, MM.DD.YYYY, DD.MM.YYYY [102815]
+* Add - Added the `Tribe__Process__Queue::delete_all_queues` method [111856]
 
 = [4.7.18] 2018-08-01 =
 * Fix - Add `target="_blank"` to repository links in the Help Page [107974]

--- a/src/Tribe/Process/Queue.php
+++ b/src/Tribe/Process/Queue.php
@@ -173,6 +173,48 @@ abstract class Tribe__Process__Queue extends WP_Background_Process {
 	}
 
 	/**
+	 * Deletes all queues for a specific action.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $action The action (prefix) of the queues to delete.
+	 *
+	 * @return int The number of delete queues.
+	 */
+	public static function delete_all_queues( $action ) {
+		global $wpdb;
+
+		$table  = $wpdb->options;
+		$column = 'option_name';
+
+		if ( is_multisite() ) {
+			$table  = $wpdb->sitemeta;
+			$column = 'meta_key';
+		}
+
+		$action = $wpdb->esc_like( 'tribe_queue_' . $action ) . '%';
+
+		$queues = $wpdb->get_col( $wpdb->prepare( "
+			SELECT DISTINCT({$column})
+			FROM {$table}
+			WHERE {$column} LIKE %s
+		", $action ) );
+
+		if ( empty( $queues ) ) {
+			return 0;
+		}
+
+		$deleted = 0;
+
+		foreach ( $queues as $queue ) {
+			$deleted ++;
+			self::delete_queue( $queue );
+		}
+
+		return $deleted;
+	}
+
+	/**
 	 * {@inheritdoc}
 	 */
 	public function delete( $key ) {

--- a/tests/wpunit/Tribe/Process/QueueTest.php
+++ b/tests/wpunit/Tribe/Process/QueueTest.php
@@ -274,4 +274,26 @@ class QueueTest extends WPTestCase {
 		wp_cache_flush();
 		$this->assertEmpty( get_option( $sut->get_id() ) );
 	}
+
+	/**
+	 * It should allow deleting queues of a specific action
+	 *
+	 * @test
+	 */
+	public function should_allow_deleting_queues_of_a_specific_action() {
+		$action = 'dummy_queue';
+
+		$this->assertEquals( 0, Queue::delete_all_queues( $action ) );
+
+		$this->make_instance()->push_to_queue( [ 'foo' => 'bar' ] )->save();
+
+		$this->assertEquals( 1, Queue::delete_all_queues( $action ) );
+
+		$this->make_instance()->push_to_queue( [ 'foo' => 'bar' ] )->save();
+		$this->make_instance()->push_to_queue( [ 'foo' => 'bar' ] )->save();
+		$this->make_instance()->push_to_queue( [ 'foo' => 'bar' ] )->save();
+
+		$this->assertEquals( 0, Queue::delete_all_queues( 'not-dummy' ) );
+		$this->assertEquals( 3, Queue::delete_all_queues( $action ) );
+	}
 }


### PR DESCRIPTION
Ticket:  https://central.tri.be/issues/111856

This PR adds the `Tribe__Process__Queue::delete_all_queues` method to allow deleting all queues of a class.
E.g. if a queue class has an `action` of `some_queue` then:
```php
Tribe__Process__Queue::delete_all_queues( 'some_queue' );
```
will delete all the queues of that class no matter their state.