### PR TITLE
Define Promoter filter for Authentication early

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * Tweak - added the `tribe_sanitize_deep` function to sanitize and validate input values [134427]
 * Tweak - use the `tribe_sanitize_deep` function to sanitize the values returned by the `tribe_get_request_var` function [134427]
 * Tweak - Rename "Datepicker Date Format" to "Compact Date Format" [134526]
+* Tweak - Adjust Promoter loading order to increase compatibility with plugins that use authentication early in the process [134862]
 
 = [4.9.17] 2019-09-16 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,7 @@
 * Tweak - use the `tribe_sanitize_deep` function to sanitize the values returned by the `tribe_get_request_var` function [134427]
 * Tweak - Rename "Datepicker Date Format" to "Compact Date Format" [134526]
 * Tweak - Adjust Promoter loading order to increase compatibility with plugins that use authentication early in the process [134862]
+* Tweak - Add support for Authentication using a Header when using Promoter [133922]
 
 = [4.9.17] 2019-09-16 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -86,6 +86,8 @@ class Tribe__Main {
 		$parent_plugin_dir = trailingslashit( plugin_basename( $this->plugin_path ) );
 		$this->plugin_url  = plugins_url( $parent_plugin_dir === $this->plugin_dir ? $this->plugin_dir : $parent_plugin_dir );
 
+		$this->promoter_connector();
+
 		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 1 );
 		add_action( 'tribe_common_loaded', array( $this, 'tribe_common_app_store' ), 10 );
 	}
@@ -580,12 +582,29 @@ class Tribe__Main {
 
 		tribe_register_provider( Tribe__Editor__Provider::class );
 		tribe_register_provider( Tribe__Service_Providers__Debug_Bar::class );
-		tribe_register_provider( Tribe__Service_Providers__Promoter_Connector::class );
+		tribe_register_provider( Tribe__Service_Providers__Promoter::class );
 		tribe_register_provider( Tribe__Service_Providers__Tooltip::class );
 
 		tribe_register_provider( Tribe\Service_Providers\PUE::class );
 		tribe_register_provider( Tribe\Log\Service_Provider::class );
 	}
