### PR TITLE
If we tribe_catch_and_throw, we need to restore error handler in catch

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -1245,6 +1245,9 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				$date = new Date_I18n( $datetime, $timezone_object );
 				restore_error_handler();
 			} catch ( Exception $e ) {
+				// if we encounter an error, we need to restore after catching
+				restore_error_handler();
+
 				if ( $timezone_object === null ) {
 					$timezone_object = Tribe__Timezones::build_timezone_object( $timezone );
 				}

--- a/tests/wpunit/Tribe/Date_UtilsTest.php
+++ b/tests/wpunit/Tribe/Date_UtilsTest.php
@@ -28,6 +28,9 @@ class Date_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		parent::setUp();
 
 		// your set up methods here
+
+		// Default timezone to UTC at beginning of each test
+		date_default_timezone_set( 'UTC' );
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
When we use our `tribe_catch_and_throw()` function, we need to be sure to restore the proper error handler upon catching the exception so we don't take over error handling for other errors in and out of our control.

The particular error in question was related to PHP 7.3 alongside WP 4.9.12 (and lower) where a notice is thrown within the `class-wp-comment-query.php` class file due to PHP 7.3's handling of `compact()`. We had an overly aggressive error handler that was never relinquishing control once it caught a date error. This fixes that problem.

![Screen Shot 2019-12-18 at 8 09 14 PM](https://user-images.githubusercontent.com/430385/71136355-92ebd800-21d2-11ea-9b6d-ee2ed1d121cd.png)

see/138785