### PR TITLE
fix(Tribe__Context.php) cache the result of the get method

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -401,6 +401,10 @@ class Tribe__Context {
 		 */
 		$value = apply_filters( "tribe_context_{$key}", $value );
 
+		if ( $value !== static::NOT_FOUND ) {
+			$this->request_cache[ $key ] = $value;
+		}
+
 		return $value;
 	}
 

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1219,50 +1219,39 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				return clone $datetime;
 			}
 
-			$cache_key = md5( __METHOD__ . serialize( func_get_args() ) );
-			/** @var Tribe__Cache $cache */
-			$cache = tribe( 'cache' );
-
-			/*
-			 * This check implies a small inefficiency when we deal with a request w/o fallback and there is an
-			 * exception, yet this is such a small percentage we can re-calculate in those instances.
-			 */
-			if ( false !== $cached = $cache[ $cache_key ] ) {
-				return $cached;
-			}
-
-			if ( class_exists( 'DateTimeImmutable' ) && $datetime instanceof DateTimeImmutable ) {
+			if ( class_exists('DateTimeImmutable') && $datetime instanceof DateTimeImmutable ) {
 				// Return the mutable version of the date.
-				$date = new DateTime( $datetime->format( 'Y-m-d H:i:s' ), $datetime->getTimezone() );
-			} else {
-				$timezone_object = null;
-
-				try {
-					// PHP 5.2 will not throw an exception but will generate an error.
-					$utc = new DateTimeZone( 'UTC' );
-
-					if ( self::is_timestamp( $datetime ) ) {
-						// Timestamps timezone is always UTC.
-						$date = new DateTime( '@' . $datetime, $utc );
-					} else {
-						$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
-
-						set_error_handler( 'tribe_catch_and_throw' );
-						$date = new DateTime( $datetime, $timezone_object );
-						restore_error_handler();
-					}
-				} catch ( Exception $e ) {
-					if ( $timezone_object === null ) {
-						$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
-					}
-
-					$date = $with_fallback
-						? new DateTime( 'now', $timezone_object )
-						: false;
-				}
+				return new DateTime( $datetime->format( 'Y-m-d H:i:s' ), $datetime->getTimezone() );
 			}
 
-			$cache[ $cache_key ] = $date;
+			$timezone_object = null;
+			$datetime = empty($datetime) ? 'now' : $datetime;
+
+			try {
+				// PHP 5.2 will not throw an exception but will generate an error.
+				$utc = new DateTimeZone( 'UTC' );
+				$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+
+				if ( self::is_timestamp( $datetime ) ) {
+					// Timestamps timezone is always UTC.
+					$date =  new DateTime( '@' . $datetime, $utc );
+
+					// If we have a timezone, then set it.
+					return $timezone ? $date->setTimezone( $timezone_object ) : $date;
+				}
+
+				set_error_handler( 'tribe_catch_and_throw' );
+				$date = new DateTime( $datetime, $timezone_object );
+				restore_error_handler();
+			} catch ( Exception $e ) {
+				if ( $timezone_object === null ) {
+					$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
+				}
+
+				return $with_fallback
+					? new DateTime( 'now', $timezone_object )
+					: false;
+			}
 
 			return $date;
 		}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138218 

This PR fixes an issue where the Context would not cache the result of a `get` method call when resolved.
While it does make sense not to cache a "not found" result, it might be found or be available later in the lifecycle of a request,
repeated calls to the `Tribe__Context::get` method should return, when called on the same object instance, the same result.  
This is one of the requirements of the Context immutable nature.

I'm opening TEC and PRO prs based on this to highlight the changes this implies, in short: our tests had an implicit inter-dependency I've tackled, in part, in an update to `tribe-testing-facilities` [here](https://github.com/moderntribe/tribe-testing-facilities/pull/20) and in part in updates to test code on TEC.