### PR TITLE
Update WPRest function and toMoment function

### DIFF
--- a/src/modules/utils/api.js
+++ b/src/modules/utils/api.js
@@ -41,10 +41,16 @@ export const wpREST = async ( params ) => {
 			headers,
 		} );
 
+		let data = {};
+
 		if ( response.ok ) {
-			return await response.json();
+			data = await response.json();
 		}
-		throw new Error( 'Response was not completed correctly' );
+
+		return {
+			response,
+			data,
+		};
 	} catch ( e ) {
 		throw e;
 	}

--- a/src/modules/utils/moment.js
+++ b/src/modules/utils/moment.js
@@ -112,13 +112,14 @@ export const parseFormats = ( date, formats = [ dateUtil.FORMATS.DATABASE.dateti
  *
  * @param {(Date|moment|string)} date The date to be converted.
  * @param {string} format The format of the data to be used
+ * @param {bool} Force the parse of the format default to true
  * @returns {moment} A moment object
  */
-export const toMoment = ( date, format = dateUtil.FORMATS.DATABASE.datetime ) => {
+export const toMoment = ( date, format = dateUtil.FORMATS.DATABASE.datetime, parseFormat = true ) => {
 	if ( date instanceof moment || date instanceof Date ) {
 		return moment( date );
 	} else if ( isString( date ) ) {
-		return moment( date, toFormat( format ) );
+		return moment( date, parseFormat ? toFormat( format ) : format );
 	}
 
 	return moment();


### PR DESCRIPTION
- Allow to access to the `response` of the API
- Allow skip of `toFormat` call into format

Ticket: https://central.tri.be/issues/117939