### PR TITLE
Feat - void_query support

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -474,6 +474,7 @@ class Tribe__Context {
 
 		foreach ( $request_vars as $request_var ) {
 			$the_value = tribe_get_request_var( $request_var, self::NOT_FOUND );
+			$the_value = filter_var( $the_value, FILTER_SANITIZE_STRING );
 			if ( $the_value !== self::NOT_FOUND ) {
 				$value = $the_value;
 				break;

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -559,6 +559,10 @@ abstract class Tribe__Repository
 	public function build_query( $use_query_builder = true ) {
 		$query = null;
 
+		if ( array_key_exists( 'void_query', $this->query_args ) && false !== $this->query_args['void_query'] ) {
+			$this->void_query = true;
+		}
+
 		// We'll let the query builder decide if the query has to be rebuilt or not.
 		if ( $use_query_builder && null !== $this->query_builder ) {
 			$query = $this->build_query_with_builder();
@@ -1068,7 +1072,9 @@ abstract class Tribe__Repository
 	 * {@inheritdoc}
 	 */
 	public function by( $key, $value = null ) {
-		if ( $this->void_query ) {
+		if ( $this->void_query || ( $key === 'void_query' && false !== $value ) ) {
+			$this->void_query = true;
+
 			// No point in doing more computations if the query is void.
 			return $this;
 		}

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -1072,7 +1072,7 @@ abstract class Tribe__Repository
 	 * {@inheritdoc}
 	 */
 	public function by( $key, $value = null ) {
-		if ( $this->void_query || ( $key === 'void_query' && false !== $value ) ) {
+		if ( $this->void_query || ( 'void_query' === $key && false !== $value ) ) {
 			$this->void_query = true;
 
 			// No point in doing more computations if the query is void.

--- a/tests/wpunit/Tribe/Repository/ReadTest.php
+++ b/tests/wpunit/Tribe/Repository/ReadTest.php
@@ -1041,4 +1041,23 @@ class ReadTest extends ReadTestBase {
 		$this->assertContainsOnlyInstancesOf( \WP_Post::class, $results );
 		$this->assertEquals( $queries_count + 1, $this->queries()->countQueries() );
 	}
+
+	/**
+	 * It should allow invalidating a query using args
+	 *
+	 * @test
+	 */
+	public function should_allow_invalidating_a_query_using_args() {
+		$repository = $this->repository();
+
+		foreach ( range( 1, 3 ) as $i ) {
+			static::factory()->post->create( [ 'post_type' => 'book' ] );
+		}
+
+		$this->assertCount( 3, $repository->all() );
+		$this->assertEmpty( $repository->by( 'void_query', true )->all() );
+		$this->assertEmpty( $repository->by_args( [ 'void_query' => true ] )->all() );
+		$this->assertCount( 0, $repository->by_args( [ 'void_query' => false ] )->all() );
+		$this->assertCount( 0, $repository->by( 'void_query', false )->all() );
+	}
 }

--- a/tests/wpunit/Tribe/RepositoryTest.php
+++ b/tests/wpunit/Tribe/RepositoryTest.php
@@ -5,7 +5,6 @@ namespace Tribe;
 require_once codecept_data_dir( 'classes/Repository/Book_Repository.php' );
 
 use Tribe\Common\Tests\Repository\Book_Repository as Repository;
-use Tribe__Repository__Read_Interface as Read_Interface;
 
 class RepositoryTest extends \Codeception\TestCase\WPTestCase {
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/134426 

This PR:

* ensures the request var values read from the context are sanitized (as strings)
* adds support, in the repository, for the `void_query` query var; this will void the query in an args compat way