### PR TITLE
feat(tooltip assets): Don't use the same name for two assets.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -68,7 +68,7 @@ class Tribe__Assets {
 				)
 				|| (
 					'js' !== $asset->type
-					&&  wp_style_is( $asset->slug, 'registered' )
+					&& wp_style_is( $asset->slug, 'registered' )
 				)
 			) {
 				continue;

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -59,18 +59,8 @@ class Tribe__Assets {
 		uasort( $assets, [ $this, 'order_by_priority' ] );
 
 		foreach ( $assets as $asset ) {
-
-			if (
-				$asset->is_registered
-				|| (
-					'js' === $asset->type
-					&& wp_script_is( $asset->slug, 'registered' )
-				)
-				|| (
-					'js' !== $asset->type
-					&& wp_style_is( $asset->slug, 'registered' )
-				)
-			) {
+			// Asset is already registered.
+			if ( $asset->is_registered ) {
 				continue;
 			}
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -75,11 +75,23 @@ class Tribe__Assets {
 			}
 
 			if ( 'js' === $asset->type ) {
+				// Script is already registered.
+				if ( wp_script_is( $asset->slug, 'registered' ) ) {
+					continue;
+				}
+
 				wp_register_script( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->in_footer );
+
 				// Register that this asset is actually registered on the WP methods.
 				$asset->is_registered = wp_script_is( $asset->slug, 'registered' );
 			} else {
+				// Style is already registered.
+				if ( wp_style_is( $asset->slug, 'registered' ) ) {
+					continue;
+				}
+
 				wp_register_style( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->media );
+
 				// Register that this asset is actually registered on the WP methods.
 				$asset->is_registered = wp_style_is( $asset->slug, 'registered' );
 			}

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -59,14 +59,36 @@ class Tribe__Assets {
 		uasort( $assets, [ $this, 'order_by_priority' ] );
 
 		foreach ( $assets as $asset ) {
-			if ( 'js' === $asset->type ) {
-				wp_register_script( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->in_footer );
-			} else {
-				wp_register_style( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->media );
+
+			if (
+				$asset->is_registered
+				|| (
+					'js' === $asset->type
+					&& wp_script_is( $asset->slug, 'registered' )
+				)
+				|| (
+					'js' !== $asset->type
+					&&  wp_style_is( $asset->slug, 'registered' )
+				)
+			) {
+				continue;
 			}
 
-			// Register that this asset is actually registered on the WP methods.
-			$asset->is_registered = true;
+			if ( 'js' === $asset->type ) {
+				wp_register_script( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->in_footer );
+				// Register that this asset is actually registered on the WP methods.
+				$asset->is_registered = wp_script_is( $asset->slug, 'registered' );
+				bdump(
+					'script - ' . $asset->slug
+				);
+			} else {
+				wp_register_style( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->media );
+				// Register that this asset is actually registered on the WP methods.
+				$asset->is_registered = wp_style_is( $asset->slug, 'registered' );
+				bdump(
+					'style - ' . $asset->slug
+				);
+			}
 
 			// If we don't have an action we don't even register the action to enqueue.
 			if ( empty( $asset->action ) ) {

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -78,16 +78,10 @@ class Tribe__Assets {
 				wp_register_script( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->in_footer );
 				// Register that this asset is actually registered on the WP methods.
 				$asset->is_registered = wp_script_is( $asset->slug, 'registered' );
-				bdump(
-					'script - ' . $asset->slug
-				);
 			} else {
 				wp_register_style( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->media );
 				// Register that this asset is actually registered on the WP methods.
 				$asset->is_registered = wp_style_is( $asset->slug, 'registered' );
-				bdump(
-					'style - ' . $asset->slug
-				);
 			}
 
 			// If we don't have an action we don't even register the action to enqueue.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -265,7 +265,7 @@ class Tribe__Main {
 
 		tribe_asset(
 			$this,
-			'tribe-tooltip',
+			'tribe-tooltip-js',
 			'tooltip.js',
 			[ 'tribe-common' ],
 			'admin_enqueue_scripts',

--- a/src/Tribe/Service_Providers/Tooltip.php
+++ b/src/Tribe/Service_Providers/Tooltip.php
@@ -37,7 +37,7 @@ class Tribe__Service_Providers__Tooltip extends tad_DI52_ServiceProvider {
 	public function add_tooltip_assets() {
 		tribe_asset(
 			Tribe__Main::instance(),
-			'tribe-tooltip',
+			'tribe-tooltip-css',
 			'tooltip.css',
 			[],
 			[ 'wp_enqueue_scripts', 'admin_enqueue_scripts' ]

--- a/src/resources/js/tooltip.js
+++ b/src/resources/js/tooltip.js
@@ -37,9 +37,7 @@ tribe.tooltip = tribe.tooltip || {};
 	 * @return {void}
 	 */
 	obj.onClick = function () {
-		console.log('click');
 		var $tooltip = $( this ).closest( obj.selectors.tooltip );
-		console.log(obj.selectors.active);
 		var add = ! $tooltip.hasClass( obj.selectors.active );
 
 		$( obj.selectors.tooltip ).each( function () {

--- a/src/resources/js/tooltip.js
+++ b/src/resources/js/tooltip.js
@@ -14,7 +14,7 @@ tribe.tooltip = tribe.tooltip || {};
 	 */
 	obj.selectors = {
 		tooltip: '.tribe-tooltip',
-		active: '.active',
+		active: 'active',
 	};
 
 	/**
@@ -37,15 +37,17 @@ tribe.tooltip = tribe.tooltip || {};
 	 * @return {void}
 	 */
 	obj.onClick = function () {
+		console.log('click');
 		var $tooltip = $( this ).closest( obj.selectors.tooltip );
-		var add = ! $tooltip.hasClass( obj.selectors.active.className );
+		console.log(obj.selectors.active);
+		var add = ! $tooltip.hasClass( obj.selectors.active );
 
 		$( obj.selectors.tooltip ).each( function () {
-			$( this ).removeClass( obj.selectors.active.className ).attr( 'aria-expanded', false );
+			$( this ).removeClass( obj.selectors.active ).attr( 'aria-expanded', false );
 		} );
 
 		if ( add ) {
-			$( $tooltip ).addClass( obj.selectors.active.className ).attr( 'aria-expanded', true );
+			$( $tooltip ).addClass( obj.selectors.active ).attr( 'aria-expanded', true );
 		}
 	};
 


### PR DESCRIPTION
A few things happening here. First, we changed the style and script names so they are different to
avoid any checks incorrectly tossing one out. 

Then we instituted a check for assets that had already been registered - no need to do so twice. 

We also utilized `wp_style_is` and `wp_script_is` for more accurate information on registered assets. 

Then we went into the script and tweaked a few things - mainly removed a `.` from the beginning of the class name - since that isn't a valid class name and won't match the `className` check later in the script.

🎫 https://central.tri.be/issues/130658