### PR TITLE
feat(Traits/Cache_User.php) add reset_caches method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Add the `Tribe\Traits\Cache_User::reset_caches` method to clear cache entries [138357]
+
 = [4.10.2] 2019-12-10 =
 
 * Tweak - Add the `Tribe__Cache::warmup_post_caches` method to warmup the post caches for a set of posts [136624]

--- a/src/Tribe/Traits/Cache_User.php
+++ b/src/Tribe/Traits/Cache_User.php
@@ -125,4 +125,21 @@ trait Cache_User {
 			}
 		}
 	}
+
+	/**
+	 * Resets the instance caches for the this instance.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string> A list of the emptied cache properties.
+	 */
+	public function reset_caches() {
+		$emptied = [];
+		foreach ( array_keys( $this->caches ) as $key ) {
+			$emptied[]              = $key;
+			$this->{"{$key}_cache"} = [];
+		}
+
+		return $emptied;
+	}
 }

--- a/src/Tribe/Traits/Cache_User.php
+++ b/src/Tribe/Traits/Cache_User.php
@@ -131,7 +131,7 @@ trait Cache_User {
 	 *
 	 * @since TBD
 	 *
-	 * @return array<string> A list of the emptied cache properties.
+	 * @return string[] A list of the emptied cache properties.
 	 */
 	public function reset_caches() {
 		$emptied = [];


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138357

This PR adds the `Cache_User::reset_caches` method to the `Cache_User` trait.  
The method will empty and reset the instance cache properties of an object using the trait.