### PR TITLE
Use `tribe_plugins_loaded` as hook to register assets

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,10 @@
 
 == Changelog ==
 
+= [4.8.1] TBD =
+
+* Fix - Make sure assets are injected before is too late
+
 = [4.8] 2018-11-29 =
 
 * Add - Added `tribe_cache_expiration` filter that allows plugins to use persistent caching based on cache key [117158]

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -27,8 +27,6 @@ class Tribe__Editor__Assets {
 	public function register() {
 
 		$plugin = Tribe__Main::instance();
-		/** @var Tribe__Editor__Configuration $editor_configuration */
-		$editor_configuration = tribe( 'common.editor.configuration' );
 
 		tribe_asset(
 			$plugin,

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -12,7 +12,7 @@ class Tribe__Editor__Assets {
 	 * @return void
 	 */
 	public function hook() {
-		add_action( 'wp_loaded', array( $this, 'register' ) );
+		add_action( 'tribe_plugins_loaded', array( $this, 'register' ) );
 	}
 
 	/**
@@ -51,7 +51,7 @@ class Tribe__Editor__Assets {
 						 *
 						 * @param array An array with the variables to be localized
 						 */
-						'data' => $editor_configuration->localize(),
+						'data' => tribe_callback( 'common.editor.configuration', 'localize' ),
 					),
 				),
 				'priority'  => 11,


### PR DESCRIPTION
Deleegate code execution until the point of the action fired by the
asset so functions are present at that point.

Ticket: https://central.tri.be/issues/119240