### PR TITLE
Set the default link color, to prevent theme overrides.

### DIFF
--- a/src/resources/postcss/base/typography/_anchors.pcss
+++ b/src/resources/postcss/base/typography/_anchors.pcss
@@ -1,7 +1,7 @@
 .tribe-common {
 
 	a {
-		color: color: var(--color-text-primary);
+		color: var(--color-text-primary);
 		cursor: pointer;
 	}
 

--- a/src/resources/postcss/base/typography/_anchors.pcss
+++ b/src/resources/postcss/base/typography/_anchors.pcss
@@ -1,6 +1,7 @@
 .tribe-common {
 
 	a {
+		color: color: var(--color-text-primary);
 		cursor: pointer;
 	}
 


### PR DESCRIPTION
As we talked with @paulmskim on the Month view PR, the idea would be to set the default link color on the common styles directly.