### PR TITLE
fix(tooltips assets): replace `tribe_asset` with `wp_enqueue_style`.

### DIFF
--- a/src/Tribe/Service_Providers/Tooltip.php
+++ b/src/Tribe/Service_Providers/Tooltip.php
@@ -35,12 +35,9 @@ class Tribe__Service_Providers__Tooltip extends tad_DI52_ServiceProvider {
 	 * @since 4.9.8
 	 */
 	public function add_tooltip_assets() {
-		tribe_asset(
-			Tribe__Main::instance(),
+		wp_enqueue_style(
 			'tribe-tooltip',
-			'tooltip.css',
-			[],
-			[ 'wp_enqueue_scripts', 'admin_enqueue_scripts' ]
+			plugins_url( 'resources/css/', dirname( dirname( __FILE__ ) ) ) .'tooltip.css'
 		);
 	}
 }


### PR DESCRIPTION
The tooltip assets aren't getting enqueued properly, so replacing them with the wp built-in.

This needs a release and likely a ticket - at which point someone can dig in and see if there is actually a bug in `tribe_asset`