### PR TITLE
Functions - add tribe_sanitize_deep

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,11 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - added the `tribe_sanitize_deep` function to sanitize and validate input values [134427]
+* Tweak - use the `tribe_sanitize_deep` function to sanitize the values returned by the `tribe_get_request_var` function [134427]
+
 = [4.9.17] 2019-09-16 =
 
 * Tweak - Changed the 'url' validation error text to just say it needs to be valid, not that it has to be a valid *absolute* URL [72214]

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -474,7 +474,6 @@ class Tribe__Context {
 
 		foreach ( $request_vars as $request_var ) {
 			$the_value = tribe_get_request_var( $request_var, self::NOT_FOUND );
-			$the_value = filter_var( $the_value, FILTER_SANITIZE_STRING );
 			if ( $the_value !== self::NOT_FOUND ) {
 				$value = $the_value;
 				break;

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -142,7 +142,9 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 	 * @return mixed
 	 */
 	function tribe_get_request_var( $var, $default = null ) {
-		return Tribe__Utils__Array::get_in_any( array( $_GET, $_POST, $_REQUEST ), $var, $default );
+		$unsafe = Tribe__Utils__Array::get_in_any( array( $_GET, $_POST, $_REQUEST ), $var, $default );
+
+		return tribe_sanitize_deep( $unsafe );
 	}
 }
 
@@ -675,5 +677,41 @@ if ( ! function_exists( 'tribe_get_request_vars' ) ) {
 		);
 
 		return $cache;
+	}
+}
+
+if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
+
+	/**
+	 * Sanitizes a value according to its type.
+	 *
+	 * The function will recursively sanitize array values.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value The value, or values, to sanitize.
+	 *
+	 * @return mixed|null Either the sanitized version of the value, or `null` if the value is not a string, number or
+	 *                    array.
+	 */
+	function tribe_sanitize_deep( &$value ) {
+		if ( is_string( $value ) ) {
+			$value = filter_var( $value, FILTER_SANITIZE_STRING );
+			return $value;
+		}
+		if ( is_int( $value ) ) {
+			filter_var( $value, FILTER_VALIDATE_INT );
+			return $value;
+		}
+		if ( is_float( $value ) ) {
+			filter_var( $value, FILTER_VALIDATE_FLOAT );
+			return $value;
+		}
+		if ( is_array( $value ) ) {
+			array_walk( $value, 'tribe_sanitize_deep' );
+			return $value;
+		}
+
+		return null;
 	}
 }

--- a/tests/wpunit/Tribe/functions/utilsTest.php
+++ b/tests/wpunit/Tribe/functions/utilsTest.php
@@ -142,4 +142,80 @@ class utilsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertFalse( tribe_post_exists( $user_id, 'page' ) );
 		$this->assertFalse( tribe_post_exists( $user_id, [ 'post', 'page' ] ) );
 	}
+
+	public function tribe_sanitize_deep_data_set() {
+		return [
+			'empty_string'            => [ '', '' ],
+			'spaces'                  => [ '  ', '  ' ],
+			'string'                  => [ 'hello world', 'hello world' ],
+			'int_zero'                => [ 0, 0 ],
+			'float_zero'              => [ 0.0, 0.0 ],
+			'int_value'               => [ 23, 23 ],
+			'float_value_wo_decimals' => [ 23.00, 23.00 ],
+			'float_value_w_decimals'  => [ 23.89, 23.89 ],
+			'string_w_tag'            => [ '<h1>Hello World!</h1>', 'Hello World!' ],
+			'string_url'              => [ 'http://example.org', 'http://example.org' ],
+			'string_ip_address'       => [ '1.1.2.3', '1.1.2.3' ],
+			'object'                  => [ new \stdClass(), null ],
+			'good_array'              => [
+				[
+					'string'                  => 'hello world',
+					'int_zero'                => 0,
+					'float_zero'              => 0.0,
+					'int_value'               => 23,
+					'float_value_wo_decimals' => 23.00,
+					'string_w_tag'            => '<h1>Hello World!</h1>',
+				],
+				[
+					'string'                  => 'hello world',
+					'int_zero'                => 0,
+					'float_zero'              => 0.0,
+					'int_value'               => 23,
+					'float_value_wo_decimals' => 23.00,
+					'string_w_tag'            => 'Hello World!',
+				],
+			],
+			'nested_array'            => [
+				[
+					'string'       => 'hello world',
+					'int_zero'     => 0,
+					'float_zero'   => 0.0,
+					'string_w_tag' => '<h1>Hello World!</h1>',
+					'sub_1'        => [
+						'int_value'               => 23,
+						'float_value_wo_decimals' => 23.00,
+						'string_w_tag'            => '<h1>Hello World!</h1>',
+						'sub_2'                   => [
+							'int_zero'     => 0,
+							'float_zero'   => 0.0,
+							'string_w_tag' => '<h1>Hello World!</h1>',
+						]
+					]
+				],
+				[
+					'string'       => 'hello world',
+					'int_zero'     => 0,
+					'float_zero'   => 0.0,
+					'string_w_tag' => 'Hello World!',
+					'sub_1'        => [
+						'int_value'               => 23,
+						'float_value_wo_decimals' => 23.00,
+						'string_w_tag'            => 'Hello World!',
+						'sub_2'                   => [
+							'int_zero'     => 0,
+							'float_zero'   => 0.0,
+							'string_w_tag' => 'Hello World!',
+						]
+					]
+				],
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider  tribe_sanitize_deep_data_set
+	 */
+	public function test_tribe_sanitize_deep( $input, $expected ) {
+		$this->assertEquals( $expected, tribe_sanitize_deep( $input ) );
+	}
 }


### PR DESCRIPTION
Tickets:

* https://central.tri.be/issues/134427
* https://central.tri.be/issues/134428

This PR adds the `tribe_sanitize_deep` function.

The function will sanitize a value, or an array of values to make sure the input is safe and valid, else will return `null`.

The PR, also, modifies the `tribe_get_request_var` function to use the `tribe_sanitize_deep` function before returning the request var.