### PR TITLE
feat(Date_Utils) add immutable method and tests

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1225,17 +1225,20 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 			}
 
 			$timezone_object = null;
+			$datetime = empty($datetime) ? 'now' : $datetime;
 
 			try {
 				// PHP 5.2 will not throw an exception but will generate an error.
 				$utc = new DateTimeZone( 'UTC' );
+				$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
 
 				if ( self::is_timestamp( $datetime ) ) {
 					// Timestamps timezone is always UTC.
-					return new DateTime( '@' . $datetime, $utc );
-				}
+					$date =  new DateTime( '@' . $datetime, $utc );
 
-				$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+					// If we have a timezone, then set it.
+					return $timezone ? $date->setTimezone( $timezone_object ) : $date;
+				}
 
 				set_error_handler( 'tribe_catch_and_throw' );
 				$date = new DateTime( $datetime, $timezone_object );
@@ -1284,28 +1287,30 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		public static function get_week_start_end( $date, $start_of_week = null ) {
 			$week_start = static::build_date_object( $date );
 			$week_start->setTime( 0, 0, 0 );
+			// `0` (for Sunday) through `6` (for Saturday), the way WP handles the `start_of_week` option.
+			$week_start_day = null !== $start_of_week
+				? (int) $start_of_week
+				: (int) get_option( 'start_of_week', 0 );
 
-			// `0` (for Sunday) through `6` (for Saturday); we correct Sunday to stick w/ ISO notation.
-			$week_start_day = null !== $start_of_week ? (int) $start_of_week : (int) get_option( 'start_of_week', 0 );
-			if ( 0 === $week_start_day ) {
-				$week_start_day = 7;
+			$cache_key = md5(
+				__METHOD__ . serialize( [ $week_start->format( static::DBDATEFORMAT ), $week_start_day ] )
+			);
+			$cache = tribe( 'cache' );
+
+			if ( false !== $cached = $cache[ $cache_key ] ) {
+				return $cached;
 			}
-			// `1` (for Monday) through `7` (for Sunday).
-			$date_day = (int) $week_start->format( 'N' );
+
+			// `0` (for Sunday) through `6` (for Saturday), the way WP handles the `start_of_week` option.
+			$date_day = (int) $week_start->format( 'w' );
+
+			// If the current date is before the start of the week, move back a week.
+			$week_offset = $date_day < $week_start_day ? - 1 : 0;
 
 			/*
 			 * From the PHP docs, the `W` format stands for:
 			 * - ISO-8601 week number of year, weeks starting on Monday
-			 * We compensate for weeks starting on Sunday here.
 			 */
-			$week_offset = array_sum(
-				[
-					// If the week starts on Sunday move to the next week.
-					0 === $week_start_day ? 1 : 0,
-					// If the current date is before the start of the week, move back a week.
-					$date_day < $week_start_day ? - 1 : 0,
-				]
-			);
 			$week_start->setISODate(
 				(int) $week_start->format( 'o' ),
 				(int) $week_start->format( 'W' ) + $week_offset,
@@ -1316,6 +1321,11 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 			// Add 6 days, then move at the end of the day.
 			$week_end->add( new DateInterval( 'P6D' ) );
 			$week_end->setTime( 23, 59, 59 );
+
+			$week_start = static::immutable( $week_start );
+			$week_end   = static::immutable( $week_end );
+
+			$cache[ $cache_key ] = [ $week_start, $week_end ];
 
 			return [ $week_start, $week_end ];
 		}
@@ -1338,6 +1348,76 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 			}
 
 			return $interval;
+		}
+
+		/**
+		 * Builds the immutable version of a date from a string, integer (timestamp) or \DateTime object.
+		 *
+		 * It's the immutable version of the `Tribe__Date_Utils::build_date_object` method.
+		 *
+		 * @since TBD
+		 *
+		 * @param string|DateTime|int      $datetime      A `strtotime` parse-able string, a DateTime object or
+		 *                                                a timestamp; defaults to `now`.
+		 * @param string|DateTimeZone|null $timezone      A timezone string, UTC offset or DateTimeZone object;
+		 *                                                defaults to the site timezone; this parameter is ignored
+		 *                                                if the `$datetime` parameter is a DatTime object.
+		 * @param bool                     $with_fallback Whether to return a DateTime object even when the date data is
+		 *                                                invalid or not; defaults to `true`.
+		 *
+		 * @return DateTimeImmutable|false A DateTime object built using the specified date, time and timezone; if
+		 *                                 `$with_fallback` is set to `false` then `false` will be returned if a
+		 *                                 DateTime object could not be built.
+		 */
+		static function immutable( $datetime = 'now', $timezone = null, $with_fallback = true ) {
+			if ( $datetime instanceof DateTimeImmutable ) {
+				return $datetime;
+			}
+
+			if ( $datetime instanceof DateTime ) {
+				return DateTimeImmutable::createFromMutable( $datetime );
+			}
+
+			$mutable = static::build_date_object( $datetime, $timezone, $with_fallback );
+
+			if ( false === $mutable ) {
+				return false;
+			}
+
+			$cache_key = md5( ( __METHOD__ . $mutable->getTimestamp() ) );
+			$cache     = tribe( 'cache' );
+
+			if ( false !== $cached = $cache[ $cache_key ] ) {
+				return $cached;
+			}
+
+			$immutable = DateTimeImmutable::createFromMutable( $mutable );
+
+			$cache[ $cache_key ] = $immutable;
+
+			return $immutable;
+		}
+
+		/**
+		 * Builds a date object from a given datetime and timezone.
+		 *
+		 * An alias of the `Tribe__Date_Utils::build_date_object` function.
+		 *
+		 * @since TBD
+		 *
+		 * @param string|DateTime|int      $datetime      A `strtotime` parse-able string, a DateTime object or
+		 *                                                a timestamp; defaults to `now`.
+		 * @param string|DateTimeZone|null $timezone      A timezone string, UTC offset or DateTimeZone object;
+		 *                                                defaults to the site timezone; this parameter is ignored
+		 *                                                if the `$datetime` parameter is a DatTime object.
+		 * @param bool                     $with_fallback Whether to return a DateTime object even when the date data is
+		 *                                                invalid or not; defaults to `true`.
+		 *
+		 * @return DateTime|false A DateTime object built using the specified date, time and timezone; if `$with_fallback`
+		 *                        is set to `false` then `false` will be returned if a DateTime object could not be built.
+		 */
+		public static function mutable( $datetime = 'now', $timezone = null, $with_fallback = true ) {
+			return static::build_date_object( $datetime, $timezone, $with_fallback );
 		}
 	}
 }

