### PR TITLE
WordPress is throwing a notice for home_url() without a slash.

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -1024,7 +1024,7 @@ class Tribe__Rewrite {
 			return home_url();
 		}
 
-		$clean = $this->get_canonical_url( add_query_arg( $parsed_vars, home_url() ), $force );
+		$clean = $this->get_canonical_url( add_query_arg( $parsed_vars, home_url( '/' ) ), $force );
 
 		$this->clean_url_cache[ $url ] = $clean;
 


### PR DESCRIPTION
![Image 2020-01-27 at 09 02 54](https://user-images.githubusercontent.com/236579/73180827-19ee7300-40e4-11ea-8449-bb2045c41ec0.png)

Resolving a problem where WordPress code seems to dislike trying to do `redirect_canonical()` on a `home_url()` without a slash.