### PR TITLE
fix(Collection_Trait.php) allow for pre (un)serialize methods

### DIFF
--- a/src/Tribe/Utils/Collection_Trait.php
+++ b/src/Tribe/Utils/Collection_Trait.php
@@ -152,14 +152,27 @@ trait Collection_Trait {
 	 * {@inheritDoc}
 	 */
 	public function serialize() {
-		return serialize( $this->all() );
+		$to_serialize = $this->all();
+
+		if ( method_exists( $this, 'before_serialize' ) ) {
+			$to_serialize = $this->before_serialize( $this->all() );
+		}
+
+		return serialize( $to_serialize );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function unserialize( $serialized ) {
-		$this->items = unserialize( $serialized );
+		$to_unserialize = $serialized;
+
+		if ( method_exists( $this, 'custom_unserialize' ) ) {
+			$this->items = $this->custom_unserialize( $to_unserialize );
+			return;
+		}
+
+		$this->items = unserialize( $to_unserialize );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/138249 

This PR adds support, in the `Collection_Trait` for custom `serialize` and `unserialize` handling by classes using the trait.