### PR TITLE
Feature/125915 filter validate changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,9 @@
 
 == Changelog ==
 
+= [4.9.6] TBD =
+* Fix - Fixed incorrect position of arg in filter_var function of email validation in Validate.php Props to @dharmin for the fix! [125915]
+
 = [4.9.5] TBD =
 
 * Tweak - Allow for external modal control for modal button component [123818]

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -544,7 +544,7 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 			if ( ! $this->result->valid ) {
 				$this->result->error = sprintf( esc_html__( '%s must be an email address.', 'tribe-common' ), $this->label );
 			} else {
-				$this->value = filter_var( trim( $candidate, FILTER_SANITIZE_EMAIL ) );
+				$this->value = filter_var( trim( $candidate ), FILTER_SANITIZE_EMAIL );
 			}
 		}
 


### PR DESCRIPTION
Implements contributions from @dharmin via #968

Fixed incorrect position of arg in filter_var function of email validation in Validate.php

🎫 https://central.tri.be/issues/125915