### PR TITLE
WIP: support single instance edit/break-out

### DIFF
--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2894,4 +2894,31 @@ abstract class Tribe__Repository
 
 		return $query;
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function pluck( $field ) {
+		$list = new WP_List_Util( $this->all() );
+
+		return $list->pluck( $field );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function filter( $args = array(), $operator = 'AND' ) {
+		$list = new WP_List_Util( $this->all() );
+
+		return $list->filter( $args, $operator );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sort( $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
+		$list = new WP_List_Util( $this->all() );
+
+		return $list->sort( $orderby, $order, $preserve_keys );
+	}
 }

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -222,7 +222,7 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	 * {@inheritdoc}
 	 */
 	public function nth( $n ) {
-		return $this->decorated->first();
+		return $this->decorated->nth( $n );
 	}
 
 	/**

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -534,4 +534,25 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 			? $this->decorated->get_decorated_repository()
 			: $this->decorated;
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function pluck( $field ) {
+		return $this->decorated->pluck( $field );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function filter( $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
+		return $this->decorated->filter( $orderby, $order, $preserve_keys );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sort( $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
+		return $this->decorated->sort( $orderby, $order, $preserve_keys );
+	}
 }

--- a/src/Tribe/Repository/Read_Interface.php
+++ b/src/Tribe/Repository/Read_Interface.php
@@ -476,4 +476,61 @@ interface Tribe__Repository__Read_Interface extends Tribe__Repository__Setter_In
 	 * @return WP_Query A query object ready to return, and operate, on the posts.
 	 */
 	public function get_query_for_posts( array $posts );
+
+	/**
+	 * Plucks a field from all results and returns it.
+	 *
+	 * This method will implicitly build and use a `WP_List_Util` instance on the return
+	 * value of a call to the `all` method.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $field The field to pluck from each result.
+	 *
+	 * @return array An array of the plucked results.
+	 *
+	 * @see \wp_list_pluck()
+	 */
+	public function pluck( $field );
+
+	/**
+	 * Filters the results according to the specified criteria.
+	 *
+	 * This method will implicitly build and use a `WP_List_Util` instance on the return
+	 * value of a call to the `all` method.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $args     Optional. An array of key => value arguments to match
+	 *                         against each object. Default empty array.
+	 * @param string $operator Optional. The logical operation to perform. 'AND' means
+	 *                         all elements from the array must match. 'OR' means only
+	 *                         one element needs to match. 'NOT' means no elements may
+	 *                         match. Default 'AND'.
+	 *
+	 * @return array An array of the filtered results.
+	 *
+	 * @see \wp_list_filter()
+	 */
+	public function filter( $args = array(), $operator = 'AND' );
+
+	/**
+	 * Sorts the results according to the specified criteria.
+	 *
+	 * This method will implicitly build and use a `WP_List_Util` instance on the return
+	 * value of a call to the `all` method.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array $orderby       Optional. Either the field name to order by or an array
+	 *                                    of multiple orderby fields as $orderby => $order.
+	 * @param string       $order         Optional. Either 'ASC' or 'DESC'. Only used if $orderby
+	 *                                    is a string.
+	 * @param bool         $preserve_keys Optional. Whether to preserve keys. Default false.
+	 *
+	 * @return array An array of the sorted results.
+	 *
+	 * @see \wp_list_sort()
+	 */
+	public function sort( $orderby = array(), $order = 'ASC', $preserve_keys = false  );
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/119511

This PR adds code to support the single instance override/break-out in RBE:
* add the `Repository::pluck()` method to be able to write code like `tribe_events()->where('parent', 23)->pluck('start_date');`
* add the `Repository::sort()` mehtod to be abe to sort posts after the query ran using custom order, see `wp_list_sort`
* add the `Repository::filter()` method to filter posts after teh query ran using custom criteria, see `wp_list_filter`

Still a work in progress, and I might add the concept of collections but, for the time being, good enough:
```php
tribe_events()
    ->where('start_date_after', 'now')
    ->pluck('start_date_utc');
```