### PR TITLE
Add a default value for `tribe_ev`

### DIFF
--- a/src/resources/js/dialog.js
+++ b/src/resources/js/dialog.js
@@ -1,4 +1,5 @@
 var tribe = tribe || {};
+var tribe_ev = tribe_ev || {};
 tribe.dialogs = tribe.dialogs || {};
 
 	( function ( obj ) {


### PR DESCRIPTION
Prevents console errors like the one in https://central.tri.be/issues/132568 (not the cause of that issue, but could have similar problems)