### PR TITLE
Parameter of `wp_clear_scheduled_hook` must be array (of array)

### DIFF
--- a/src/Tribe/Process/Handler.php
+++ b/src/Tribe/Process/Handler.php
@@ -157,7 +157,7 @@ abstract class Tribe__Process__Handler {
 		 * fallback to use the cron-based approach and just call the handle method
 		 * removing it first from the action to avoid multiple calls.
 		 */
-		wp_clear_scheduled_hook( $this->healthcheck_cron_hook_id, $data_source );
+		wp_clear_scheduled_hook( $this->healthcheck_cron_hook_id, [ $data_source ] );
 
 		$this->handle( $data_source );
 	}


### PR DESCRIPTION
🎫 https://central.tri.be/issues/124019
