### PR TITLE
Fix return value for `exclude_tribe_blocks()`

### DIFF
--- a/src/Tribe/Editor/Utils.php
+++ b/src/Tribe/Editor/Utils.php
@@ -134,7 +134,7 @@ class Tribe__Editor__Utils {
 		$match_blocks_exp = '/\<\!\-\- \/?wp\:tribe.*\/?-->/i';
 
 		if ( ! preg_match( $match_blocks_exp, $content ) ) {
-			return false;
+			return $content;
 		}
 
 		return preg_replace( $match_blocks_exp, '', $content );


### PR DESCRIPTION
🎫 https://central.tri.be/issues/118679

Fix the return value. This function is used for the iCal export and by returning a bool, it's not exporting the content for events created on the classic editor