### PR TITLE
Remove version number from dependency message for self.

### DIFF
--- a/src/Tribe/Dependency.php
+++ b/src/Tribe/Dependency.php
@@ -356,6 +356,15 @@ if ( ! class_exists( 'Tribe__Dependency' ) ) {
 					continue;
 				}
 
+				if ( $class === $checked_plugin['class'] ) {
+					/*
+					 * If the required plugin class is the same we're checking we clear the version to keep the message
+					 * clear and redirect users to the latest version download link in place of providing a wrong
+					 * version number.
+					 */
+					$version = '';
+				}
+
 				$dependent_plugin = $tribe_plugins->get_plugin_by_class( $class );
 				$this->admin_messages[ $plugin['class'] ]->add_required_plugin( $dependent_plugin['short_name'], $dependent_plugin['thickbox_url'], $is_registered, $version, $addon );
 				$failed_dependency++;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/126615

This fix removes the version number from the message/link that will alllow users to download a plugin latest version when the plugin version is not above the minimum required one by the parent plugin.
I.e. TEC required PRO `>=4.7` but PRO is on version `4.6`.
The message, before, would show the **minimum** required version, not the latest one while the text suggests downloading the latest version.
This PR removes the version from the message entirely to simply redirect users to the latest version download.

Before: 
![Screen Shot 2019-05-07 at 17 05 24](https://user-images.githubusercontent.com/2749650/57311089-45ab7200-70eb-11e9-9f09-e311ea79f7f0.png)

After:
![Screen Shot 2019-05-07 at 17 12 32](https://user-images.githubusercontent.com/2749650/57311134-5d82f600-70eb-11e9-82f8-29ff200b24db.png)
