### PR TITLE
Properly do the priority ordering for Assets.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -111,7 +111,7 @@ class Tribe__Assets {
 	 * @param string|array $groups Which groups will be enqueued.
 	 */
 	public function enqueue_group( $groups ) {
-		$assets = $this->get( null, false );
+		$assets  = $this->get( null, false );
 		$enqueue = [];
 
 		foreach ( $assets as $asset ) {
@@ -599,9 +599,10 @@ class Tribe__Assets {
 	 * Get the Asset Object configuration.
 	 *
 	 * @since 4.3
+	 * @since 4.11.0  Added $sort param.
 	 *
 	 * @param string|array $slug Slug of the Asset.
-	 * @param boolean      sort  If we should do any sorting before returning.
+	 * @param boolean      $sort  If we should do any sorting before returning.
 	 *
 	 * @return array|object|null Array of asset objects, single asset object, or null if looking for a single asset but
 	 *                           it was not in the array of objects.
@@ -612,7 +613,7 @@ class Tribe__Assets {
 				$cache_key_count = __METHOD__ . ':count';
 				// Sorts by priority.
 				$cache_count = tribe_get_var( $cache_key_count, 0 );
-				$count = count( $this->assets );
+				$count       = count( $this->assets );
 
 				if ( $count !== $cache_count ) {
 					uasort( $this->assets, 'tribe_sort_by_priority' );

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -93,7 +93,7 @@ class Tribe__Assets {
 			foreach ( (array) $asset->action as $action ) {
 				// Enqueue the registered assets at the appropriate time.
 				if ( did_action( $action ) > 0 ) {
-					$this->enqueue( $asset->slug );
+					$this->enqueue();
 				} else {
 					add_action( $action, [ $this, 'enqueue' ], $asset->priority, 0 );
 				}


### PR DESCRIPTION
🎟  TEC-3153
---
On performance work, we modified how often `uasort()` was being called on priority since it was slowing down both registering and loading the assets.

@paulmskim reported a bug around Gutenberg/Blocks editor that highlighted that we were doing the sorting in the incorrect places, this PR modified that.

Now sorting will only happen on with getting all the assets, which reduced the number of sorts from about 8 to about 5 per page.

We introduced one more layer to avoid ordering which was the sorting only a new asset was added, which reduced it to only 2 calls per page.

📹 https://i.bordoni.me/DOuvK6Pw

---

Updated the code after the video was recorded to resolve the `tribe_ev` error on the edit page.