### PR TITLE
Add Tribe__Repository::flush() to make it easier to reset the repository object

### DIFF
--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3435,7 +3435,7 @@ abstract class Tribe__Repository
 
 			if ( 'AND' === $where_relation && 0 === count( $intersection ) ) {
 				// Let's not waste any more time.
-				$this->void_query;
+				$this->void_query = true;
 
 				return $this;
 			}
@@ -3485,5 +3485,18 @@ abstract class Tribe__Repository
 		$this->filter_query->where( implode( " {$where_relation} ", $wheres ) );
 
 		return $this;
+	}
+
+	/**
+	 * Flush current filters and query information.
+	 *
+	 * @since TBD
+	 */
+	public function flush() {
+		$this->current_query    = null;
+		$this->current_filters  = [];
+		$this->current_filter   = null;
+		$this->last_built_query = null;
+		$this->last_built_hash  = '';
 	}
 }

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3491,6 +3491,8 @@ abstract class Tribe__Repository
 	 * Flush current filters and query information.
 	 *
 	 * @since TBD
+	 *
+	 * @return self
 	 */
 	public function flush() {
 		$this->current_query    = null;
@@ -3498,5 +3500,7 @@ abstract class Tribe__Repository
 		$this->current_filter   = null;
 		$this->last_built_query = null;
 		$this->last_built_hash  = '';
+
+		return $this;
 	}
 }


### PR DESCRIPTION
https://central.tri.be/issues/120395

Resets current query + filter + filters and last built query + hash.

```php
// Get certain results.
$repository->where( .... )->per_page( 100 )->all();

// Announce intention to 
$repository->flush();

// Get first 10 results, not limited to previously set where().
$repository->per_page( 10 )->all();
```