### PR TITLE
feat(Utils/Query.php) add Query utils

### DIFF
--- a/src/Tribe/Utils/Query.php
+++ b/src/Tribe/Utils/Query.php
@@ -22,7 +22,7 @@ class Query {
 	 * Builds a new `WP_Query` object and sets the post, and accessory flags, on it.
 	 *
 	 * The query is built to yield to run a query that will yield no result and to have a `request` property that
-	 * will never yield results; calls on the `WP_Query::get_posts` method are filtered to return always the post set.
+	 * will never yield results; calls on the `WP_Query::get_posts` method are filtered to always return the post set.
 	 * Queries built by this function can be spotted by looking for the `tribe_mock_query` property.
 	 *
 	 * @since TBD
@@ -47,8 +47,7 @@ class Query {
 		$query->request = "SELECT ID FROM {$wpdb->posts} WHERE 1=0";
 
 		// Return the same set of posts on each method requiring posts.
-		$filter_posts_pre_query = static function ( $the_posts, $the_query ) use ( $posts, $query )
-		{
+		$filter_posts_pre_query = static function ( $the_posts, $the_query ) use ( $posts, $query ) {
 			if ( $the_query !== $query ) {
 				return $the_posts;
 			}

--- a/src/Tribe/Utils/Query.php
+++ b/src/Tribe/Utils/Query.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Provides utility method related to the creation and manipulation of queries and query objects.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Utils
+ */
+
+namespace Tribe\Utils;
+
+/**
+ * Class Query
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Utils
+ */
+class Query {
+
+	/**
+	 * Builds a new `WP_Query` object and sets the post, and accessory flags, on it.
+	 *
+	 * The query is built to yield to run a query that will yield no result and to have a `request` property that
+	 * will never yield results; calls on the `WP_Query::get_posts` method are filtered to return always the post set.
+	 * Queries built by this function can be spotted by looking for the `tribe_mock_query` property.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $posts The array of posts that should be used to build the query.
+	 *
+	 * @return \WP_Query The new WP_Query object, built to reflect the posts passed to it.
+	 */
+	public static function for_posts( array $posts = [] ) {
+		if ( empty( $posts ) ) {
+			$posts = [];
+		}
+
+		$query                   = new \WP_Query();
+		$query->posts            = $posts;
+		$query->found_posts      = count( $posts );
+		$query->post             = reset( $posts );
+		$query->query            = [ 'p' => 0 ];
+		$query->tribe_mock_query = true;
+		global $wpdb;
+		// Use a query that will never yield results.
+		$query->request = "SELECT ID FROM {$wpdb->posts} WHERE 1=0";
+
+		// Return the same set of posts on each method requiring posts.
+		$filter_posts_pre_query = static function ( $the_posts, $the_query ) use ( $posts, $query )
+		{
+			if ( $the_query !== $query ) {
+				return $the_posts;
+			}
+
+			$fields = $query->get( 'fields', false );
+			// We assume some uniformity here.
+			$posts_are_objects = ! is_numeric( reset( $posts ) );
+
+			switch ( $fields ) {
+				case 'ids':
+					return $posts_are_objects ? wp_list_pluck( $posts, 'ID' ) : $posts;
+				case 'id=>parent':
+				default:
+					return $posts_are_objects ? $posts : array_map( 'get_post', $posts );
+			}
+		};
+
+		add_filter( 'posts_pre_query', $filter_posts_pre_query, 10, 2 );
+
+		return $query;
+	}
+}

--- a/tests/wpunit/Tribe/Utils/QueryTest.php
+++ b/tests/wpunit/Tribe/Utils/QueryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tribe\Utils;
+
+class QueryTest extends \Codeception\TestCase\WPTestCase {
+
+	public function test_for_posts_w_empty_posts() {
+		$query = Query::for_posts( [] );
+
+		$this->assertEquals( [], $query->posts );
+		$this->assertFalse( $query->post );
+		$this->assertEquals( 0, $query->found_posts );
+		$this->assertEquals( [], $query->get_posts() );
+	}
+
+	public function test_for_posts_with_posts() {
+		$posts = array_map( static function ()
+		{
+			return static::factory()->post->create_and_get();
+		},
+			range( 1, 3 ) );
+
+
+		$query = Query::for_posts( $posts );
+
+		$this->assertEquals( $posts, $query->posts );
+		$this->assertEquals( reset( $posts ), $query->post );
+		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( $posts, $query->get_posts() );
+
+		$query->set( 'fields', 'all' );
+		$this->assertEquals( $posts, $query->get_posts() );
+
+		$query->set( 'fields', 'ids' );
+		$this->assertEquals( wp_list_pluck( $posts, 'ID' ), $query->get_posts() );
+
+		$query->set( 'fields', 'id=>parent' );
+		$expected = array_combine(
+			wp_list_pluck( $posts, 'ID' ),
+			wp_list_pluck( $posts, 'post_parent' )
+		);
+		$this->assertEquals( $expected, $query->get_posts() );
+	}
+
+	public function test_for_posts_w_ids() {
+		$posts = array_map( static function ()
+		{
+			return static::factory()->post->create();
+		},
+			range( 1, 3 ) );
+
+
+		$query = Query::for_posts( $posts );
+
+		$this->assertEquals( $posts, $query->posts );
+		$this->assertEquals( reset( $posts ), $query->post );
+		$this->assertEquals( 3, $query->found_posts );
+		$this->assertEquals( array_map( 'get_post', $posts ), $query->get_posts() );
+
+		$query->set( 'fields', 'all' );
+		$this->assertEquals( array_map( 'get_post', $posts ), $query->get_posts() );
+
+		$query->set( 'fields', 'ids' );
+		$this->assertEquals( $posts, $query->get_posts() );
+
+		$query->set( 'fields', 'id=>parent' );
+		$expected = array_combine(
+			$posts,
+			array_fill( 0, 3, 0 )
+		);
+		$this->assertEquals( $expected, $query->get_posts() );
+	}
+}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/136622

This PR adds the `Tribe\Utils\Query` class.
The class now provides just one method: `Query::for_posts( array $posts )`.
The method builds and returns a `WP_Query` object that will return the posts passed to it behaving like a query, but not running a query.