### PR TITLE
⌗119452 Ensure Admin CSS is Always Loaded Along with Notices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,7 @@
 * Fix - Fix an issue where feature detection of async-process support would fire too many requests [118876]
 * Fix - Interface and Abstracts for REST base structures are now PHP 5.2 compatible
 * Fix - Prevent to trigger error when using `array_combine` with empty arrays
+* Fix - Ensure admin CSS is enqueued any time a notice is displayed atop an admin page [119452]
 
 = [4.8.1] 2018-12-05 =
 

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -275,9 +275,6 @@ class Tribe__PUE__Notices {
 			return;
 		}
 
-		// Enqueue the notice CSS.
-		Tribe__Assets::instance()->enqueue( array( 'tribe-common-admin' ) );
-
 		$prompt = sprintf(
 			_n(
 				"It looks like you're using %1\$s, but the license key is invalid. Please download the latest version %2\$sfrom your account%3\$s.",
@@ -376,6 +373,10 @@ class Tribe__PUE__Notices {
 	 * @param string $inner_html
 	 */
 	protected function render_notice( $slug, $inner_html ) {
+
+		// Enqueue the notice CSS.
+		Tribe__Assets::instance()->enqueue( array( 'tribe-common-admin' ) );
+
 		$mascot = esc_url( Tribe__Main::instance()->plugin_url . 'src/resources/images/mascot.png' );
 
 		$html =

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -375,7 +375,7 @@ class Tribe__PUE__Notices {
 	protected function render_notice( $slug, $inner_html ) {
 
 		// Enqueue the notice CSS.
-		Tribe__Assets::instance()->enqueue( array( 'tribe-common-admin' ) );
+		tribe( 'assets' )->enqueue( array( 'tribe-common-admin' ) );
 
 		$mascot = esc_url( Tribe__Main::instance()->plugin_url . 'src/resources/images/mascot.png' );
 


### PR DESCRIPTION
**Ticket:** [**⌗119452**](http://central.tri.be/issues/119452)