### PR TITLE
Replace immutable/mutable date handling changes and resolve test issues

### DIFF
--- a/src/Tribe/Utils/Date_I18n.php
+++ b/src/Tribe/Utils/Date_I18n.php
@@ -31,7 +31,7 @@ class Date_I18n extends DateTime {
 	}
 
 	/**
-	 * Returns a translated string usign the params from this DateTime instance.
+	 * Returns a translated string using the params from this DateTime instance.
 	 *
 	 * @since  TBD
 	 *
@@ -40,8 +40,9 @@ class Date_I18n extends DateTime {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
+		$unix_with_tz = $this->getTimestamp() + $this->getOffset();
 		$translated   = date_i18n( $date_format, $unix_with_tz );
+
 		return $translated;
 	}
 }

--- a/src/Tribe/Utils/Date_I18n.php
+++ b/src/Tribe/Utils/Date_I18n.php
@@ -40,7 +40,7 @@ class Date_I18n extends DateTime {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = $this->format( 'U' );
+		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
 		$translated   = date_i18n( $date_format, $unix_with_tz );
 		return $translated;
 	}

--- a/src/Tribe/Utils/Date_I18n_Immutable.php
+++ b/src/Tribe/Utils/Date_I18n_Immutable.php
@@ -7,8 +7,6 @@
  */
 namespace Tribe\Utils;
 
-use Tribe__Date_Utils as Dates;
-use DateTime;
 use DateTimeImmutable;
 
 /**
@@ -27,11 +25,12 @@ class Date_I18n_Immutable extends DateTimeImmutable {
 		$date_object = new self;
 		$date_object = $date_object->setTimestamp( $datetime->getTimestamp() );
 		$date_object = $date_object->setTimezone( $datetime->getTimezone() );
+
 		return $date_object;
 	}
 
 	/**
-	 * Returns a translated string usign the params from this Immutable DateTime instance.
+	 * Returns a translated string using the params from this Immutable DateTime instance.
 	 *
 	 * @since  TBD
 	 *
@@ -40,8 +39,9 @@ class Date_I18n_Immutable extends DateTimeImmutable {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
+		$unix_with_tz = $this->getTimestamp() + $this->getOffset();
 		$translated   = date_i18n( $date_format, $unix_with_tz );
+
 		return $translated;
 	}
 }

--- a/src/Tribe/Utils/Date_I18n_Immutable.php
+++ b/src/Tribe/Utils/Date_I18n_Immutable.php
@@ -40,7 +40,7 @@ class Date_I18n_Immutable extends DateTimeImmutable {
 	 * @return string         Translated date.
 	 */
 	public function format_i18n( $date_format ) {
-		$unix_with_tz = $this->format( 'U' );
+		$unix_with_tz = strtotime( $this->format( Dates::DBDATETIMEFORMAT ) );
 		$translated   = date_i18n( $date_format, $unix_with_tz );
 		return $translated;
 	}

--- a/src/Tribe/Utils/Date_I18n_Immutable.php
+++ b/src/Tribe/Utils/Date_I18n_Immutable.php
@@ -2,9 +2,10 @@
 /**
  * Extends DateTimeImmutable and includes translation capabilities.
  *
- * @package Tribe\Utils
  * @since   TBD
+ * @package Tribe\Utils
  */
+
 namespace Tribe\Utils;
 
 use DateTimeImmutable;
