### PR TITLE
Folder list with Namespacing correct

### DIFF
--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -148,7 +148,7 @@ class Tribe__Template {
 	 *
 	 * @since 4.11.0
 	 *
-	 * @return array
+	 * @return array Current folder we are looking for templates.
 	 */
 	public function get_template_folder() {
 		return $this->folder;
@@ -337,8 +337,11 @@ class Tribe__Template {
 	 * in the theme's directory.
 	 *
 	 * @since  4.7.20
+	 * @since  4.11.0  Added param $plugin_namespace.
 	 *
-	 * @return array
+	 * @param string $plugin_namespace Overwrite the origin namespace with a given one.
+	 *
+	 * @return array Namespace where we to look for templates.
 	 */
 	protected function get_template_public_namespace( $plugin_namespace ) {
 		$namespace = [

--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -278,7 +278,7 @@ class Tribe__Template {
 			$context = [];
 		}
 
-		// Applies new local context on top of Global + Previous local
+		// Applies new local context on top of Global + Previous local.
 		$context = wp_parse_args( (array) $context, $this->get_values() );
 
 		/**


### PR DESCRIPTION
When including files from themes the `Tribe__Templates` class was looking into the incorrect file path depending on how the class was instantiated.

If we wanted to include an Event Tickets file from a class that was using the Origin as The Events Calendar, it would point to `[your-theme]/events/v2/event.php` instead of  `[your-theme]/tickets/v2/event.php`.

📹 https://i.bordoni.me/Koue8qN5