### PR TITLE
Code to support view fixes in RBE

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1191,7 +1191,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				return clone $datetime;
 			}
 
-			if ( $datetime instanceof DateTimeImmutable ) {
+			if ( class_exists('DateTimeImmutable') && $datetime instanceof DateTimeImmutable ) {
 				// Return the mutable version of the date.
 				return new DateTime( $datetime->format( 'Y-m-d H:i:s' ), $datetime->getTimezone() );
 			}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -147,6 +147,7 @@ class Tribe__Main {
 	 */
 	public function init_libraries() {
 		require_once $this->plugin_path . 'src/functions/utils.php';
+		require_once $this->plugin_path . 'src/functions/query.php';
 		require_once $this->plugin_path . 'src/functions/multibyte.php';
 		require_once $this->plugin_path . 'src/functions/template-tags/general.php';
 		require_once $this->plugin_path . 'src/functions/template-tags/date.php';

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2922,4 +2922,11 @@ abstract class Tribe__Repository
 
 		return $list->sort( $orderby, $order, $preserve_keys );
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function collect() {
+		return new Tribe__Utils__Post_Collection( $this->all() );
+	}
 }

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -182,6 +182,7 @@ abstract class Tribe__Repository
 		'post_content_filtered',
 		'guid',
 		'perm',
+		'order',
 	);
 
 	/**
@@ -1226,6 +1227,7 @@ abstract class Tribe__Repository
 	public function by_args( array $args ) {
 		foreach ( $args as $key => $value ) {
 			$this->by( $key, $value );
+			$foo = 'bar';
 		}
 
 		return $this;

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -1227,7 +1227,6 @@ abstract class Tribe__Repository
 	public function by_args( array $args ) {
 		foreach ( $args as $key => $value ) {
 			$this->by( $key, $value );
-			$foo = 'bar';
 		}
 
 		return $this;

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -555,4 +555,11 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	public function sort( $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
 		return $this->decorated->sort( $orderby, $order, $preserve_keys );
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function collect() {
+		return $this->decorated->collect();
+	}
 }

--- a/src/Tribe/Repository/Read_Interface.php
+++ b/src/Tribe/Repository/Read_Interface.php
@@ -535,4 +535,13 @@ interface Tribe__Repository__Read_Interface extends Tribe__Repository__Setter_In
 	 * @see \wp_list_sort()
 	 */
 	public function sort( $orderby = array(), $order = 'ASC', $preserve_keys = false  );
+
+	/**
+	 * Builds a collection on the result of the `all()` method call.
+	 *
+	 * @since TBD
+	 *
+	 * @return \Tribe__Utils__Post_Collection
+	 */
+	public function collect();
 }

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -100,7 +100,8 @@ class Tribe__Timezones {
 			$timezone_object = $timezone_string instanceof DateTimeZone
 				? $timezone_string
 				: new DateTimeZone( $timezone_string );
-			$date_time       = $date instanceof DateTime || $date instanceof DateTimeImmutable
+			$date_time = $date instanceof DateTime
+			             || ( class_exists( 'DateTimeImmutable' ) && $date instanceof DateTimeImmutable )
 				? $date
 				: Tribe__Date_Utils::build_date_object( $date, $timezone_object );
 

--- a/src/Tribe/Utils/Collection.php
+++ b/src/Tribe/Utils/Collection.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Models a generic collection of elements as a linked list.
+ *
+ * @since TBD
+ */
+
+/**
+ * Class Tribe__Utils__Collection
+ *
+ * @since TBD
+ */
+class Tribe__Utils__Collection extends SplDoublyLinkedList {
+
+	/**
+	 * The list of items the collection was initialized with.
+	 *
+	 * @var array
+	 */
+	protected $items = array();
+
+	/**
+	 * The doubly-linked list that will hold the items handled by the collection.
+	 *
+	 * @var \SplDoublyLinkedList
+	 */
+	protected $list;
+
+	/**
+	 * Tribe__Utils__Collection constructor.
+	 *
+	 * @param array $items The array of items to initialize the linked list with.
+	 */
+	public function __construct( array $items ) {
+		$this->items = $items;
+		foreach ( $items as $item ) {
+			$this->push( $item );
+		}
+	}
+
+	/**
+	 * Runs a callback function on all the collection items and returns the results.
+	 *
+	 * This is just a wrapper around the `array_map` method.
+	 *
+	 * @since TBD
+	 *
+	 * @param callable $callback The callback to run on each collection item.
+	 *
+	 * @return array An array of results returned by running the callback on all
+	 *               collection items.
+	 */
+	public function map( $callback ) {
+		return array_map( $callback, $this->items );
+	}
+}

--- a/src/Tribe/Utils/Post_Collection.php
+++ b/src/Tribe/Utils/Post_Collection.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * An extension of the base collection implementation to handle posts.
+ *
+ * @since TBD
+ */
+
+/**
+ * Class Tribe__Utils__Post_Collection
+ *
+ * @since TBD
+ */
+class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
+
+	/**
+	 * Tribe__Utils__Post_Collection constructor.
+	 *
+	 * Overrides the base constructor to ensure all elements in the collection are, in fact, posts.
+	 * Elements that do not resolve to a post are discarded.
+	 *
+	 * @param array $items
+	 */
+	public function __construct( array $items ) {
+		parent::__construct( array_filter( array_map( 'get_post', $items ) ) );
+	}
+
+	/**
+	 * Plucks a meta key for all elements in the collection.
+	 *
+	 * Elements that are not posts or do not have the meta set will have an
+	 * empty string value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $meta_key The meta key to pluck.
+	 * @param bool   $single   Whether to fetch the meta key as single or not.
+	 *
+	 * @return array An array of meta values for each item in the collection; items that
+	 *               do not have the meta set or that are not posts, will have an empty
+	 *               string value.
+	 */
+	public function pluck_meta( $meta_key, $single = true ) {
+		$plucked = array();
+
+		foreach ( $this as $item ) {
+			$plucked[] = get_post_meta( $item->ID, $meta_key, $single );
+		}
+
+		return $plucked;
+	}
+}

