### PR TITLE
Adding a GitHub Action to perform automated code reviews with phpcs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Code Review
+on:
+  pull_request:
+    paths-ignore:
+      - 'lang/**'
+      - '**.txt'
+      - '**.md'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: moderntribe/action-tribe-phpcs@master
+        with:
+          github-bot-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
This will add our first GitHub action to tribe-common that allows for consistent code reviews that don't depend on Jenkins.

Here's the demo of this working on _this_ PR: https://github.com/moderntribe/tribe-common/pull/1171/checks?check_run_id=252105384

Related:

* https://github.com/moderntribe/the-events-calendar/pull/2743
* https://github.com/moderntribe/events-filterbar/pull/188
* https://github.com/moderntribe/events-pro/pull/1267