### PR TITLE
Allow repositories and decorators to get/set query controller

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1192,21 +1192,27 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				return $datetime instanceof DateTime ? clone $datetime : $datetime;
 			}
 
-			$utc = new DateTimeZone( 'UTC' );
-
-			if ( self::is_timestamp( $datetime ) ) {
-				// Timestamps timezone is always UTC.
-				return new DateTime( '@' . $datetime, $utc );
-			}
-
-			$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+			$timezone_object = null;
 
 			try {
 				// PHP 5.2 will not throw an exception but will generate an error.
+				$utc = new DateTimeZone( 'UTC' );
+
+				if ( self::is_timestamp( $datetime ) ) {
+					// Timestamps timezone is always UTC.
+					return new DateTime( '@' . $datetime, $utc );
+				}
+
+				$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+
 				set_error_handler( 'tribe_catch_and_throw' );
 				$date = new DateTime( $datetime, $timezone_object );
 				restore_error_handler();
 			} catch ( Exception $e ) {
+				if ( $timezone_object === null ) {
+					$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+				}
+
 				return $with_fallback
 					? new DateTime( 'now', $timezone_object )
 					: false;

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2255,9 +2255,20 @@ abstract class Tribe__Repository
 	 * {@inheritdoc}
 	 */
 	public function has_filter( $key, $value = null ) {
-		return null === $value
-			? array_key_exists( $key, $this->current_filters )
-			: array_key_exists( $key, $this->current_filters ) && $this->current_filters[ $key ] === $value;
+		$args   = func_get_args();
+		$values = array_slice( $args, 1 );
+
+		if ( null === $value ) {
+			// We just want to check if a filter is applied.
+			return array_key_exists( $key, $this->current_filters );
+		}
+
+		// We check if the filter exists and the arguments match; inline to prevent "Undefined index" errors.
+		return array_key_exists( $key, $this->current_filters ) && array_slice(
+			$this->current_filters[ $key ],
+			0,
+			min( count( $this->current_filters[ $key ] ), count( $values ) )
+		) === $values;
 	}
 
 	/**

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -4,13 +4,6 @@ abstract class Tribe__Repository
 	implements Tribe__Repository__Interface {
 
 	/**
-	 * A list of query controllers in the shape [ { query: <WP_Query>, controller: <Repository> }, ... ].
-	 *
-	 * @var array
-	 */
-	protected static $controllers;
-
-	/**
 	 * @var  array An array of keys that cannot be updated on this repository.
 	 */
 	protected static $blocked_keys = array(
@@ -535,7 +528,7 @@ abstract class Tribe__Repository
 		if ( $use_query_builder && null !== $this->query_builder ) {
 			$built = $this->query_builder->build_query();
 
-			self::set_query_controller( $this->query_builder, $built );
+			$built->builder = $this->query_builder;
 
 			if ( null !== $built ) {
 				return $built;
@@ -544,7 +537,7 @@ abstract class Tribe__Repository
 
 		$query = new WP_Query();
 
-		self::set_query_controller( $this, $query );
+		$query->builder = $this;
 
 		$this->filter_query->set_query( $query );
 
@@ -1010,7 +1003,7 @@ abstract class Tribe__Repository
 
 		$call_args = func_get_args();
 
-		$this->current_filters[ $key ] = $value;
+		$this->current_filters[ $key ] = array_slice( $call_args, 1 );
 
 		try {
 			// Set current filter as which one we are running.
@@ -2888,37 +2881,5 @@ abstract class Tribe__Repository
 		$query->current_post = - 1;
 
 		return $query;
-	}
-
-	/**
-	 * Returns a query controller repository if any.
-	 *
-	 * This method is useful to track the repository instance that generated a query.
-	 *
-	 * @since  TBD
-	 *
-	 * @param \WP_Query $query The query to fetch the controller for.
-	 *
-	 * @return Tribe__Repository__Interface|null The query controller repository if any.
-	 */
-	public static function get_query_controller( WP_Query $query ) {
-		$exists = array_key_exists( spl_object_hash( $query ), self::$controllers );
-
-		return $exists ? self::$controllers[ $exists ]['controller'] : null;
-	}
-
-	/**
-	 * Sets a repository as the controller of a specific query.
-	 *
-	 * @since TBD
-	 *
-	 * @param Tribe__Repository__Interface $repository The repository controlling the query.
-	 * @param WP_Query $wp_query The controlled query.
-	 */
-	public static function set_query_controller( Tribe__Repository__Interface $repository, WP_Query $wp_query ) {
-		self::$controllers[ spl_object_hash( $wp_query ) ] = [
-			'query'      => $wp_query,
-			'controller' => $repository,
-		];
 	}
 }

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -527,12 +527,12 @@ abstract class Tribe__Repository
 	/**
 	 * {@inheritdoc}
 	 */
-	public function build_query() {
+	public function build_query( $use_query_builder = true ) {
 		/**
 		 * Allow classes extending or decorating the repository to act before
 		 * the query is built or replace its building completely.
 		 */
-		if ( null !== $this->query_builder ) {
+		if ( $use_query_builder && null !== $this->query_builder ) {
 			$built = $this->query_builder->build_query();
 
 			self::set_query_controller( $this->query_builder, $built );

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -311,8 +311,8 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	/**
 	 * {@inheritdoc}
 	 */
-	public function build_query() {
-		return $this->decorated->build_query();
+	public function build_query( $use_query_builder = true ) {
+		return $this->decorated->build_query( $use_query_builder );
 	}
 
 	/**

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -502,4 +502,34 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	public function get_query_for_posts( array $posts ) {
 		return $this->decorated->get_query_for_posts( $posts );
 	}
+
+	/**
+	 * Whether the decorator is decorating an instance of a specific repository class or not.
+	 *
+	 * The check is made recursively for decorators to get to the first repository implementation.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $class The class to check for.
+	 *
+	 * @return bool Whether the decorator is decorating an instance of a specific repository class or not.
+	 */
+	public function decorates_an_instance_of( $class ) {
+		return $this->decorated instanceof Tribe__Repository__Decorator
+			? $this->decorated->decorates_an_instance_of( $class )
+			: $this->decorated instanceof $class;
+	}
+
+	/**
+	 * Returns the concrete repository implementation that's "hidden" under the decorator(s).
+	 *
+	 * @since TBD
+	 *
+	 * @return \Tribe__Repository__Interface The concrete repository instance.
+	 */
+	public function get_decorated_repository() {
+		return $this->decorated instanceof Tribe__Repository__Decorator
+			? $this->decorated->get_decorated_repository()
+			: $this->decorated;
+	}
 }

--- a/src/Tribe/Repository/Interface.php
+++ b/src/Tribe/Repository/Interface.php
@@ -67,9 +67,11 @@ interface Tribe__Repository__Interface
 	 *
 	 * @since 4.7.19
 	 *
+	 * @param bool $use_query_builder Whether to use the query builder, if set, or not.
+	 *
 	 * @return WP_Query
 	 */
-	public function build_query();
+	public function build_query( $use_query_builder = true );
 
 	/**
 	 * Adds a custom JOIN clause to the query.


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/118240

This PR adds the `Repository::set_query_controller` and `Repository::get_query_controller` to allow any code to get/set the repository (or decorator) that's controlling a `WP_Query` instance.
While not fully used in the code in other branches the idea behind it is to be able to get a repository from a query and call its methods to perform tasks.