### PR TITLE
feat(Context) add the safe_set method

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -1571,4 +1571,29 @@ class Tribe__Context {
 
 		return $location;
 	}
+
+	/**
+	 * Safely set the value of a group of locations.
+	 *
+	 * This method can only augment the context, without altering it; it can only add new values.
+	 *
+	 * @since TBD
+	 *
+	 * @param array|string $values The values to set, if not already set or the key of the value to set, requires
+	 *                             the `$value` to be passed.
+	 * @param mixed|null $value    The value to set for the key, this parameter will be ignored if the `$values_or_key`
+	 *                             parameter is not a string.
+	 */
+	public function safe_set( $values_or_key, $value = null ) {
+		$values = func_num_args() === 2
+			? [ $values_or_key => $value ]
+			: $values_or_key;
+
+		foreach ( $values as $key => $val ) {
+			if ( static::NOT_FOUND !== $this->get( $key, static::NOT_FOUND ) ) {
+				continue;
+			}
+			$this->request_cache[ $key ] = $val;
+		}
+	}
 }

--- a/tests/wpunit/Tribe/ContextTest.php
+++ b/tests/wpunit/Tribe/ContextTest.php
@@ -1541,4 +1541,28 @@ class ContextTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( 89, $context->get( 'location_func' ) );
 	}
+
+	/**
+	 * It should allow safe seting of values
+	 *
+	 * @test
+	 */
+	public function should_allow_safe_seting_of_values() {
+		$context = tribe_context()->add_locations( [
+			'test_location' => [
+				'read' => [
+					Context::FUNC => static function ()
+					{
+						return 66;
+					}
+				]
+			],
+		] );
+
+		$context->safe_set( 'test_location', 23 );
+		$context->safe_set( [ 'test_location_2' => 89 ] );
+
+		$this->assertEquals( 66, $context->get( 'test_location' ) );
+		$this->assertEquals( 89, $context->get( 'test_location_2' ) );
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/137410

This PR adds the `Tribe__Context::safe_set` method.
The method allows **writing into a context instance as long as the location(s) are not found**.

This feature tries to strike a balance between the context immutability and the fact that classes receiving the context might need to add data to it as part of their mandate.
The case here is that, on PRO, the geo-location resolution handlers will add latitude and longitude coordinates to the context after resolving the geo-location-based search.

In code:
```php
$context = tribe_context()->alter([
	'foo' => 23
]);

// The `foo` location is already set, it will not be over-written.
$context->safe_write('foo', 89);

assert(23 !== $context->get('foo'));

// The `bar` location is not set/found, it will be written.
$context->safe_write('bar', 66);

assert(66 === $context->get('bar'));
```