### PR TITLE
Bail if the page has no `$download_link` to avoid console errors

### DIFF
--- a/src/resources/js/admin-log-controls.js
+++ b/src/resources/js/admin-log-controls.js
@@ -90,13 +90,12 @@ var tribe_logger_data  = tribe_logger_data || {};
 	 * currently selected log file.
 	 */
 	function update_download_link() {
-		var url = $download_link.attr( 'href' );
-
 		// bail if not in DOM
-		if ( typeof url === 'undefined' ) {
+		if ( 1 > $download_link.length ) {
 			return;
 		}
 
+		var url = $download_link.attr( 'href' );
 		var log = encodeURI( get_current_view() );
 		var matches = url.match(/&log=([a-z0-9\-]+)/i);
 

--- a/src/resources/js/admin-log-controls.js
+++ b/src/resources/js/admin-log-controls.js
@@ -91,6 +91,12 @@ var tribe_logger_data  = tribe_logger_data || {};
 	 */
 	function update_download_link() {
 		var url = $download_link.attr( 'href' );
+
+		// bail if not in DOM
+		if ( typeof url === 'undefined' ) {
+			return;
+		}
+
 		var log = encodeURI( get_current_view() );
 		var matches = url.match(/&log=([a-z0-9\-]+)/i);
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/125042

Seems like with the new freemius implementation there are pages where we don't have the download link so we were trying to manipulate data that wasn't there, hence we were getting a console error.