### PR TITLE
 Add set_found_rows() so that we can let found() work without extra queries

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [4.9.10] TBD =
 
 * Tweak - Add ability to prevent duplicate JOINs by allowing an optionally supplied ID per join [128202]
+* Tweak - Add ability to turn on/off no_found_rows logic for queries [128202]
 * Fix - Resolve issues with pagination in REST API by making the query cache more comprehensive [127710]
 
 = [4.9.9] 2019-05-16 =

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3516,6 +3516,8 @@ abstract class Tribe__Repository
 	 */
 	public function set_found_rows( $found_rows ) {
 		$this->skip_found_rows = ! $found_rows;
+
+		return $this;
 	}
 
 	/**

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3512,6 +3512,13 @@ abstract class Tribe__Repository
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	public function set_found_rows( $found_rows ) {
+		$this->skip_found_rows = ! $found_rows;
+	}
+
+	/**
 	 * Flush current filters and query information.
 	 *
 	 * @since 4.9.10

--- a/src/Tribe/Repository/Decorator.php
+++ b/src/Tribe/Repository/Decorator.php
@@ -653,4 +653,13 @@ abstract class Tribe__Repository__Decorator implements Tribe__Repository__Interf
 
 		return $this;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function set_found_rows( $found_rows ) {
+		$this->decorated->set_found_rows( $found_rows );
+
+		return $this;
+	}
 }

--- a/src/Tribe/Repository/Interface.php
+++ b/src/Tribe/Repository/Interface.php
@@ -279,5 +279,14 @@ interface Tribe__Repository__Interface
 	 * @return \Tribe__Repository__Interface The repository instance, for chaining.
 	 * @throws \Tribe__Repository__Usage_Error If trying to set the query after a fetching operation is done.
 	 */
-	public function set_query( WP_Query $query  );
+	public function set_query( WP_Query $query );
+
+	/**
+	 * Sets the found rows calculation to be enabled for queries.
+	 *
+	 * @since 4.9.10
+	 *
+	 * @param bool $found_rows Whether found rows calculation should be enabled.
+	 */
+	public function set_found_rows( $found_rows );
 }

--- a/src/Tribe/Repository/Interface.php
+++ b/src/Tribe/Repository/Interface.php
@@ -287,6 +287,8 @@ interface Tribe__Repository__Interface
 	 * @since 4.9.10
 	 *
 	 * @param bool $found_rows Whether found rows calculation should be enabled.
+	 *
+	 * @return \Tribe__Repository__Interface The repository instance, for chaining.
 	 */
 	public function set_found_rows( $found_rows );
 }


### PR DESCRIPTION
When you call `->all()` and then `->found()` it will always run an extra query. You should be able to turn on found rows that's built into WP_Query on as needed.

https://central.tri.be/issues/128202