### PR TITLE
#108900 - modify post transient to check for empty array item

### DIFF
--- a/src/Tribe/Post_Transient.php
+++ b/src/Tribe/Post_Transient.php
@@ -63,7 +63,7 @@ class Tribe__Post_Transient {
 			$value        = get_post_meta( $post_id, $meta, false );
 
 			// if there aren't any values, communicate that it did not fetch data from post transient
-			if ( ! is_array( $value ) || 0 === count( $value ) ) {
+			if ( ! is_array( $value ) || 0 === count( $value ) || empty( $value[0] ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
_Ref:_ [C#108900](https://central.tri.be/issues/108900 )

When working on the tsm bucket I found EDD and Woo Attendees were not showing, I determined it was because an empty array was saved to the meta field. Adding a check for a empty value in the first item of an array resolved the issue, but maybe there is a better way to do it?