### PR TITLE
refactor(Timezones.php) use Tribe_Cache to cache

### DIFF
--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -10,24 +10,12 @@ class Tribe__Timezones {
 	const SITE_TIMEZONE  = 'site';
 	const EVENT_TIMEZONE = 'event';
 
-
 	/**
 	 * Container for reusable DateTimeZone objects.
 	 *
 	 * @var array
 	 */
 	protected static $timezones = array();
-
-	/**
-	 * A static cache.
-	 *
-	 * @since TBD
-	 *
-	 * @var array
-	 */
-	protected static $cache = [
-		'build_timezone_object' => [],
-	];
 
 	public static function init() {
 		self::invalidate_caches();
@@ -591,8 +579,11 @@ class Tribe__Timezones {
 			return $timezone;
 		}
 
-		if ( is_string( $timezone ) && isset( static::$cache['build_timezone_object'][ $timezone ] ) ) {
-			return clone static::$cache['build_timezone_object'][ $timezone ];
+		/** @var Tribe__Cache $cache */
+		$cache = tribe('cache');
+
+		if ( is_string( $timezone ) && $cached = $cache[ __METHOD__ . $timezone ] ) {
+			return clone $cached;
 		}
 
 		$timezone = null === $timezone ? self::wp_timezone_string() : $timezone;
@@ -604,7 +595,7 @@ class Tribe__Timezones {
 		}
 
 		if ( is_string( $timezone ) ) {
-			static::$cache['build_timezone_object'][ $timezone ] = $object;
+			$cache[ __METHOD__ . $timezone ] = $object;
 		}
 
 		return $object;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/136624

This PR refactors the modification done in #1209 (and its reproposition on a diff. base #1219) to use `Tribe__Cache` to cache timezone results on a request basis.

This offers 2 advantages:

1. Calls to `wp_cache_flush`, like those done in the context of tests, will clear the cache without need to "run after" each caching class and call static, cache-reset, methods.
2. It leverages `Tribe__Cache` implementation of `ArrayAccess` that makes any value set with the array API be a non-permanent one.