@@ -12,8 +13,8 @@ use DateTimeImmutable;
 /**
  * Class Date i18n Immutable
  *
- * @package Tribe\Utils
  * @since   TBD
+ * @package Tribe\Utils
  */
 class Date_I18n_Immutable extends DateTimeImmutable {
 	/**
@@ -34,7 +35,7 @@ class Date_I18n_Immutable extends DateTimeImmutable {
 	 *
 	 * @since  TBD
 	 *
-	 * @param  string $date_format Format to be used in the translation.
+	 * @param string $date_format Format to be used in the translation.
 	 *
 	 * @return string         Translated date.
 	 */

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Tribe\Utils;
 
-use Tribe__Date_Utils as Dates;
+use Codeception\TestCase\WPTestCase;
 use DateTimeZone;
-use \Codeception\TestCase\WPTestCase;
+use Tribe__Date_Utils as Dates;
 
 class Date_I18n_Test extends WPTestCase {
 	/**
@@ -24,21 +25,23 @@ class Date_I18n_Test extends WPTestCase {
 	}
 
 	public function data_dates_and_timezones() {
-		$timezones         = [
+		$timezones = [
 			'UTC',
 			'America/Sao_Paulo',
 			'Europe/Berlin',
 			'Pacific/Honolulu',
 		];
+
 		$input_to_expected = [
 			'2018-02-01 18:00:00' => '2018-02-01 18:00:00',
 		];
-		foreach ($timezones as $default_timezone){
-			foreach ($timezones as $date_timezone){
-				foreach ($input_to_expected as $input => $expected){
+
+		foreach ( $timezones as $default_timezone ) {
+			foreach ( $timezones as $date_timezone ) {
+				foreach ( $input_to_expected as $input => $expected ) {
 					{
 						yield $date_timezone . ' on ' . $default_timezone . ' default timezone' =>
-						[ $input,$date_timezone,$default_timezone, $expected];
+						[ $input, $date_timezone, $default_timezone, $expected ];
 					};
 				}
 			}
@@ -58,16 +61,21 @@ class Date_I18n_Test extends WPTestCase {
 	/**
 	 * @test
 	 * @dataProvider data_dates_and_timezones
-	 * @group utils
+	 * @group        utils
 	 */
-	public function it_should_retain_timezone_and_timestamp_when_created_from_immutable_object( $datetime, $timezone,$date_default_timezone,$expected  ) {
+	public function it_should_retain_timezone_and_timestamp_when_created_from_immutable_object(
+		$datetime,
+		$timezone,
+		$date_default_timezone,
+		$expected
+	) {
 		date_default_timezone_set( $date_default_timezone );
 
 		$this->assertEquals( $date_default_timezone, date_default_timezone_get() );
 
-		$timezone  = new DateTimeZone( $timezone );
+		$timezone = new DateTimeZone( $timezone );
 		$immutable = new Date_I18n_Immutable( $datetime, $timezone );
-		$mutable   = Date_I18n::createFromImmutable( $immutable );
+		$mutable = Date_I18n::createFromImmutable( $immutable );
 
 		$this->assertEquals( $immutable->getTimestamp(), $mutable->getTimestamp() );
 		$this->assertEquals( $expected, $mutable->format_i18n( Dates::DBDATETIMEFORMAT ) );

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -73,12 +73,46 @@ class Date_I18n_Test extends WPTestCase {
 
 		$this->assertEquals( $date_default_timezone, date_default_timezone_get() );
 
-		$timezone = new DateTimeZone( $timezone );
+		$timezone  = new DateTimeZone( $timezone );
 		$immutable = new Date_I18n_Immutable( $datetime, $timezone );
-		$mutable = Date_I18n::createFromImmutable( $immutable );
+		$mutable   = Date_I18n::createFromImmutable( $immutable );
 
 		$this->assertEquals( $immutable->getTimestamp(), $mutable->getTimestamp() );
 		$this->assertEquals( $expected, $mutable->format_i18n( Dates::DBDATETIMEFORMAT ) );
 		$this->assertEquals( $timezone, $mutable->getTimezone() );
+	}
+
+	public function timestamp_timezones() {
+		// Build the timestamp in a system-timezone independent way.
+		$timestamp = ( new \DateTime( '2018-02-01 18:00:00', new DateTimeZone( 'UTC' ) ) )
+			->getTimestamp();
+
+		return [
+			'UTC'               => [ $timestamp, 'UTC' ],
+			'America/Sao_Paulo' => [ $timestamp, 'America/Sao_Paulo' ],
+			'Europe/Berlin'     => [ $timestamp, 'Europe/Berlin' ],
+			'Pacific/Honolulu'  => [ $timestamp, 'Pacific/Honolulu' ],
+		];
+	}
+
+	/**
+	 * It should ignore the timezone when built from timestamp
+	 *
+	 * @test
+	 * @dataProvider timestamp_timezones
+	 */
+	public function should_ignore_the_timezone_when_built_from_timestamp( $timestamp, $timezone ) {
+		$date = new Date_I18n( '@' . $timestamp, new DateTimeZone( $timezone ) );
+
+		$this->assertEquals(
+			$timestamp,
+			$date->getTimestamp(),
+			'DateTime behavior is to ignore the DateTimezone when building from timestamp: we should stick w/ that.'
+		);
+		$this->assertEquals(
+			new DateTimeZone( 'GMT+0' ),
+			$date->getTimezone(),
+			'DateTime behavior is to ignore the DateTimezone when building from timestamp: we should stick w/ that.'
+		);
 	}
 }

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -20,10 +20,10 @@ class Date_I18n_Test extends WPTestCase {
 
 	public function data_dates_and_timezones() {
 		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 20:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 23:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 17:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-02 04:00:00' ],
+			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 18:00:00' ],
+			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 18:00:00' ],
+			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 18:00:00' ],
+			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 18:00:00' ],
 		];
 	}
 
@@ -32,11 +32,12 @@ class Date_I18n_Test extends WPTestCase {
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_properly_convert_to_utc_from_provided_timezone( $datetime, $timezone, $expected ) {
+	public function it_should_retain_timezone_and_timestamp_when_created_from_immutable_object( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
 		$date_object = new Date_I18n( $datetime, $timezone );
 		$date_object = Date_I18n::createFromImmutable( $date_object );
 
 		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
+		$this->assertEquals( $timezone, $date_object->getTimezone() );
 	}
 }

--- a/tests/wpunit/Tribe/Utils/Date_I18nTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18nTest.php
@@ -2,12 +2,49 @@
 namespace Tribe\Utils;
 
 use Tribe__Date_Utils as Dates;
-use DateTime;
 use DateTimeZone;
-use DateTimeImmutable;
 use \Codeception\TestCase\WPTestCase;
 
 class Date_I18n_Test extends WPTestCase {
+	/**
+	 * The value of `date_default_timezone_get` before the tests.
+	 *
+	 * @var string
+	 */
+	protected static $date_default_timezone_backup;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::$date_default_timezone_backup = date_default_timezone_get();
+	}
+
+	public static function tearDownAfterClass() {
+		date_default_timezone_set( static::$date_default_timezone_backup );
+		parent::tearDownAfterClass();
+	}
+
+	public function data_dates_and_timezones() {
+		$timezones         = [
+			'UTC',
+			'America/Sao_Paulo',
+			'Europe/Berlin',
+			'Pacific/Honolulu',
+		];
+		$input_to_expected = [
+			'2018-02-01 18:00:00' => '2018-02-01 18:00:00',
+		];
+		foreach ($timezones as $default_timezone){
+			foreach ($timezones as $date_timezone){
+				foreach ($input_to_expected as $input => $expected){
+					{
+						yield $date_timezone . ' on ' . $default_timezone . ' default timezone' =>
+						[ $input,$date_timezone,$default_timezone, $expected];
+					};
+				}
+			}
+		}
+	}
+
 	/**
 	 * @test
 	 *
@@ -18,26 +55,22 @@ class Date_I18n_Test extends WPTestCase {
 		$this->assertInstanceOf( Date_I18n::class, $date );
 	}
 
-	public function data_dates_and_timezones() {
-		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 18:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 18:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 18:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 18:00:00' ],
-		];
-	}
-
 	/**
 	 * @test
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_retain_timezone_and_timestamp_when_created_from_immutable_object( $datetime, $timezone, $expected ) {
-		$timezone = new DateTimeZone( $timezone );
-		$date_object = new Date_I18n( $datetime, $timezone );
-		$date_object = Date_I18n::createFromImmutable( $date_object );
+	public function it_should_retain_timezone_and_timestamp_when_created_from_immutable_object( $datetime, $timezone,$date_default_timezone,$expected  ) {
+		date_default_timezone_set( $date_default_timezone );
 
-		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
-		$this->assertEquals( $timezone, $date_object->getTimezone() );
+		$this->assertEquals( $date_default_timezone, date_default_timezone_get() );
+
+		$timezone  = new DateTimeZone( $timezone );
+		$immutable = new Date_I18n_Immutable( $datetime, $timezone );
+		$mutable   = Date_I18n::createFromImmutable( $immutable );
+
+		$this->assertEquals( $immutable->getTimestamp(), $mutable->getTimestamp() );
+		$this->assertEquals( $expected, $mutable->format_i18n( Dates::DBDATETIMEFORMAT ) );
+		$this->assertEquals( $timezone, $mutable->getTimezone() );
 	}
 }

--- a/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
@@ -20,10 +20,10 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 
 	public function data_dates_and_timezones() {
 		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 20:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 23:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 17:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-02 04:00:00' ],
+			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 18:00:00' ],
+			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 18:00:00' ],
+			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 18:00:00' ],
+			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 18:00:00' ],
 		];
 	}
 
@@ -32,11 +32,12 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_properly_convert_to_utc_from_provided_timezone( $datetime, $timezone, $expected ) {
+	public function it_should_retain_timezone_and_timestamp_when_created_from_mutable_object( $datetime, $timezone, $expected ) {
 		$timezone = new DateTimeZone( $timezone );
 		$date_object = new Date_I18n_Immutable( $datetime, $timezone );
 		$date_object = Date_I18n_Immutable::createFromMutable( $date_object );
 
 		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
+		$this->assertEquals( $timezone, $date_object->getTimezone() );
 	}
 }

--- a/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
+++ b/tests/wpunit/Tribe/Utils/Date_I18n_ImmutableTest.php
@@ -1,13 +1,50 @@
 <?php
 namespace Tribe\Utils;
 
-use Tribe__Date_Utils as Dates;
-use DateTime;
+use Codeception\TestCase\WPTestCase;
 use DateTimeZone;
-use DateTimeImmutable;
-use \Codeception\TestCase\WPTestCase;
+use Tribe__Date_Utils as Dates;
 
 class Date_I18n_Immutable_Test extends WPTestCase {
+	/**
+	 * The value of `date_default_timezone_get` before the tests.
+	 *
+	 * @var string
+	 */
+	protected static $date_default_timezone_backup;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::$date_default_timezone_backup = date_default_timezone_get();
+	}
+
+	public static function tearDownAfterClass() {
+		date_default_timezone_set( static::$date_default_timezone_backup );
+		parent::tearDownAfterClass();
+	}
+
+	public function data_dates_and_timezones() {
+		$timezones         = [
+			'UTC',
+			'America/Sao_Paulo',
+			'Europe/Berlin',
+			'Pacific/Honolulu',
+		];
+		$input_to_expected = [
+			'2018-02-01 18:00:00' => '2018-02-01 18:00:00',
+		];
+		foreach ($timezones as $default_timezone){
+			foreach ($timezones as $date_timezone){
+				foreach ($input_to_expected as $input => $expected){
+					{
+						yield $date_timezone . ' on ' . $default_timezone . ' default timezone' =>
+						[ $input,$date_timezone,$default_timezone, $expected];
+					};
+				}
+			}
+		}
+	}
+
 	/**
 	 * @test
 	 *
@@ -18,26 +55,22 @@ class Date_I18n_Immutable_Test extends WPTestCase {
 		$this->assertInstanceOf( Date_I18n_Immutable::class, $date );
 	}
 
-	public function data_dates_and_timezones() {
-		return [
-			'America/Sao_Paulo' => [ '2018-02-01 18:00:00', 'America/Sao_Paulo', '2018-02-01 18:00:00' ],
-			'America/New_York'  => [ '2018-02-01 18:00:00', 'America/New_York', '2018-02-01 18:00:00' ],
-			'Europe/Berlin'     => [ '2018-02-01 18:00:00', 'Europe/Berlin', '2018-02-01 18:00:00' ],
-			'Pacific/Honolulu'  => [ '2018-02-01 18:00:00', 'Pacific/Honolulu', '2018-02-01 18:00:00' ],
-		];
-	}
-
 	/**
 	 * @test
 	 * @dataProvider data_dates_and_timezones
 	 * @group utils
 	 */
-	public function it_should_retain_timezone_and_timestamp_when_created_from_mutable_object( $datetime, $timezone, $expected ) {
-		$timezone = new DateTimeZone( $timezone );
-		$date_object = new Date_I18n_Immutable( $datetime, $timezone );
-		$date_object = Date_I18n_Immutable::createFromMutable( $date_object );
+	public function it_should_retain_timezone_and_timestamp_when_created_from_mutable_object( $datetime, $timezone,$date_default_timezone,$expected ) {
+		date_default_timezone_set( $date_default_timezone );
 
-		$this->assertEquals( $expected, $date_object->format_i18n( Dates::DBDATETIMEFORMAT ) );
-		$this->assertEquals( $timezone, $date_object->getTimezone() );
+		$this->assertEquals( $date_default_timezone, date_default_timezone_get() );
+
+		$timezone    = new DateTimeZone( $timezone );
+		$mutable = new Date_I18n( $datetime, $timezone );
+		$immutable = Date_I18n_Immutable::createFromMutable( $mutable);
+
+		$this->assertEquals( $mutable->getTimestamp(), $immutable->getTimestamp() );
+		$this->assertEquals( $expected, $immutable->format_i18n( Dates::DBDATETIMEFORMAT ) );
+		$this->assertEquals( $timezone, $immutable->getTimezone() );
 	}
 }


### PR DESCRIPTION
This puts back the datetime fixes that bordoni put in place and fixes the tests so that their values are appropriately validated.

:movie_camera: http://p.tri.be/gV3Jcy

Related: https://github.com/moderntribe/the-events-calendar/pull/2945

see/138795