### PR TITLE
⌗116124 Only Invalidate Cache When Tribe Options are Updated

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 = [TBD] TBD =
 
 * Feature - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]
-* Fix - Adjust cache invalidation behavior so that the value `tribe_last_save_post` is only update on `save_post` of Event, Venue, and Organizer post types, and the updating of Tribe options [116124]
+* Fix - Adjust cache invalidation behavior so that the value of `tribe_last_save_post` is only update on `save_post` of Event, Venue, and Organizer post types, and the updating of Tribe options [116124]
 
 = [4.7.23] 2018-11-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,8 @@
 
 = [TBD] TBD =
 
-* Add - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]
+* Feature - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]
+* Fix - Adjust cache invalidation behavior so that the value `tribe_last_save_post` is only update on `save_post` of Event, Venue, and Organizer post types, and the updating of Tribe options [116124]
 
 = [4.7.23] 2018-11-13 =
 

--- a/src/Tribe/Cache_Listener.php
+++ b/src/Tribe/Cache_Listener.php
@@ -32,7 +32,7 @@
 		 */
 		private function add_hooks() {
 			add_action( 'save_post', array( $this, 'save_post' ), 0, 2 );
-			add_action( 'updated_option', array( $this, 'update_last_save_post' ) );
+			add_action( 'updated_option', array( $this, 'update_last_save_post' ), 10, 3 );
 		}
 
 		/**
@@ -50,11 +50,15 @@
 		/**
 		 * Run the caching functionality that is executed on saving tribe calendar options.
 		 *
-		 * @param string    $option
 		 * @see 'updated_option'
+		 *
+	     * @param string $option    Name of the updated option.
+	     * @param mixed  $old_value The old option value.
+	     * @param mixed  $value     The new option value.
 		 */
-		public function update_last_save_post( $option ) {
-			if ( $option != 'tribe_last_save_post' ) {
+		public function update_last_save_post( $option, $old_value, $value ) {
+
+			if ( $option === 'tribe_events_calendar_options' ) {
 				$this->cache->set_last_occurrence( 'save_post' );
 			}
 		}


### PR DESCRIPTION
**Ticket:** [**⌗116124**](http://central.tri.be/issues/116124)

**Related PR:** https://github.com/moderntribe/the-events-calendar/pull/2278

An initial pass at improving the cache invalidation on `tribe_last_save_post`.