### PR TITLE
Do not use the network key if the plugin is not network active

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -816,18 +816,19 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$license_key    = '';
 			$license_origin = 'm';
 
-			if ( ( 'network' === $type || 'any' === $type ) && is_multisite() ) {
-				$license_key = get_network_option( null, $this->pue_install_key, '' );
-			}
-
 			/*
 			 * Even if we have a network key if the plugin is not active on the network then it should
 			 * not be used.
 			 */
 			if (
-				( 'local' === $type || 'any' === $type )
-				&& ( empty( $license_key ) || ! $this->is_plugin_active_for_network() )
+				( 'network' === $type || 'any' === $type )
+				&& is_multisite()
+				&& $this->is_plugin_active_for_network()
 			) {
+				$license_key = get_network_option( null, $this->pue_install_key, '' );
+			}
+
+			if ( ( 'local' === $type || 'any' === $type ) && empty( $license_key ) ) {
 				$license_key = get_option( $this->pue_install_key, '' );
 			}
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -820,7 +820,14 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$license_key = get_network_option( null, $this->pue_install_key, '' );
 			}
 
-			if ( empty( $license_key ) && ( 'local' === $type || 'any' === $type ) ) {
+			/*
+			 * Even if we have a network key if the plugin is not active on the network then it should
+			 * not be used.
+			 */
+			if (
+				( 'local' === $type || 'any' === $type )
+				&& ( empty( $license_key ) || ! $this->is_plugin_active_for_network() )
+			) {
 				$license_key = get_option( $this->pue_install_key, '' );
 			}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/114170

This PR modifies the method that retrieves the PUE key for a plugin adding a check to make sure the network key, if available, will be used only if the plugin is active for the whole network.