### PR TITLE
fix(Date_Utils) correctly use timezone when building from timestamp

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1233,11 +1233,9 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
 
 				if ( self::is_timestamp( $datetime ) ) {
-					// Timestamps timezone is always UTC.
-					$date =  new DateTime( '@' . $datetime, $utc );
+					$timestamp_timezone = $timezone ? $timezone_object : $utc;
 
-					// If we have a timezone, then set it.
-					return $timezone ? $date->setTimezone( $timezone_object ) : $date;
+					return  new DateTime( '@' . $datetime, $timestamp_timezone );
 				}
 
 				set_error_handler( 'tribe_catch_and_throw' );

--- a/tests/wpunit/Tribe/Date_UtilsTest.php
+++ b/tests/wpunit/Tribe/Date_UtilsTest.php
@@ -301,7 +301,7 @@ class Date_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		];
 		yield '2019-12-01 08:00:00 timestamp w/ timezone' => [
 			( new DateTime( '2019-12-01 08:00:00', $timezone_obj ) )->getTimestamp(),
-			'2019-12-01 08:00:00',
+			'2019-12-01 07:00:00',
 			$timezone_str,
 		];
 
@@ -322,7 +322,7 @@ class Date_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		];
 		yield '2019-12-01 08:00:00 timestamp w/ timezone obj' => [
 			( new DateTimeImmutable( '2019-12-01 08:00:00', $timezone_obj ) )->getTimestamp(),
-			'2019-12-01 08:00:00',
+			'2019-12-01 07:00:00',
 			$timezone_obj,
 		];
 	}


### PR DESCRIPTION
Ticket: n/a

This PR fixes an issue introduced during the work done in `Date_Utils` where, when using date timestamps to build the date, the output would not be the one we expect.