### PR TITLE
fix(Tribe__Rewrite): remove eager call to `setup`

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -89,7 +89,6 @@ class Tribe__Rewrite {
 	public static function instance() {
 		if ( ! static::$instance ) {
 			static::$instance = new static;
-			static::$instance->setup();
 		}
 
 		return static::$instance;


### PR DESCRIPTION
In B19.07 I've added an eager call to the `setup` method in the `instance` (singleton
implementation) of the class. That method is called in many places in the code and before plugins in
need of filtering the rewrite bases (e.g. PRO) have even hooked or initialized. The `setup` method
should be called lazily, and on-demand, when the setup is required.