+
+	/**
+	 * Create the Promoter connector singleton early to allow hook into the filters early.
+	 *
+	 * Add a filter to determine_current_user during the setup of common library.
+	 *
+	 * @since TBD
+	 */
+	public function promoter_connector() {
+		tribe_singleton( 'promoter.connector', 'Tribe__Promoter__Connector' );
+
+		add_filter(
+			'determine_current_user',
+			tribe_callback( 'promoter.connector', 'authenticate_user_with_connector' )
+		);
+	}
+
 
 	/************************
 	 *                      *

--- a/src/Tribe/Promoter/Auth.php
+++ b/src/Tribe/Promoter/Auth.php
@@ -21,16 +21,6 @@ class Tribe__Promoter__Auth {
 	 */
 	public function __construct( Tribe__Promoter__Connector $connector ) {
 		$this->connector = $connector;
-		$this->hook();
-	}
-
-	/**
-	 * Attach hooks to this class.
-	 *
-	 * @since  4.9.12
-	 */
-	public function hook() {
-		add_filter( 'tribe_promoter_secret_key', [ $this, 'filter_promoter_secret_key' ] );
 	}
 
 	/**

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -197,7 +197,7 @@ class Tribe__Promoter__Connector {
 
 		$token = \Firebase\JWT\JWT::encode( $payload, $secret_key );
 
-		$url = $this->base_url();
+		$url = $this->base_url()  . 'connect/notify';
 
 		$args = [
 			'body' => [ 'token' => $token ],

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -240,15 +240,7 @@ class Tribe__Promoter__Connector {
 		$code     = wp_remote_retrieve_response_code( $response );
 		$body     = wp_remote_retrieve_body( $response );
 
-		if ( is_wp_error( $response ) ) {
-			tribe( 'logger' )->log( $response->get_error_message() );
-
-			return false;
-		}
-
-		if ( $code > 299 ) {
-			tribe( 'logger' )->log( $body, 0 );
-
+		if ( is_wp_error( $response ) || $code > 299 ) {
 			return false;
 		}
 

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -197,7 +197,7 @@ class Tribe__Promoter__Connector {
 
 		$token = \Firebase\JWT\JWT::encode( $payload, $secret_key );
 
-		$url = $this->base_url()  . 'connect/notify';
+		$url = $this->base_url() . 'connect/notify';
 
 		$args = [
 			'body' => [ 'token' => $token ],

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * Custom class for communicating with the Promoter Auth Connector
+ * Custom class for communicating with the Promoter Auth Connector the class is created
+ * early in the process and many functions that come from utils are not available during the
+ * execution of the methods from this class
  *
  * @since 4.9
  */

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -48,22 +48,18 @@ class Tribe__Promoter__Connector {
 	public function authorize_with_connector( $user_id, $secret_key, $promoter_key, $license_key ) {
 		$url = $this->base_url() . 'connect';
 
-		$payload = array(
+		$payload = [
 			'clientSecret' => $secret_key,
-			'licenseKey'   => $license_key,
-			'userId'       => $user_id,
-		);
-
-		tribe( 'logger' )->log( $url );
+			'licenseKey' => $license_key,
+			'userId' => $user_id,
+		];
 
 		$token = \Firebase\JWT\JWT::encode( $payload, $promoter_key );
 
-		$args = array(
-			'body'      => array( 'token' => $token ),
+		$response = $this->make_call( $url, [
+			'body' => [ 'token' => $token ],
 			'sslverify' => false,
-		);
-
-		$response = $this->make_call( $url, $args );
+		] );
 
 		return (bool) $response;
 	}
@@ -94,12 +90,10 @@ class Tribe__Promoter__Connector {
 
 		$url = $this->base_url() . 'connect/auth';
 
-		$args = array(
-			'body'      => array( 'token' => $token ),
+		$response = $this->make_call( $url, [
+			'body' => [ 'token' => $token ],
 			'sslverify' => false,
-		);
-
-		$response = $this->make_call( $url, $args );
+		] );
 
 		if ( ! $response ) {
 			return $user_id;
@@ -177,7 +171,7 @@ class Tribe__Promoter__Connector {
 	public function notify_promoter_of_changes( $post_id ) {
 		$post_type = get_post_type( $post_id );
 
-		if ( ! in_array( $post_type, array( 'tribe_events', 'tribe_tickets' ), true ) ) {
+		if ( ! in_array( $post_type, [ 'tribe_events', 'tribe_tickets' ], true ) ) {
 			return;
 		}
 
@@ -196,19 +190,19 @@ class Tribe__Promoter__Connector {
 			return;
 		}
 
-		$payload = array(
+		$payload = [
 			'licenseKey' => $license_key,
-			'sourceId'   => $post_id,
-		);
+			'sourceId' => $post_id,
+		];
 
 		$token = \Firebase\JWT\JWT::encode( $payload, $secret_key );
 
-		$url = $this->base_url() . 'connect/notify';
+		$url = $this->base_url();
 
-		$args = array(
-			'body'      => array( 'token' => $token ),
+		$args = [
+			'body' => [ 'token' => $token ],
 			'sslverify' => false,
-		);
+		];
 
 		$this->make_call( $url, $args );
 	}

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -24,13 +24,11 @@ class Tribe__Promoter__Connector {
 	 * @since 4.9
 	 */
 	public function base_url() {
-		$url = 'https://us-central1-promoter-auth-connector.cloudfunctions.net/promoterConnector/';
-
 		if ( defined( 'TRIBE_PROMOTER_AUTH_CONNECTOR_URL' ) ) {
-			$url = TRIBE_PROMOTER_AUTH_CONNECTOR_URL;
+			return TRIBE_PROMOTER_AUTH_CONNECTOR_URL;
 		}
 
-		return $url;
+		return 'https://us-central1-promoter-auth-connector.cloudfunctions.net/promoterConnector/';
 	}
 
 	/**

--- a/src/Tribe/Service_Providers/Promoter.php
+++ b/src/Tribe/Service_Providers/Promoter.php
@@ -7,14 +7,13 @@
  *
  * Handles the registration and creation of our async process handlers.
  */
-class Tribe__Service_Providers__Promoter_Connector extends tad_DI52_ServiceProvider {
+class Tribe__Service_Providers__Promoter extends tad_DI52_ServiceProvider {
 
 	/**
 	 * Binds and sets up implementations.
 	 */
 	public function register() {
 		tribe_singleton( 'promoter.auth', 'Tribe__Promoter__Auth' );
-		tribe_singleton( 'promoter.connector', 'Tribe__Promoter__Connector' );
 		tribe_singleton( 'promoter.pue', 'Tribe__Promoter__PUE', array( 'load' ) );
 		tribe_singleton( 'promoter.view', 'Tribe__Promoter__View' );
 
@@ -27,10 +26,13 @@ class Tribe__Service_Providers__Promoter_Connector extends tad_DI52_ServiceProvi
 	private function hook() {
 		add_action( 'template_redirect', tribe_callback( 'promoter.view', 'display_auth_check_view' ), 10, 0 );
 		add_action( 'init', tribe_callback( 'promoter.view', 'add_rewrites' ) );
-		// Add early-firing filter for user auth on REST.
-		add_filter( 'determine_current_user', tribe_callback( 'promoter.connector', 'authenticate_user_with_connector' ), 10, 1 );
 
 		tribe( 'promoter.pue' );
+
+		add_filter(
+			'tribe_promoter_secret_key',
+			tribe_callback( 'promoter.auth', 'filter_promoter_secret_key' )
+		);
 
 		// The usage of a high priority so we can push the icon to the end
 		add_action( 'admin_bar_menu', array( $this, 'add_promoter_logo_on_admin_bar' ), 1000 );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/134862
Ticket: https://central.tri.be/issues/133922

In order to prevent conflicts with plugins that try to determine if the user is authenticated or not before any Tribe plugin we define the filter ASAP in the loading process.