### PR TITLE
feat(Context) add LOCATION_FUNC support

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -129,6 +129,13 @@ class Tribe__Context {
 	 */
 	const WP_MATCHED_QUERY = 'wp_matched_query';
 
+	/**
+	 * The key to indicate a location should be read by applying a callback to the value of another context location.
+	 *
+	 * @since TBD
+	 */
+	const LOCATION_FUNC = 'location_func';
+
 	/*
 	 *
 	 * An array defining the properties the context will be able to read and (dangerously) write.
@@ -155,6 +162,7 @@ class Tribe__Context {
 	 * method - get the value calling a method on a tribe() container binding.
 	 * func - get the value from a function or a closure.
 	 * filter - get the value by applying a filter.
+	 * location_func - get the value by applying a callback to the value of a location.
 	 *
 	 * For each location additional arguments can be specified:
 	 * orm_arg - if `false` then the location will never produce an ORM argument, if provided the ORM arg produced bye the
@@ -1449,5 +1457,37 @@ class Tribe__Context {
 		}
 
 		return $filled;
+	}
+
+	/**
+	 * Convenience method to get and check if a location has a truthy value or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $flag_key The location to check.
+	 * @param bool   $default  The default value to return if the location is not set.
+	 *
+	 * @return bool Whether the location has a truthy value or not.
+	 */
+	public function is( $flag_key, $default = false ) {
+		$val = $this->get( $flag_key, $default );
+
+		return ! empty( $val ) || tribe_is_truthy( $val );
+	}
+
+	/**
+	 * Reads the value from one callback, passing it the value of another Context location.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $location_and_callback An array of two elements: the location key and the callback to call on the
+	 *                                     location value. The callback will receive the location value as argument.
+	 *
+	 * @return mixed The return value of the callback, called on the location value.
+	 */
+	public function location_func( array $location_and_callback ) {
+		list( $location, $callback ) = $location_and_callback;
+
+		return $callback( $this->get( $location ) );
 	}
 }

--- a/src/Tribe/Context/locations.php
+++ b/src/Tribe/Context/locations.php
@@ -67,4 +67,11 @@ return [
 			Tribe__Context::QUERY_VAR   => [ 'name', 'post_name' ],
 		],
 	],
+	'post_type' => [
+		'read' => [
+			Tribe__Context::QUERY_PROP  => 'post_type',
+			Tribe__Context::QUERY_VAR   => 'post_type',
+			Tribe__Context::REQUEST_VAR => 'post_type',
+		],
+	],
 ];

--- a/tests/wpunit/Tribe/ContextTest.php
+++ b/tests/wpunit/Tribe/ContextTest.php
@@ -1511,4 +1511,34 @@ class ContextTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $populated );
 	}
+
+
+	/**
+	 * It should allow getting a value calling a function on a location value.
+	 *
+	 * @test
+	 */
+	public function should_allow_getting_a_value_calling_a_fucntion_on_a_location_value() {
+		$context = tribe_context()->add_locations( [
+			'test_location' => [
+				'read' => [
+					Context::FUNC => static function () {
+						return 66;
+					}
+				]
+			],
+			'location_func' => [
+				'read' => [
+					Context::LOCATION_FUNC => [
+						'test_location',
+						static function ( $val ) {
+							return (int) $val + 23;
+						}
+					]
+				]
+			],
+		] );
+
+		$this->assertEquals( 89, $context->get( 'location_func' ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/129118

This PR adds the Context `LOCATION_FUNC` location type to read/write a context as the result of a callback called on another location value.

An example, given these locations:
```php
'post_type' => [
	'read' => [
			Tribe__Context::QUERY_PROP  => 'post_type',
			Tribe__Context::QUERY_VAR   => 'post_type',
			Tribe__Context::REQUEST_VAR => 'post_type',
		],
],
'tec_post_type' => [
		'read' => [
			Tribe__Context::LOCATION_FUNC => [
				'post_type',
				static function ( $post_type ) {
					return count( array_intersect(
							(array) $post_type,
							[ TEC::POSTTYPE, Venue::POSTTYPE, Organizer::POSTTYPE ] )
					);
				}
			],
		],
],

```

The `tec_post_type` location will be produced by passing the current value of the `post_type` location to the specified callback.
As any other Context location the location will be request cached, alterable, and overrideable in tests.