### PR TITLE
Fix tec global

### DIFF
--- a/src/modules/utils/globals.js
+++ b/src/modules/utils/globals.js
@@ -18,7 +18,7 @@ export const list = () => ( {
 } );
 
 // TEC
-export const tec = () => config().tec || {};
+export const tec = () => config().events || {};
 export const editor = () => tec().editor || {};
 export const settings = () => tec().settings || {};
 export const mapsAPI = () => tec().googleMap || {};


### PR DESCRIPTION
🎫 https://central.tri.be/issues/118682

As part of https://central.tri.be/issues/118682 I've found that the global for TEC is not using the correct name, hence is not being loaded at all.