### PR TITLE
fix(tribe_get_event) add and use Lazy_Events

### DIFF
--- a/src/Tribe/Utils/Lazy_Collection.php
+++ b/src/Tribe/Utils/Lazy_Collection.php
@@ -85,6 +85,7 @@ class Lazy_Collection implements Collection_Interface {
 
 		$items       = call_user_func( $this->callback );
 		$this->items = (array) $items;
+		$this->resolved();
 	}
 
 	/**

--- a/src/Tribe/Utils/Lazy_Collection.php
+++ b/src/Tribe/Utils/Lazy_Collection.php
@@ -33,6 +33,7 @@ namespace Tribe\Utils;
  */
 class Lazy_Collection implements Collection_Interface {
 	use Collection_Trait;
+	use Lazy_Events;
 
 	/**
 	 * The callback in charge of providing the elements.

--- a/src/Tribe/Utils/Lazy_Events.php
+++ b/src/Tribe/Utils/Lazy_Events.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Provides methods for "lazy" objects to act upon life cycle events.
+ *
+ * @since   TBD
+ *
+ * @example
+ * ```php
+ *         class Lazy_List_Of_Stuff {
+ *              use Tribe\Utils\Lazy_Events;
+ *
+ *              protected $list;
+ *
+ *              public function fetch_list(){
+ *                  $cached = wp_cache_get( 'list_of_stuff_one' );
+ *
+ *                  if( false !== $cached ){
+ *                      return $cached;
+ *
+ *                      if( null === $this->list ){
+ *                          $this->list = really_expensive_calculation();
+ *                      }
+ *
+ *                      $this->resolved();
+ *                  }
+ *
+ *                  return $this->list;
+ *              }
+ *         }
+ *
+ *         class Lazy_Value {
+ *              use Tribe\Utils\Lazy_Events;
+ *
+ *              protected $value;
+ *
+ *              public function calculate_value(){
+ *                  $cached = wp_cache_get( 'expensive_value' );
+ *
+ *                  if( false !== $cached ){
+ *                      return $cached;
+ *
+ *                      if( null === $this->value ){
+ *                          $this->value = really_expensive_calculation();
+ *                      }
+ *
+ *                      $this->resolved();
+ *                  }
+ *
+ *                  return $this->value;
+ *              }
+ *          }
+ *
+ *          class List_And_Value {
+ *              protected $list;
+ *              protected $value;
+ *
+ *              public function __construct( Lazy_List_Of_Stuff $list, Lazy_Value $value ){
+ *                  $this->list = $list;
+ *                  $this->value = $value;
+ *                  $this->list->on_resolve( [ $this, 'cache' ] );
+ *                  $this->value->on_resolve( [ $this, 'cache' ] );
+ *              }
+ *
+ *              public function cache(){
+ *                  wp_cache_set( 'list_and_value', [
+ *                      'list' => $this->list->fetch_list(),
+ *                      'value' => $this->value->calculate_value(),
+ *                  ]);
+ *              }
+ *
+ *              public function get_list(){
+ *                  $cached = wp_cache_get( 'list_and_value' );
+ *
+ *                  return $cached ? $cached['list'] : $this->list->fetch_list();
+ *              }
+ *
+ *              public function get_value(){
+ *                  $cached = wp_cache_get( 'list_and_value' );
+ *
+ *                  return $cached ? $cached['value'] : $this->value->fetch_value();
+ *              }
+ *          }
+ *
+ *
+ *         $list = new Lazy_List_Of_Stuff();
+ *         $value = new Lazy_Value();
+ *         $list_and_value = new List_And_Value( $list, $value );
+ *
+ *         // Accessing `value` will make it so that `list` too will be cached.
+ *         $list_and_value->get_value();
+ * ````
+ *
+ * @package Tribe\Utils
+ */
+
+namespace Tribe\Utils;
+
+/**
+ * Trait Lazy_Events
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Utils
+ *
+ * @property string $lazy_resolve_action The action to which the trait will hook to run the callback if the object
+ *                                       resolved. Using classes should define the property if the default `shutdown`
+ *                                       one is not correct.
+ * @property int $lazy_resolve_priority The priority at which the resolution callback will be hooked on the
+ *                                      `$lazy_resolve_action`; defaults to `10`.
+ */
+trait Lazy_Events {
+
+	/**
+	 * The callback that will be called when, and if, the lazy object resolved at least once.
+	 *
+	 * @since TBD
+	 *
+	 * @var
+	 */
+	protected $lazy_resolve_callback;
+
+	/**
+	 * Sets the callback that will be hooked to the resolve action when, and if, the `resolved` method is called.
+	 *
+	 * @since TBD
+	 *
+	 * @param callable $callback The callback that will be hooked on the `$lazy_resolve_action` (defaults to `shutdown`)
+	 *                           if the `resolved` method is called.
+	 *
+	 * @see Lazy_Events::resolved()
+	 */
+	public function on_resolve( callable $callback ) {
+		$this->lazy_resolve_callback = $callback;
+	}
+
+	/**
+	 * Hooks the `$lazy_resolve_callback` to the `$lazy_resolve_action` with the `$lazy_resolve_priority` if set.
+	 *
+	 * @since TBD
+	 */
+	protected function resolved() {
+		if ( empty( $this->lazy_resolve_callback ) ) {
+			return;
+		}
+
+		$action   = property_exists( $this, 'lazy_resolve_action' ) ?
+			$this->lazy_resolve_action
+			: 'shutdown';
+		$priority = property_exists( $this, 'lazy_resolve_priority' ) ?
+			$this->lazy_resolve_priority
+			: 10;
+
+		$hooked = has_action( $action, $this->lazy_resolve_callback );
+
+		// Let's play it safe and move the caching as late as possible.
+		$new_priority = false !== $hooked ? max( $hooked, $priority ) : $priority;
+
+		if ( is_numeric( $hooked ) && $hooked !== $new_priority ) {
+			remove_action( $action, $this->lazy_resolve_callback, $hooked );
+		}
+
+		add_action( $action, $this->lazy_resolve_callback, $new_priority );
+	}
+}

--- a/src/Tribe/Utils/Lazy_Events.php
+++ b/src/Tribe/Utils/Lazy_Events.php
@@ -156,7 +156,7 @@ trait Lazy_Events {
 
 		$hooked = has_action( $action, $this->lazy_resolve_callback );
 
-		// Let's play it safe and move the caching as late as possible.
+		// Let's play it safe and move the resoloution as late as possible.
 		$new_priority = false !== $hooked ? max( $hooked, $priority ) : $priority;
 
 		if ( is_numeric( $hooked ) && $hooked !== $new_priority ) {

--- a/src/Tribe/Utils/Lazy_Events.php
+++ b/src/Tribe/Utils/Lazy_Events.php
@@ -127,10 +127,14 @@ trait Lazy_Events {
 	 * @param callable $callback The callback that will be hooked on the `$lazy_resolve_action` (defaults to `shutdown`)
 	 *                           if the `resolved` method is called.
 	 *
+	 * @return static The object instance.
+	 *
 	 * @see Lazy_Events::resolved()
 	 */
 	public function on_resolve( callable $callback ) {
 		$this->lazy_resolve_callback = $callback;
+
+		return $this;
 	}
 
 	/**

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -12,6 +12,8 @@ namespace Tribe\Utils;
 
 
 class Lazy_String implements \Serializable, \JsonSerializable {
+	use Lazy_Events;
+
 	/**
 	 * The string value produced by the callback, cached.
 	 *

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -72,6 +72,7 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	public function __toString() {
 		if ( null === $this->string ) {
 			$this->string = call_user_func( $this->value_callback );
+			$this->resolved();
 		}
 
 		return $this->string;

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -28,6 +28,8 @@ use Tribe__Utils__Array as Arr;
  * @package Tribe\Utils
  */
 class Post_Thumbnail implements \ArrayAccess, \Serializable {
+	use Lazy_Events;
+
 	/**
 	 * An array of the site image sizes, including the `full` one.
 	 *

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -200,6 +200,8 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		 */
 		$thumbnail_data = apply_filters( 'tribe_post_thumbnail_data', $thumbnail_data, $post_id );
 
+		$this->resolved();
+
 		return $thumbnail_data;
 	}
 

--- a/tests/wpunit/Tribe/Utils/Lazy_EventsTest.php
+++ b/tests/wpunit/Tribe/Utils/Lazy_EventsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tribe\Utils;
+
+class Lazy_EventsTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * It should call the resolve callback if set and resolved
+	 *
+	 * @test
+	 */
+	public function should_call_the_resolve_callback_if_set_and_resolved() {
+		$lazy = $this->make_lazy_object();
+
+		$called = false;
+		$lazy->on_resolve( static function () use ( &$called ) {
+			$called = true;
+		} );
+
+		$this->assertEquals( 'test', $lazy->resolve() );
+
+		do_action( 'test_action' );
+
+		$this->assertTrue( $called );
+	}
+
+	protected function make_lazy_object() {
+		$lazy = new class {
+			use Lazy_Events;
+
+			protected $lazy_resolve_action = 'test_action';
+			public $lazy_resolve_priority = 23;
+
+			public function resolve() {
+				$this->resolved();
+
+				return 'test';
+			}
+		};
+
+		return $lazy;
+	}
+
+	/**
+	 * It should only call the resolve callback once even if hooked multiple times.
+	 *
+	 * @test
+	 */
+	public function should_only_call_the_resolve_callback_once_even_if_hooked_multiple_times_() {
+		$lazy_1 = $this->make_lazy_object();
+		$lazy_2 = $this->make_lazy_object();
+		$lazy_3 = $this->make_lazy_object();
+
+		$on_resolve = function () {
+			yield true;
+			$this->fail( 'The on_resolve callback should be called once.' );
+		};
+
+		$lazy_1->on_resolve( $on_resolve );
+		$lazy_2->on_resolve( $on_resolve );
+		$lazy_3->on_resolve( $on_resolve );
+
+		$this->assertEquals( 'test', $lazy_1->resolve() );
+		$this->assertEquals( 'test', $lazy_2->resolve() );
+		$this->assertEquals( 'test', $lazy_3->resolve() );
+
+		$this->assertEquals( 23, has_action( 'test_action', $on_resolve ) );
+
+		do_action( 'test_action' );
+	}
+
+	/**
+	 * It should hook the on_resolve callback at most once for different objects
+	 *
+	 * @test
+	 */
+	public function should_hook_the_on_resolve_callback_at_most_once_for_different_objects() {
+		$lazy_1 = $this->make_lazy_object();
+		$lazy_2 = $this->make_lazy_object();
+		$lazy_2->lazy_resolve_priority = 89;
+
+		$on_resolve = function () {
+			yield true;
+			$this->fail( 'The on_resolve callback should be called once.' );
+		};
+
+		$lazy_1->on_resolve( $on_resolve );
+		$lazy_2->on_resolve( $on_resolve );
+
+		$this->assertEquals( 'test', $lazy_1->resolve() );
+		$this->assertEquals( 'test', $lazy_2->resolve() );
+
+		$this->assertEquals( 89, has_action( 'test_action', $on_resolve ) );
+
+		do_action( 'test_action' );
+	}
+}


### PR DESCRIPTION
Ticket: n/a

This PR scaffolds the support code to make sure the `tribe_get_events` function will not eagerly cache.