### PR TITLE
Set the datepicker (compact) default to a more friendly setting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Set the default datepicker (compact) format to MM/D/YYYY [136789]
+
 = [4.10.2] 2019-12-10 =
 
 * Tweak - Add the `Tribe__Cache::warmup_post_caches` method to warmup the post caches for a set of posts [136624]

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -46,7 +46,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				$datepicker = self::datepicker_formats( $datepicker );
 			}
 
-			$default_datepicker = self::datepicker_formats( 0 );
+			$default_datepicker = self::datepicker_formats( 1 );
 
 			// If the current datepicker is the default we don't care
 			if ( $datepicker === $default_datepicker ) {
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				return $formats;
 			}
 
-			return isset( $formats[ $translate ] ) ? $formats[ $translate ] : $formats[0];
+			return isset( $formats[ $translate ] ) ? $formats[ $translate ] : $formats[1];
 		}
 
 		/**

--- a/src/Tribe/Utils/Date_I18n.php
+++ b/src/Tribe/Utils/Date_I18n.php
@@ -40,7 +40,7 @@ class Date_I18n extends DateTime {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
+		$unix_with_tz = $this->format( 'U' );
 		$translated   = date_i18n( $date_format, $unix_with_tz );
 		return $translated;
 	}

--- a/src/Tribe/Utils/Date_I18n_Immutable.php
+++ b/src/Tribe/Utils/Date_I18n_Immutable.php
@@ -40,7 +40,7 @@ class Date_I18n_Immutable extends DateTimeImmutable {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
+		$unix_with_tz = $this->format( 'U' );
 		$translated   = date_i18n( $date_format, $unix_with_tz );
 		return $translated;
 	}

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -31,12 +31,12 @@ $displayTab = array(
 					)
 					. '</p>',
 			),
-			'datepickerFormat'                   => array(
+			'datepickerFormat'                   => [
 				'type'            => 'dropdown',
 				'label'           => esc_html__( 'Compact Date Format', 'tribe-common' ),
 				'tooltip'         => esc_html__( 'Select the date format used for elements with minimal space, such as in datepickers.', 'tribe-common' ),
-				'default'         => 'Y-m-d',
-				'options'         => array(
+				'default'         => 1,
+				'options'         => [
 					'0' => date( 'Y-m-d', $sample_date ),
 					'1' => date( 'n/j/Y', $sample_date ),
 					'2' => date( 'm/d/Y', $sample_date ),
@@ -49,13 +49,13 @@ $displayTab = array(
 					'9' => date( 'Y.m.d', $sample_date ),
 					'10' => date( 'm.d.Y', $sample_date ),
 					'11' => date( 'd.m.Y', $sample_date ),
-				),
+				],
 				'validation_type' => 'options',
-			),
-			'tribe-form-content-end' => array(
+			],
+			'tribe-form-content-end' => [
 				'type' => 'html',
 				'html' => '</div>',
-			),
+			],
 		)
 	),
 );

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -32,7 +32,7 @@ class Date_I18n_Test extends WPTestCase {
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_properly_include_timezones( $datetime, $timezone, $expected ) {
+	public function it_should_properly_convert_to_utc_from_provided_timezone( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
 		$date_object = new Date_I18n( $datetime, $timezone );
 		$date_object = Date_I18n::createFromImmutable( $date_object );

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -20,10 +20,10 @@ class Date_I18n_Test extends WPTestCase {
 
 	public function data_dates_and_timezones() {
 		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 16:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 13:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 19:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 08:00:00' ],
+			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 20:00:00' ],
+			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 23:00:00' ],
+			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 17:00:00' ],
+			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-02 04:00:00' ],
 		];
 	}
 
@@ -34,9 +34,8 @@ class Date_I18n_Test extends WPTestCase {
 	 */
 	public function it_should_properly_include_timezones( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
-		$date_object = new Date_I18n;
-		$date_object->setTimestamp( strtotime( $datetime ) );
-		$date_object->setTimezone( $timezone );
+		$date_object = new Date_I18n( $datetime, $timezone );
+		$date_object = Date_I18n::createFromImmutable( $date_object );
 
 		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
 	}

--- a/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
@@ -20,10 +20,10 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 
 	public function data_dates_and_timezones() {
 		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 16:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 13:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 19:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 08:00:00' ],
+			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 20:00:00' ],
+			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 23:00:00' ],
+			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 17:00:00' ],
+			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-02 04:00:00' ],
 		];
 	}
 
@@ -34,9 +34,8 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 	 */
 	public function it_should_properly_include_timezones( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
-		$date_object = new Date_I18n_Immutable;
-		$date_object = $date_object->setTimestamp( strtotime( $datetime ) );
-		$date_object = $date_object->setTimezone( $timezone );
+		$date_object = new Date_I18n_Immutable( $datetime, $timezone );
+		$date_object = Date_I18n_Immutable::createFromMutable( $date_object );
 
 		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
 	}

--- a/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
@@ -32,7 +32,7 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_properly_include_timezones( $datetime, $timezone, $expected ) {
+	public function it_should_properly_convert_to_utc_from_provided_timezone( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
 		$date_object = new Date_I18n_Immutable( $datetime, $timezone );
 		$date_object = Date_I18n_Immutable::createFromMutable( $date_object );


### PR DESCRIPTION
This sets the default datepicker format to a friendly US-centric setting.

🎥 http://p.tri.be/wKeyp9

Related:
* https://github.com/moderntribe/the-events-calendar/pull/2916
* https://github.com/moderntribe/events-pro/pull/1405

[see/136789](https://central.tri.be/issues/136789)