### PR TITLE
fix(Context.php) correctly pick up not_found values

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -383,7 +383,7 @@ class Tribe__Context {
 			foreach ( $locations[ $key ]['read'] as $location => $keys ) {
 				$the_value = $this->$location( (array) $keys, $default );
 
-				if ( $default !== $the_value ) {
+				if ( $default !== $the_value && static::NOT_FOUND !== $the_value ) {
 					$value = $the_value;
 					break;
 				}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/134639 

This PR fixes an issue where the Context would not correctly detect a location returning a value of `Tribe__Context::NOT_FOUND` as not found if a default value was set.