### PR TITLE
VR - Support perf. improvments step 2

### DIFF
--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -278,9 +278,10 @@ class Tribe__Cache implements ArrayAccess {
 	 *
 	 * @since TBD
 	 *
-	 * @param array|int $post_ids A post ID, or a collection of post IDs.
+	 * @param array|int $post_ids               A post ID, or a collection of post IDs.
+	 * @param bool      $update_post_meta_cache Whether to warm-up the post meta cache for the posts or not.
 	 */
-	public function warmup_post_caches( $post_ids ) {
+	public function warmup_post_caches( $post_ids, $update_post_meta_cache = false ) {
 		if ( empty( $post_ids ) ) {
 			return;
 		}
@@ -307,7 +308,8 @@ class Tribe__Cache implements ArrayAccess {
 		$limit = $feature_detection->mysql_limit_for_example( 'post_result' );
 
 		/**
-		 * Filters the LIMIT that should be used to warm-up post caches.
+		 * Filters the LIMIT that should be used to warm-up post caches and postmeta caches (if the
+		 * `$update_post_meta_cache` parameter is `true`).
 		 *
 		 * Lower this value on less powerful hosts. Return `0` to disable the warm-up completely, and `-1` to remove the
 		 * limit (not recommended).
@@ -338,11 +340,16 @@ class Tribe__Cache implements ArrayAccess {
 					$post = new \WP_Post( $post_object );
 					wp_cache_set( $post_object->ID, $post, 'posts' );
 				}
+
+				if ( $update_post_meta_cache ) {
+					update_meta_cache( 'post', $these_ids );
+				}
 			}
 		} while (
 			! empty( $post_objects )
 			&& is_array( $post_objects )
 			&& count( $post_objects ) < count( $post_ids )
 		);
-	}
+
+    }
 }

--- a/src/Tribe/Models/Post_Types/Base.php
+++ b/src/Tribe/Models/Post_Types/Base.php
@@ -180,21 +180,26 @@ abstract class Base {
 			return '__return_true';
 		}
 
-		// Cache by post ID and filter.
-		$cache_key  = $cache_slug . '_' . $this->post->ID . '_' . $filter;
-		$cache      = new Cache();
+		$callback = null;
 
-		// Define a function to cache this event when, and if, one of the lazy properties is loaded.
-		$callback = function () use ( $cache, $cache_key, $filter )
-		{
-			$properties = $this->get_properties( $filter );
-
+		if ( wp_using_ext_object_cache() ) {
 			/*
-			 * Cache without expiration, but only until a post of the types managed by The Events Calendar is
-			 * updated or created.
+			 * If any real caching is in place , then define a function to cache this event when, and if, one of the
+			 * lazy properties is loaded.
+			 * Cache by post ID and filter.
 			 */
-			$cache->set( $cache_key, $properties, 0, Cache_Listener::TRIGGER_SAVE_POST );
-		};
+			$cache_key = $cache_slug . '_' . $this->post->ID . '_' . $filter;
+			$cache     = new Cache();
+			$callback  = function () use ( $cache, $cache_key, $filter ) {
+				$properties = $this->get_properties( $filter );
+
+				/*
+				 * Cache without expiration, but only until a post of the types managed by The Events Calendar is
+				 * updated or created.
+				 */
+				$cache->set( $cache_key, $properties, 0, Cache_Listener::TRIGGER_SAVE_POST );
+			};
+		}
 
 		return $callback;
 	}

--- a/src/Tribe/Utils/Collection_Trait.php
+++ b/src/Tribe/Utils/Collection_Trait.php
@@ -170,14 +170,25 @@ trait Collection_Trait {
 	}
 
 	/**
-	 * Applies a filter callback to each element of this collection.
+	 * Applies a filter callback to each element of this collection changing the collection elements to only those
+	 * passing the filter.
 	 *
 	 * @since TBD
 	 *
 	 * @param callable $filter_callback The filter callback that will be applied to each element of the collection; the
 	 *                                  callback will receive the element as parameter.
+	 *
+	 * @return Collection_Trait A new collection instance, that contains only the elements that passed the filter.
 	 */
 	public function filter( $filter_callback ) {
-		$this->event_results = array_filter( $this->all(), $filter_callback );
+		if ( $this->count() === 0 ) {
+			// If there is nothing to filter to begin with, just return this.
+			return $this;
+		}
+
+		$filtered        = new static();
+		$filtered->items = array_filter( $this->all(), $filter_callback );
+
+		return $filtered;
 	}
 }

--- a/src/Tribe/Utils/Lazy_Events.php
+++ b/src/Tribe/Utils/Lazy_Events.php
@@ -131,7 +131,11 @@ trait Lazy_Events {
 	 *
 	 * @see Lazy_Events::resolved()
 	 */
-	public function on_resolve( callable $callback ) {
+	public function on_resolve( callable $callback = null ) {
+		if ( null === $callback ) {
+			return $this;
+		}
+
 		$this->lazy_resolve_callback = $callback;
 
 		return $this;


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/136624 

This PR lays out some smaller optimizations to support further performance tweaking:

* allow updating the post meta caches too when warming up the post caches; this removes the single queries for each.
* do not try to store the post models on `__destruct` when there is no persistent caching; this avoids the cost of resolving all lazy "things" when there's no chance to leverage their value in the next request.