### PR TITLE
Avoid boolval() as it was introduced in PHP 5.5

### DIFF
--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -176,7 +176,7 @@ abstract class Tribe__Editor__Meta
 	 * @return bool
 	 */
 	public function sanitize_boolean( $value ) {
-		return boolval( $value );
+		return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**


### PR DESCRIPTION
Resolves PHP 5.2 compatibility.