### PR TITLE
fix(Main::post_id_helper): refactor code and make it a bit more robust

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -477,34 +477,15 @@ class Tribe__Main {
 	 * Helper function for getting Post ID. Accepts `null` or a Post ID. If attempting
 	 * to detect $post object and it is not found, returns `false` to avoid a PHP Notice.
 	 *
-	 * @param null|int|WP_Post $post Post ID or object, `null` to get the ID of the global post object.
+	 * @param  null|int|WP_Post  $candidate  Post ID or object, `null` to get the ID of the global post object.
 	 *
-	 * @return int|false The ID of the passed or global post.
+	 * @return int|false The ID of the passed or global post, `false` if the passes object is not a post or the global
+	 *                   post is not set.
 	 */
-	public static function post_id_helper( $post = null ) {
-		if (
-			is_numeric( $post )
-			&& 0 < (int) $post
-			&& null !== $post
-		) {
-			return (int) $post;
-		}
+	public static function post_id_helper( $candidate = null ) {
+		$candidate_post = get_post( $candidate );
 
-		if (
-			is_object( $post )
-			&& ! empty( $post->ID )
-		) {
-			return (int) $post->ID;
-		}
-
-		if (
-			! empty( $GLOBALS['post'] )
-			&& $GLOBALS['post'] instanceof WP_Post
-		) {
-			return get_the_ID();
-		}
-
-		return false;
+		return $candidate_post instanceof WP_Post ? $candidate_post->ID : false;
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Utils/Post_ID_HelperTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_ID_HelperTest.php
@@ -51,16 +51,16 @@ class Post_ID_HelperTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * @test         When passing positive integers, return the int as-is.
+	 * @test It should return false when passed non existing post ID
 	 *
 	 * @param int $post_id
 	 *
 	 * @dataProvider integers
 	 */
-	public function it_should_return_int_when_passed_positive_int( int $post_id ) {
+	public function it_should_return_false_when_passed_non_existing_post_id( int $post_id ) {
 		$actual = Main::post_id_helper( $post_id );
 
-		$this->assertEquals( $post_id, $actual );
+		$this->assertFalse( $actual );
 	}
 
 	/**
@@ -76,15 +76,15 @@ class Post_ID_HelperTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should return int when passed a numeric string.
+	 * It should return false when passed a numeric string for non existing post IDs.
 	 *
 	 * @test
 	 * @dataProvider numeric_string_inputs
 	 */
-	public function it_should_return_int_when_passed_numeric_strings( string $numeric_string ) {
+	public function it_should_return_int_when_passed_numeric_strings_for_non_existing_post_ids( string $numeric_string ) {
 		$actual = Main::post_id_helper( $numeric_string );
 
-		$this->assertEquals( (int) $numeric_string, $actual );
+		$this->assertFalse( $actual );
 	}
 
 	/**
@@ -128,5 +128,36 @@ class Post_ID_HelperTest extends \Codeception\TestCase\WPTestCase {
 			':-]'       => [ ':-]' ],
 			'π'         => [ 'π' ],
 		];
+	}
+
+	/**
+	 * It should return false when passed zero
+	 *
+	 * @test
+	 */
+	public function should_return_false_when_passed_zero() {
+		$this->assertFalse( Main::post_id_helper( 0 ) );
+	}
+
+	/**
+	 * It should return the post ID when passed numeric string of existing post ID
+	 *
+	 * @test
+	 */
+	public function should_return_the_post_id_when_passed_numeric_string_of_existing_post_id() {
+		$post_id = static::factory()->post->create();
+
+		$this->assertEquals( $post_id, Main::post_id_helper( (string) $post_id ) );
+	}
+
+	/**
+	 * It should return false if global post is set to non post object
+	 *
+	 * @test
+	 */
+	public function should_return_false_if_global_post_is_set_to_non_post_object() {
+		$GLOBALS['post'] = 'not-a-post-object';
+
+		$this->assertFalse( Main::post_id_helper() );
 	}
 }


### PR DESCRIPTION
Following Cliff's suggestion this commit tries to slim down the code leveraging the number of checks
WordPress `get_post` function already does and, by extension, covers the case where the function is
passed a valid integer number that is, but, not an actual post ID. In this last case the could
would, previously, return the integer number making it so that, if the `Tribe__Main::post_id_helper`
function is used in filtering/validating loops, the post would be flagged as valid; the correct
behavior should be to filter out the post as invalid.

re https://central.tri.be/issues/118994