### PR TITLE
Track dev-master on tribe-testing-facilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "lucatume/function-mocker-le": "^1.0",
     "lucatume/wp-browser": "^2.2.4",
     "moderntribe/tribalscents": "dev-master",
-    "moderntribe/tribe-testing-facilities": "dev-spotfix/include-views-exclusion-for-data-attr-breakpoints",
+    "moderntribe/tribe-testing-facilities": "dev-master",
     "phpunit/phpunit": "~6.0",
     "wp-cli/checksum-command": "1.0.5",
     "wp-coding-standards/wpcs": "^2.1"


### PR DESCRIPTION
Following merge of the [PR](https://github.com/lucatume/wp-snapshot-assertions/pull/2) we can resume using `dev-master` branch.