### PR TITLE
feat(Cost_Utils.php): Add the `parse_separators` method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,7 @@
 * Tweak - Divide the `tribe-common.js` file to prevent that file from being bloated with external dependencies. [129526]
 * Tweak - Make sure `UTC-0` is converted back to `UTC` instead of `UTC-01` [129240]
 * Tweak - Add new function `tribe_register_rest_route` Wrapper around `register_rest_route` to filter the arguments when a new REST endpoint is created [129517]
+* Tweak - Add new method `Tribe__Cost_Utils::parse_separators` to infer decimal and thousands separators from a value that might have been formatted in a local different from the current one [98061]
 * Fix - Prevent Clipboard Javascript from loading all over the place on `/wp-admin/` [129526]
 
 = [4.9.11.1] 2019-06-13 =

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -486,4 +486,50 @@ class Tribe__Cost_Utils {
 
 		return ! empty( $currency_positions ) ? reset( $currency_positions ) : false;
 	}
+
+	/**
+	 * Parses the cost value and current locale to infer decimal and thousands separators.
+	 *
+	 * The cost values stored in the meta table might not use the same decimal and thousands separator as the current
+	 * locale.
+	 * To work around this we parse the value assuming the decimal separator will be the last non-numeric symbol,
+	 * if any.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|int|float $value The cost value to parse.
+	 *
+	 * @return array An array containing the parsed decimal and thousands separator symbols.
+	 */
+	public function parse_separators( $value ) {
+		global $wp_locale;
+		$locale_decimal_point = $wp_locale->number_format['decimal_point'];
+		$locale_thousands_sep = $wp_locale->number_format['thousands_sep'];
+		$decimal_sep          = $locale_decimal_point;
+		$thousands_sep        = $locale_thousands_sep;
+
+		preg_match_all( '/[\\.,]+/', $value, $matches );
+
+		if ( ! empty( $matches[0] ) ) {
+			$matched_separators = $matches[0];
+			if ( count( array_unique( $matched_separators ) ) > 1 ) {
+				// We have both, the decimal separator will be the last non-numeric symbol.
+				$decimal_sep   = end( $matched_separators );
+				$thousands_sep = reset( $matched_separators );
+			} else {
+				/*
+				 * We only have one, we can assume it's the decimal separator if it comes before a number of numeric
+				 * symbols that is not exactly 3. If there are exactly 3 number after the symbols we fall back on the
+				 * locale; we did our best and cannot guess any further.
+				 */
+				$frags = explode( end( $matched_separators ), $value );
+				if ( strlen( end( $frags ) ) !== 3 ) {
+					$decimal_sep   = end( $matched_separators );
+					$thousands_sep = $decimal_sep === $locale_decimal_point ? $locale_thousands_sep : $locale_decimal_point;
+				}
+			}
+		}
+
+		return [ $decimal_sep, $thousands_sep ];
+	}
 }

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -525,7 +525,9 @@ class Tribe__Cost_Utils {
 				$frags = explode( end( $matched_separators ), $value );
 				if ( strlen( end( $frags ) ) !== 3 ) {
 					$decimal_sep   = end( $matched_separators );
-					$thousands_sep = $decimal_sep === $locale_decimal_point ? $locale_thousands_sep : $locale_decimal_point;
+					$thousands_sep = $decimal_sep === $locale_decimal_point ?
+						$locale_thousands_sep
+						: $locale_decimal_point;
 				}
 			}
 		}

--- a/tests/wpunit/Tribe/Cost_UtilsTest.php
+++ b/tests/wpunit/Tribe/Cost_UtilsTest.php
@@ -115,4 +115,28 @@ class Cost_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $expected, $sut->maybe_format_with_currency( $cost, $post_id, $symbol, $position ) );
 	}
 
+	public function parse_separators_data_set() {
+		return [
+			'empty_string' => [ '', [ '.', ',' ] ],
+			'zero' => [ 0, [ '.', ',' ] ],
+			'string' => [ 'Free', [ '.', ',' ] ],
+			'int_wo_separators' => [ '23', [ '.', ',' ] ],
+			'w_decimal_separator' => [ '23.89', [ '.', ',' ] ],
+			'w_thousands_separator' => [ '23,892', [ '.', ',' ] ],
+			'w_both_separators' => [ '23,892.4', [ '.', ',' ] ],
+			'w_both_separators_inverted' => [ '23.892,4', [ ',', '.' ] ],
+			'w_comma_decimal_separator' => [ '23,89', [ ',', '.' ] ],
+		];
+}
+	/**
+	 * Test parse_separators
+	 * @dataProvider parse_separators_data_set
+	 */
+	public function test_parse_separators( $value, $expected ) {
+		$cost_utils = $this->make_instance();
+
+		$parsed = $cost_utils->parse_separators( $value );
+
+		$this->assertEquals( $expected, $parsed );
+	}
 }


### PR DESCRIPTION
The `Tribe__Cost__Utils::parse_separators` method comes in handy when trying to parse cost values
from cost strings that might have been generated in the context of another locale. With some basic
logic we might infer that `23,89` is using `,` as a decimal separator even in an `en_EN` locale. On
the same note, while in the context of a `de_DE` locale we might infer `23.89` is using `.` as a
decimal separator. The method, due to inherent limits to this guessing, will not be able to come to
a ny definitive conclusion, and will fall back on the separators defined by the current locale, when
working on non numeric vvalues (e.g. `Free`) or "ambiguous" values (e.g. `23,899`) where the 3
numbers after the separator do not allow to clearly distinguish it.

re https://central.tri.be/issues/98061