### PR TITLE
build(package-whitelist.json) use correct path

### DIFF
--- a/package-whitelist.json
+++ b/package-whitelist.json
@@ -29,6 +29,6 @@
   "vendor/tribe-select2/*.png",
   "vendor/xrstf/composer-php52/*",
   "vendor/psr/log/Psr/Log/*.php",
-  "vendor/composer/monolog/monolog/src/*.php",
-  "vendor/composer/monolog/monolog/src/**/*.php"
+  "vendor/monolog/monolog/src/*.php",
+  "vendor/monolog/monolog/src/**/*.php"
 ]


### PR DESCRIPTION
Use the correct path to locate the Monolog library.