### PR TITLE
Improve conditionals on `generate_timezone_string_from_utc_offset()` to return only string timezones

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,10 @@
 
 == Changelog ==
 
+= [4.8.5] TBD =
+
+* Fix - Improve conditionals on `Tribe__Timezones::generate_timezone_string_from_utc_offset` to return only string timezones [120647]
+
 = [4.8.4] TBD =
 
 * Fix - Updated translation strings from the Gutenberg extension merge [118656]

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -152,7 +152,7 @@ class Tribe__Timezones {
 				foreach ( $abbr as $city ) {
 					if (
 						(bool) $city['dst'] === $is_dst
-						&& intval( $city['offset'] ) === $seconds
+						&& intval( $city['offset'] ) === intval( $seconds )
 						&& $city['timezone_id']
 					) {
 						return $city['timezone_id'];

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -146,13 +146,14 @@ class Tribe__Timezones {
 		$timezone = timezone_name_from_abbr( '', $seconds, 0 );
 
 		if ( false === $timezone ) {
-			$is_dst = date( 'I' );
+			$is_dst = (bool) date( 'I' );
 
 			foreach ( timezone_abbreviations_list() as $abbr ) {
 				foreach ( $abbr as $city ) {
 					if (
-						$city['dst'] == $is_dst
-						&& $city['offset'] == $seconds
+						(bool) $city['dst'] === $is_dst
+						&& intval( $city['offset'] ) === $seconds
+						&& $city['timezone_id']
 					) {
 						return $city['timezone_id'];
 					}


### PR DESCRIPTION
🎫 https://central.tri.be/issues/120647

There are cases where the conditional was failing and returning `null` (i.e.: UTC-12)