### PR TITLE
Use PHP 5.2 compat array syntax | #119073

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,8 @@
 
 = [4.8.1] TBD =
 
+* Fix - Corrected a usage of array syntax within the PUE client, in order to ensure compatibility with PHP 5.2.4 (our thanks to @megabit81 for promptly flagging this issue!) [119073]
+
 = [4.8] 2018-11-29 =
 
 * Add - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -234,7 +234,7 @@ class Tribe__PUE__Notices {
 
 		$formatted_empty_keys = array();
 		foreach ( $empty_keys as $empty_key ) {
-			$empty_key              = Tribe__Utils__Array::get( $empty_key, [ 0 ] );
+			$empty_key              = Tribe__Utils__Array::get( $empty_key, array( 0 ) );
 			$formatted_empty_keys[] = Tribe__Utils__Array::get( $plugin_names, $empty_key );
 		}
 


### PR DESCRIPTION
Use PHP 5.2-compat array syntax.

Note: I didn't locate any other uses of new style shortened array syntax, but will be clear in the testing instructions that we need to test under an appropriate PHP runtime.

:ticket: [♯119073](https://central.tri.be/issues/119073)