### PR TITLE
Unpack array arguments in filter when only an array is provided

### DIFF
--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -908,7 +908,20 @@ abstract class Tribe__Repository
 		 */
 		$args_without_key = array_splice( $call_args, 1 );
 
-		$schema_entry = call_user_func_array( $application, $args_without_key );
+		if (
+			count( $args_without_key ) === 1
+			&& is_array( $args_without_key[0] )
+			&& ! is_callable( $args_without_key[0] )
+		) {
+			/*
+			 * If we only have one argument and that is an array then unpack it.
+			 * This is useful to allow higher-level functions to set a filter using an
+			 * array argument; e.g. `'date_overlaps' => [ $start, $end ]`.
+			 */
+			$schema_entry = $application( ...$args_without_key[0] );
+		} else {
+			$schema_entry = $application( ...$args_without_key );
+		}
 
 		/**
 		 * Filters the applied modifier schema entry response.


### PR DESCRIPTION
Tickets:
* https://central.tri.be/issues/123945
* https://central.tri.be/issues/123950

This PR makes it so that array arguments, when the only non-callable, arguments, are unpacked to call the filtering repository function.
Example:

```php
// The correct way to call it now.
$events = tribe_events()->where('date_overlaps', $start, $end)->all();

// The new allowed way to call, equivalent to the one above.
$events = tribe_events()->where('date_overlaps', [$start, $end])->all();
```

This is of bigger utility in calls to proxy methods/functions like `tribe_get_events`:

```php
$events = "tribe_get_events(['date_overlaps' => [$start, $end]]);
```

Without this fix this would throw an error due to missing second argument for the `Event::filter_by_date_overlaps` function; with the fix the arguments are unpacked keeping filters that require 2+ arguments accessible from proxying methods.