--- a/tests/wpunit/Tribe/Date_UtilsTest.php
+++ b/tests/wpunit/Tribe/Date_UtilsTest.php
@@ -248,4 +248,100 @@ class Date_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $date->format( $format ), Date_Utils::reformat( $date->format( 'U' ), $format ) );
 		$this->assertEquals( $date->format( 'U' ), Date_Utils::reformat( $date->format( 'U' ), 'U' ) );
 	}
+
+	public function build_date_object_empty_data_set() {
+		return [
+			'zero'           => [ 0 ],
+			'empty_string'   => [ '' ],
+			'false'          => [ false ],
+			'foo_bar_string' => [ 'foo bar' ],
+		];
+	}
+
+	/**
+	 * @dataProvider build_date_object_empty_data_set
+	 */
+	public function test_building_date_object_for_empty_will_return_today_date( $input ) {
+		$expected = ( new \DateTime( 'now' ) )->format( 'Y-m-d' );
+		// Do not test to the second as run times might yield false negatives.
+		$this->assertEquals( $expected, Date_Utils::build_date_object( $input )->format( Date_Utils::DBDATEFORMAT ) );
+		$this->assertEquals( $expected, Date_Utils::mutable( $input )->format( Date_Utils::DBDATEFORMAT ) );
+		$this->assertEquals( $expected, Date_Utils::immutable( $input )->format( Date_Utils::DBDATEFORMAT ) );
+	}
+
+	public function build_date_object_data_set() {
+		yield '2019-12-01 08:00:00 string' => [ '2019-12-01 08:00:00', '2019-12-01 08:00:00' ];
+		yield '2019-12-01 08:00:00 DateTime' => [ new DateTime( '2019-12-01 08:00:00' ), '2019-12-01 08:00:00' ];
+		yield '2019-12-01 08:00:00 DateTimeImmutable' => [
+			new DateTimeImmutable( '2019-12-01 08:00:00' ),
+			'2019-12-01 08:00:00'
+		];
+		yield '2019-12-01 08:00:00 timestamp' => [
+			( new DateTime( '2019-12-01 08:00:00' ) )->getTimestamp(),
+			'2019-12-01 08:00:00'
+		];
+
+		$timezone_str = 'Europe/Paris';
+		$timezone_obj = new DateTimeZone($timezone_str);
+
+		yield '2019-12-01 08:00:00 string w/ timezone' => [
+			'2019-12-01 08:00:00',
+			'2019-12-01 08:00:00',
+			$timezone_str,
+		];
+		yield '2019-12-01 08:00:00 DateTime w/timezone' => [
+			new DateTime( '2019-12-01 08:00:00', $timezone_obj ),
+			'2019-12-01 08:00:00',
+			$timezone_str,
+		];
+		yield '2019-12-01 08:00:00 DateTimeImmutable w/ timezone' => [
+			new DateTimeImmutable( '2019-12-01 08:00:00', $timezone_obj ),
+			'2019-12-01 08:00:00',
+			$timezone_str,
+		];
+		yield '2019-12-01 08:00:00 timestamp w/ timezone' => [
+			( new DateTime( '2019-12-01 08:00:00', $timezone_obj ) )->getTimestamp(),
+			'2019-12-01 08:00:00',
+			$timezone_str,
+		];
+
+		yield '2019-12-01 08:00:00 string w/ timezone obj' => [
+			'2019-12-01 08:00:00',
+			'2019-12-01 08:00:00',
+			$timezone_obj,
+		];
+		yield '2019-12-01 08:00:00 DateTime w/timezone' => [
+			new DateTime( '2019-12-01 08:00:00', $timezone_obj ),
+			'2019-12-01 08:00:00',
+			$timezone_obj,
+		];
+		yield '2019-12-01 08:00:00 DateTimeImmutable w/ timezone obj' => [
+			new DateTimeImmutable( '2019-12-01 08:00:00', $timezone_obj ),
+			'2019-12-01 08:00:00',
+			$timezone_obj,
+		];
+		yield '2019-12-01 08:00:00 timestamp w/ timezone obj' => [
+			( new DateTimeImmutable( '2019-12-01 08:00:00', $timezone_obj ) )->getTimestamp(),
+			'2019-12-01 08:00:00',
+			$timezone_obj,
+		];
+	}
+
+	/**
+	 * @dataProvider build_date_object_data_set
+	 */
+	public function test_build_date_object( $input, $expected, $timezone = null ) {
+		$this->assertEquals(
+			$expected,
+			Date_Utils::build_date_object( $input, $timezone )->format( Date_Utils::DBDATETIMEFORMAT )
+		);
+		$this->assertEquals(
+			$expected,
+			Date_Utils::mutable( $input, $timezone )->format( Date_Utils::DBDATETIMEFORMAT )
+		);
+		$this->assertEquals(
+			$expected,
+			Date_Utils::immutable( $input, $timezone )->format( Date_Utils::DBDATETIMEFORMAT )
+		);
+	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/137402

This PR adds the `immutable` and `mutable` (really just an alias of `Tribe__Date_Utils::build_date_object` method) methods to the `Tribe__Date_Utils` class and, with them, tests coverage.

And a sprinkle of caching.