### PR TITLE
Extend the Tracker functionalities

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,7 @@
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
 * Tweak - Add new filters: `tribe_countries` and `tribe_us_states` to allow easier extensibility on the names used for each country [79880]
 * Fix - Updated Timezones::abbr() with additional support for timezone strings not covered by PHP date format "T" [102705]
+* Tweak - Make sure taxonomy term deletions are tracked [112035]
 
 = [4.7.10] 2018-03-28 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,8 @@
 * Tweak - Modified the `select2` implementation to work with the `maximumSelectionSize` argument via data attribute. [103577]
 * Tweak - Add new filters: `tribe_countries` and `tribe_us_states` to allow easier extensibility on the names used for each country [79880]
 * Fix - Updated Timezones::abbr() with additional support for timezone strings not covered by PHP date format "T" [102705]
-* Tweak - Make sure taxonomy term deletions are tracked [112035]
+* Tweak - Make sure taxonomy term deletions are tracked by `Tribe__Tracker` [112035]
+* Tweak - Track and update linked posts in `Tribe__Tracker` [112035]
 
 = [4.7.10] 2018-03-28 =
 

--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -672,12 +672,10 @@ class Tribe__Tracker {
 	 */
 	public function unhook() {
 		remove_filter( 'update_post_metadata', array( $this, 'filter_watch_updated_meta' ), PHP_INT_MAX - 1 );
-		remove_action( 'removeed_post_meta', array( $this, 'register_removeed_deleted_meta' ), PHP_INT_MAX - 1 );
-		remove_action( 'delete_post_meta', array( $this, 'register_removeed_deleted_meta' ), PHP_INT_MAX - 1 );
+		remove_action( 'added_post_meta', array( $this, 'register_added_deleted_meta' ), PHP_INT_MAX - 1 );
+		remove_action( 'delete_post_meta', array( $this, 'register_added_deleted_meta' ), PHP_INT_MAX - 1 );
 		remove_action( 'post_updated', array( $this, 'filter_watch_post_fields' ), 10 );
 		remove_action( 'set_object_terms', array( $this, 'track_taxonomy_term_changes' ), 10 );
 		remove_action( 'delete_term_relationships', array( $this, 'track_taxonomy_term_deletions' ), 10 );
-		remove_action( 'post_updated', array( $this, 'on_post_updated' ) );
-		remove_action( 'delete_post', array( $this, 'on_delete_post' ) );
 	}
 }

--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -671,12 +671,12 @@ class Tribe__Tracker {
 	 * @since TBD
 	 */
 	public function unhook() {
-		remove_filter( 'update_post_metadata', array( $this, 'filter_watch_updated_meta' ), PHP_INT_MAX - 1);
+		remove_filter( 'update_post_metadata', array( $this, 'filter_watch_updated_meta' ), PHP_INT_MAX - 1 );
 		remove_action( 'removeed_post_meta', array( $this, 'register_removeed_deleted_meta' ), PHP_INT_MAX - 1 );
 		remove_action( 'delete_post_meta', array( $this, 'register_removeed_deleted_meta' ), PHP_INT_MAX - 1 );
-		remove_action( 'post_updated', array( $this, 'filter_watch_post_fields' ), 10);
-		remove_action( 'set_object_terms', array( $this, 'track_taxonomy_term_changes' ), 10);
-		remove_action( 'delete_term_relationships', array( $this, 'track_taxonomy_term_deletions' ), 10);
+		remove_action( 'post_updated', array( $this, 'filter_watch_post_fields' ), 10 );
+		remove_action( 'set_object_terms', array( $this, 'track_taxonomy_term_changes' ), 10 );
+		remove_action( 'delete_term_relationships', array( $this, 'track_taxonomy_term_deletions' ), 10 );
 		remove_action( 'post_updated', array( $this, 'on_post_updated' ) );
 		remove_action( 'delete_post', array( $this, 'on_delete_post' ) );
 	}

--- a/tests/wpunit/Tribe/TrackerTest.php
+++ b/tests/wpunit/Tribe/TrackerTest.php
@@ -207,6 +207,26 @@ class TrackerTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * It should track term removals
+	 *
+	 * @test
+	 */
+	public function should_track_term_removals() {
+		$object       = $this->factory()->user->create();
+		$original_mod = time() - HOUR_IN_SECONDS;
+		update_post_meta( $object, Tracker::$field_key, [ 'post_tag' => $original_mod ] );
+		$this->factory()->tag->create_and_get( [ 'name' => 'foo' ] );
+		$this->factory()->tag->create_and_get( [ 'name' => 'bar' ] );
+
+		$sut = $this->make_instance();
+		$sut->set_tracked_post_types( [ 'post' ] );
+		$sut->set_tracked_taxonomies( [ 'post_tag' ] );
+		$exit = $sut->track_taxonomy_term_deletions( $object, $tt_ids, 'post_tag' );
+
+		$this->assertTrue( $exit );
+	}
+
+	/**
 	 * @return Tracker
 	 */
 	protected function make_instance() {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/112035

This PR updates the Tracker (and its tests) to add:
* term deletion tracking - this was missing, no idea why
* linking post tracking - when A, post of type `a`, linked by B, post of type `b`, is updated then not only update A but also update B 
* some refinements - cleanup and renamed some methods firing on actions to `on_<action>`