### PR TITLE
Register blocks in `common` instead of TEC

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 
 = [4.8.2] TBD =
 
+* Feature - Add new action `tribe_editor_register_blocks` used to register Event blocks via `common`
 * Fix - Make sure assets are injected before is too late
 * Fix - Interface and Abstracts for REST base structures are now PHP 5.2 compatible
 

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -35,7 +35,25 @@ class Tribe__Editor__Provider extends tad_DI52_ServiceProvider {
 	 *
 	 */
 	protected function hook() {
+		// Setup the registration of Blocks
+		add_action( 'init', array( $this, 'register_blocks' ), 20 );
+	}
 
+	/**
+	 * Prevents us from using `init` to register our own blocks, allows us to move
+	 * it when the proper place shows up
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_blocks() {
+		/**
+		 * Internal Action used to register blocks for Events
+		 *
+		 * @since TBD
+		 */
+		do_action( 'tribe_editor_register_blocks' );
 	}
 
 	/**


### PR DESCRIPTION
Apply block registration via common so central action to register block
is executed / trigger on `common` - New action introduced
`tribe_editor_register_blocks`.

Ticket: https://central.tri.be/issues/119362