### PR TITLE
VR > Wild West Images > Add alt to the post thumbnail object.

### DIFF
--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -188,7 +188,10 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		$srcset                   = wp_get_attachment_image_srcset( $thumbnail_id );
 		$thumbnail_data['srcset'] = ! empty( $srcset ) ? $srcset : false;
 
-		$alt                   = get_the_title( $thumbnail_id );
+		$title                   = get_the_title( $thumbnail_id );
+		$thumbnail_data['title'] = ! empty( $title ) ? $title : false;
+
+		$alt                   = trim( strip_tags( get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ) ) );
 		$thumbnail_data['alt'] = ! empty( $alt ) ? $alt : false;
 
 		/**

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -188,6 +188,9 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		$srcset                   = wp_get_attachment_image_srcset( $thumbnail_id );
 		$thumbnail_data['srcset'] = ! empty( $srcset ) ? $srcset : false;
 
+		$alt                   = get_the_title( $thumbnail_id );
+		$thumbnail_data['alt'] = ! empty( $alt ) ? $alt : false;
+
 		/**
 		 * Filters the post thumbnail data and information that will be returned for a specific post.
 		 *


### PR DESCRIPTION
🎫 https://central.tri.be/issues/135820

Adding alt to the post thumbnail object so we can use it in the new image templates.