### PR TITLE
fix(Utils/Post_Thumbnail.php) serialization issue

### DIFF
--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -293,10 +293,10 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	 * {@inheritDoc}
 	 */
 	public function unserialize( $serialized ) {
-		$data          = json_decode( $serialized, true );
+		$data = json_decode( $serialized, true );
 		array_walk( $data, static function ( &$data_entry ) {
 			if ( is_array( $data_entry ) ) {
-				$data_entry = (object)$data_entry;
+				$data_entry = (object) $data_entry;
 			}
 		} );
 		$this->post_id = $data['post_id'];

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -286,17 +286,22 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		$data            = $this->fetch_data();
 		$data['post_id'] = $this->post_id;
 
-		return serialize( $data );
+		return wp_json_encode( $data );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function unserialize( $serialized ) {
-		$data          = unserialize( $serialized );
+		$data          = json_decode( $serialized, true );
+		array_walk( $data, static function ( &$data_entry ) {
+			if ( is_array( $data_entry ) ) {
+				$data_entry = (object)$data_entry;
+			}
+		} );
 		$this->post_id = $data['post_id'];
 		unset( $data['post_id'] );
-		$this->data = $data;
+		$this->data = ! empty( $data ) ? $data : null;
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/projects/TEC/issues/TEC-3149

While working on the ticket I've noticed an issue where PHP errors would be generated when using object caching for images w/ non latin chars in the file name.

This PR fixes the cause of those errors using json_(encode|decode) for object serialization|deserialization to avoid encoding issues.