--- a/src/functions/query.php
+++ b/src/functions/query.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'tribe_filter_meta_query' ) ) {
 					}
 				}
 			}
-			$filtered [ $key ] = $entry;
+			$filtered[ $key ] = $entry;
 		}
 
 		return $filtered;

--- a/src/functions/query.php
+++ b/src/functions/query.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * A set of functions to manipulate queries or query properties.
+ *
+ * @since TBD
+ */
+
+if ( ! function_exists( 'tribe_filter_meta_query' ) ) {
+	/**
+	 * Removes meta query entries based on key and value.
+	 *
+	 * Example usage to remove all date-related meta queries, using a regular expression:
+	 *
+	 * $query->meta_query = tribe_filter_meta_query(
+	 *      $args['meta_query'],
+	 *      array( 'key' => '/_Event(Start|End)Date(UTC)/' )
+	 * );
+	 *
+	 * @since TBD
+	 *
+	 * @param array $meta_query The meta query array to filter, usually the content of the `$query->meta_query`
+	 *                          property.
+	 * @param array $where      A map of criteria for the filtering that will be applied with OR logic: if an
+	 *                          entry matches even one then it will be removed. If the value of the comparison is a
+	 *                          regular expression, with fences, then it will be used for a `preg_match` check against
+	 *                          the key, not a simple comparison.
+	 *
+	 * @return array The filtered meta query array.
+	 */
+	function tribe_filter_meta_query( array $meta_query, array $where ) {
+		$filtered = array();
+
+		foreach ( $meta_query as $key => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				$filtered[ $key ] = $entry;
+				continue;
+			}
+
+			foreach ( $where as $where_key => $where_value ) {
+				if ( isset( $entry[ $where_key ] ) ) {
+					if ( tribe_is_regex( $where_value ) ) {
+						$var = $entry[ $where_key ];
+						if ( preg_match( $where_value, $var ) ) {
+							continue 2;
+						}
+					} elseif ( $entry[ $where_key ] == $where_value ) {
+						continue 2;
+					}
+				}
+			}
+			$filtered [ $key ] = $entry;
+		}
+
+		return $filtered;
+	}
+}


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/119513
* https://central.tri.be/issues/119514
* https://central.tri.be/issues/119512

This PR adds methods and functions neede to support the fixes to TEC views due to the ORM adoption:
1. add the first implementation of Collections, now only the base one and the Post one.
2. adds the `collect` method to the ORM to get a post collection when fetching posts; in the context of Events this allows writing code like this:
    ```php
    $start_dates = tribe_events()
        ->where( 'on_date', '2018-01-10', 'America/New_York' )
        ->order_by( 'event_date', 'DESC' )
        ->collect()
        ->pluck_meta('_EventStartDate');

    ```
    See more about this in the tests.