### PR TITLE
Rreplace use of wp_doing_cron function with constant check

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -123,7 +123,7 @@ class Tribe__Context {
 		if ( null !== $doing_cron ) {
 			$this->doing_cron = (bool) $doing_cron;
 		} else {
-			$this->doing_cron = wp_doing_cron();
+			$this->doing_cron = defined( 'DOING_CRON' ) && DOING_CRON;
 		}
 
 		return $this->doing_cron;


### PR DESCRIPTION
Ticket: n/a

The `wp_doing_cron` function was introduced in WP 4.8 and that's above our min. requirements.