### PR TITLE
Add order support in orderby method

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1187,9 +1187,13 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *                        is set to `false` then `false` will be returned if a DateTime object could not be built.
 		 */
 		public static function build_date_object( $datetime = 'now', $timezone = null, $with_fallback = true ) {
-			if ( $datetime instanceof DateTime || $datetime instanceof DateTimeImmutable ) {
-				// Clone it to make sure we're not producing side effects if it's not immutable.
-				return $datetime instanceof DateTime ? clone $datetime : $datetime;
+			if ( $datetime instanceof DateTime ) {
+				return clone $datetime;
+			}
+
+			if ( $datetime instanceof DateTimeImmutable ) {
+				// Return the mutable version of the date.
+				return new DateTime( $datetime->format( 'Y-m-d H:i:s' ), $datetime->getTimezone() );
 			}
 
 			$timezone_object = null;

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -702,8 +702,9 @@ abstract class Tribe__Repository
 	/**
 	 * {@inheritdoc}
 	 */
-	public function order_by( $order_by ) {
+	public function order_by( $order_by, $order = 'DESC' ) {
 		$this->query_args['orderby'] = $order_by;
+		$this->query_args['order']   = $order;
 
 		return $this;
 	}

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -119,8 +119,8 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	/**
 	 * {@inheritdoc}
 	 */
-	public function order_by( $order_by ) {
-		$this->decorated->order_by( $order_by );
+	public function order_by( $order_by, $order = 'DESC' ) {
+		$this->decorated->order_by( $order_by, $order );
 
 		return $this;
 	}

--- a/src/Tribe/Repository/Read_Interface.php
+++ b/src/Tribe/Repository/Read_Interface.php
@@ -139,11 +139,13 @@ interface Tribe__Repository__Read_Interface extends Tribe__Repository__Setter_In
 	 *
 	 * @since 4.7.19
 	 *
-	 * @param string $order_by
+	 * @param string $order_by The post field, custom field or alias key to order posts by.
+	 * @param string $order The order direction; optional; shortcut for the `order` method; defaults
+	 *                      to `DESC`.
 	 *
 	 * @return Tribe__Repository__Read_Interface
 	 */
-	public function order_by( $order_by );
+	public function order_by( $order_by, $order = 'DESC' );
 
 	/**
 	 * Sets the fields that should be returned by the query.


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/117811

Allow for the repository to support calls like `tribe_events()->where('parent', 23)->order_by('event_date', 'ASC')->last()`.