### PR TITLE
Fix/119044 is plugin active for network

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,8 @@
 
 = [4.8.1] TBD =
 
+* Fix - Added safety measure to reduce risk of a fatal error when examining list of network-activated plugins [115826]
+
 = [4.8] 2018-11-29 =
 
 * Add - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1662,8 +1662,15 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$plugin_file = $map[ $this->plugin_file ];
 			}
 
-			return is_plugin_active_for_network( $plugin_file );
-
+			if ( function_exists( 'is_plugin_active_for_network' ) ) {
+				// If is_plugin_active_for_network() is available, let's use it!
+				return is_plugin_active_for_network( $plugin_file );
+			} else {
+				// When this method is called sufficiently early in the request,
+				// is_plugin_active_for_network() may not be available (#115826)
+				$plugins = get_site_option( 'active_sitewide_plugins' );
+				return isset( $plugins[ $plugin_file ] );
+			}
 		}
 
 		/**


### PR DESCRIPTION
We may call `is_plugin_active_for_network()` before the function has actually been loaded/defined by WordPress.

This adds a check to detect that and fallback on inspecting the `active_sitewide_plugins` option instead. This isn't _ideal,_ but without reworking many other pieces it's arguably the most time economic way to avoid fatals for the affected users. Open to thoughts on alternative approaches, though!

:ticket: [♯119044](https://central.tri.be/issues/119044)