### PR TITLE
Add a helper method for fetching the datepickerFormat index

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,10 @@
 
 == Changelog ==
 
-= [4.11.0.1] TBD =
+= [4.11.0.1] 2020-02-06 =
 
-* Fix - Fatal in Context when global query object is not set [TEC-3228]
+* Tweak - Add filtered method to Date Utils for fetching the datepickerFormat. [TEC-3229]
+* Fix - Fatal in Context when global query object is not set. [TEC-3228]
 
 = [4.11.0] 2020-01-27 =
 

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -26,10 +26,37 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		const DBTIMEFORMAT          = 'H:i:s';
 		const DBYEARMONTHTIMEFORMAT = 'Y-m';
 
+		/**
+		 * Default datepicker format index.
+		 *
+		 * @since 4.11.0.1
+		 *
+		 * @var int
+		 */
+		private static $default_datepicker_format_index = 1;
+
 		private static $localized_months_full  = array();
 		private static $localized_months_short = array();
 		private static $localized_weekdays     = array();
 		private static $localized_months       = array();
+
+		/**
+		 * Get the datepickerFormat index.
+		 *
+		 * @since 4.11.0.1
+		 *
+		 * @return int
+		 */
+		public static function get_datepicker_format_index() {
+			/**
+			 * Filter the datepickerFormat index.
+			 *
+			 * @since 4.11.0.1
+			 *
+			 * @param int $format_index Index of datepickerFormat.
+			 */
+			return apply_filters( 'tribe_datepickerFormat_index', tribe_get_option( 'datepickerFormat', static::$default_datepicker_format_index ) );
+		}
 
 		/**
 		 * Try to format a Date to the Default Datepicker format
@@ -99,7 +126,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 				return $formats;
 			}
 
-			return isset( $formats[ $translate ] ) ? $formats[ $translate ] : $formats[1];
+			return isset( $formats[ $translate ] ) ? $formats[ $translate ] : $formats[ static::get_datepicker_format_index() ];
 		}
 
 		/**


### PR DESCRIPTION
This adds a filter for the fetching of the datepickerFormat while providing the expected default if settings has not yet been saved.

Related: https://github.com/moderntribe/the-events-calendar/pull/3046

:movie_camera:
* Event Edit: http://p.tri.be/NHqoXF
* Aggregator: http://p.tri.be/VkkDoC
* Calendar View: http://p.tri.be/ewgdS7

:ticket: [TEC-3229]

[TEC-3229]: https://moderntribe.atlassian.net/browse/TEC-3229