### PR TITLE
Add hash method to ORM.

### DIFF
--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2979,24 +2979,19 @@ abstract class Tribe__Repository
 	}
 
 	/**
-	 * Returns an hash string for this repository instance filters.
-	 *
-	 * By default all applied filters will be included but specific filters can
-	 * be excluded, or included, from the hash generation.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $settings An array of settings to define how the hash should be produced in the shape
-	 *                        `[ 'exclude' => [ 'ex_1', ... ], 'include' => [ 'inc_1', ... ] ]`.
-	 *
-	 * @return string The generated hash string.
+	 * {@inheritDoc}
 	 */
-	public function hash( array $settings = [] ) {
+	public function hash( array $settings = [], WP_Query $query = null ) {
 		$filters = $this->current_filters;
+		$query_vars = null !== $query ? $query->query_vars : [];
 
 		if ( isset( $settings['exclude'] ) ) {
 			$filters = array_diff_key(
 				$filters,
+				array_combine( $settings['exclude'], $settings['exclude'] )
+			);
+			$query_vars = array_diff_key(
+				$query_vars,
 				array_combine( $settings['exclude'], $settings['exclude'] )
 			);
 		}
@@ -3006,8 +3001,12 @@ abstract class Tribe__Repository
 				$filters,
 				array_combine( $settings['include'], $settings['include'] )
 			);
+			$query_vars = array_intersect_key(
+				$query_vars,
+				array_combine( $settings['include'], $settings['include'] )
+			);
 		}
 
-		return md5( json_encode( $filters ) );
+		return md5( json_encode( [ $filters, $query_vars ] ) );
 	}
 }

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2983,7 +2983,7 @@ abstract class Tribe__Repository
 	 */
 	public function hash( array $settings = [], WP_Query $query = null ) {
 		$filters = $this->current_filters;
-		$query_vars = null !== $query ? $query->query_vars : [];
+		$query_vars = null !== $query ? $query->query : [];
 
 		if ( isset( $settings['exclude'] ) ) {
 			$filters = array_diff_key(

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2977,4 +2977,37 @@ abstract class Tribe__Repository
 
 		return $query;
 	}
+
+	/**
+	 * Returns an hash string for this repository instance filters.
+	 *
+	 * By default all applied filters will be included but specific filters can
+	 * be excluded, or included, from the hash generation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings An array of settings to define how the hash should be produced in the shape
+	 *                        `[ 'exclude' => [ 'ex_1', ... ], 'include' => [ 'inc_1', ... ] ]`.
+	 *
+	 * @return string The generated hash string.
+	 */
+	public function hash( array $settings = [] ) {
+		$filters = $this->current_filters;
+
+		if ( isset( $settings['exclude'] ) ) {
+			$filters = array_diff_key(
+				$filters,
+				array_combine( $settings['exclude'], $settings['exclude'] )
+			);
+		}
+
+		if ( isset( $settings['include'] ) ) {
+			$filters = array_intersect_key(
+				$filters,
+				array_combine( $settings['include'], $settings['include'] )
+			);
+		}
+
+		return md5( json_encode( $filters ) );
+	}
 }

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -566,7 +566,7 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	/**
 	 * {@inheritdoc}
 	 */
-	public function hash( array $settings = [] ) {
+	public function hash( array $settings = [], WP_Query $query = null ) {
 		return $this->decorated->hash( $settings );
 	}
 }

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -562,4 +562,11 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 	public function collect() {
 		return $this->decorated->collect();
 	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function hash( array $settings = [] ) {
+		return $this->decorated->hash( $settings );
+	}
 }

--- a/src/Tribe/Repository/Interface.php
+++ b/src/Tribe/Repository/Interface.php
@@ -205,17 +205,22 @@ interface Tribe__Repository__Interface
 	public function add_schema_entry( $key, $callback );
 
 	/**
-	 * Returns an hash string for this repository instance filters.
+	 * Returns an hash string for this repository instance filters and, optionally, a generated query.
 	 *
-	 * By default all applied filters will be included but specific filters can
+	 * By default all applied filters, and query vars, will be included but specific filters can
 	 * be excluded, or included, from the hash generation.
+	 * The possibility to include the query in the hash generation is required as the query vars could
+	 * be further modified after the repository filters are applied and the query is built.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $settings An array of settings to define how the hash should be produced in the shape
-	 *                        `[ 'exclude' => [ 'ex_1', ... ], 'include' => [ 'inc_1', ... ] ]`.
+	 * @param array          $settings An array of settings to define how the hash should be produced in the shape
+	 *                                 `[ 'exclude' => [ 'ex_1', ... ], 'include' => [ 'inc_1', ... ] ]`. This array
+	 *                                 will apply both to the Repository filters and the query vars.
+	 * @param WP_Query|null $query An optional query object to include in the hashing.
 	 *
 	 * @return string The generated hash string.
+	 *
 	 */
-	public function hash( array $settings = [] );
+	public function hash( array $settings = [], WP_Query $query = null );
 }

--- a/src/Tribe/Repository/Interface.php
+++ b/src/Tribe/Repository/Interface.php
@@ -203,4 +203,19 @@ interface Tribe__Repository__Interface
 	 * @param callable $callback The function that should be called to apply this filter.
 	 */
 	public function add_schema_entry( $key, $callback );
+
+	/**
+	 * Returns an hash string for this repository instance filters.
+	 *
+	 * By default all applied filters will be included but specific filters can
+	 * be excluded, or included, from the hash generation.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings An array of settings to define how the hash should be produced in the shape
+	 *                        `[ 'exclude' => [ 'ex_1', ... ], 'include' => [ 'inc_1', ... ] ]`.
+	 *
+	 * @return string The generated hash string.
+	 */
+	public function hash( array $settings = [] );
 }


### PR DESCRIPTION
Ticket: various

This PR adds a `Tribe__Repository::hash( arrray $settings = [], WP_Query $query = null )` method to the repository.
Since the ORM handles building and filtering the query the resulting query arguments might not reflect all the arguments and filters applied to it by both the ORM and other integrations.
The hashing function will be generated from the Repository `filters` property controlled completely by the Repsository, and from the query, if provided, resulting query arguments.