### PR TITLE
update providers to OpenAPI 3.0 standard

### DIFF
--- a/src/Tribe/Documentation/Swagger/Image_Definition_Provider.php
+++ b/src/Tribe/Documentation/Swagger/Image_Definition_Provider.php
@@ -19,30 +19,33 @@ class Tribe__Documentation__Swagger__Image_Definition_Provider
 		$documentation = array(
 			'type'       => 'object',
 			'properties' => array(
-				'url' => array(
-					'type' =>'string',
-					'description' =>__('The URL to the full size version of the image', 'tribe-common'),
+				'url'       => array(
+					'type'        => 'string',
+					'format'      => 'uri',
+					'description' => __( 'The URL to the full size version of the image', 'tribe-common' ),
 				),
-				'id' => array(
-					'type' => 'integer',
+				'id'        => array(
+					'type'        => 'integer',
 					'description' => __( 'The image WordPress post ID', 'tribe-common' ),
 				),
 				'extension' => array(
-					'type' =>'string',
-					'description' =>__('The image file extension', 'tribe-common'),
+					'type'        => 'string',
+					'description' => __( 'The image file extension', 'tribe-common' ),
 				),
-				'width' => array(
-					'type' => 'integer',
+				'width'     => array(
+					'type'        => 'integer',
 					'description' => __( 'The image natural width in pixels', 'tribe-common' ),
 				),
-				'height' => array(
-					'type' => 'integer',
+				'height'    => array(
+					'type'        => 'integer',
 					'description' => __( 'The image natural height in pixels', 'tribe-common' ),
 				),
-				'sizes' => array(
-					'type' => 'array',
+				'sizes'     => array(
+					'type'        => 'array',
 					'description' => __( 'The details about each size available for the image', 'tribe-common' ),
-					'$ref' => '#/definitions/ImageSize',
+					'items'       => array(
+						'$ref' => '#/components/schemas/ImageSize',
+					),
 				),
 			),
 		);

--- a/src/Tribe/Documentation/Swagger/Image_Size_Definition_Provider.php
+++ b/src/Tribe/Documentation/Swagger/Image_Size_Definition_Provider.php
@@ -33,6 +33,7 @@ class Tribe__Documentation__Swagger__Image_Size_Definition_Provider
 				),
 				'url' => array(
 					'type' => 'string',
+					'format' => 'uri',
 					'description' => __( 'The link to the image in the specified size on the site', 'tribe-common' ),
 				),
 			),


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/108024
* https://central.tri.be/issues/109710

This PR updates the /doc endoint code to make sure it will produce valid Open API 3.0 endpoint descriptions