### PR TITLE
test(Repository/Query_Filters.php) add tests for orderby filter

### DIFF
--- a/src/Tribe/Repository/Query_Filters.php
+++ b/src/Tribe/Repository/Query_Filters.php
@@ -973,10 +973,10 @@ class Tribe__Repository__Query_Filters {
 	 *
 	 * @since 4.9.5
 	 *
-	 * @param string   $orderby
-	 * @param WP_Query $query
+	 * @param string   $orderby The `ORDER BY` clause of the query being filtered.
+	 * @param WP_Query $query   The query object currently being filtered.
 	 *
-	 * @return string
+	 * @return string The filtered `ORDER BY` clause.
 	 */
 	public function filter_posts_orderby( $orderby, WP_Query $query ) {
 		if ( $query !== $this->current_query ) {

--- a/tests/wpunit/Tribe/Repository/Query_FiltersTest.php
+++ b/tests/wpunit/Tribe/Repository/Query_FiltersTest.php
@@ -77,4 +77,65 @@ class Query_FiltersTest extends \Codeception\TestCase\WPTestCase {
 			$id_filters
 		);
 	}
+
+	public function orderby_input_set() {
+		yield 'single string' => [
+			'event_date',
+			'event_date DESC, wp_posts.ID ASC',
+		];
+
+		yield 'array of strings' => [
+			[ 'event_date', 'event_venue' ],
+			'event_date DESC, event_venue DESC, wp_posts.ID ASC',
+		];
+
+		yield 'map of fields and orders' => [
+			[ 'event_date' => 'ASC', 'event_venue' => 'DESC' ],
+			'event_date ASC, event_venue DESC, wp_posts.ID ASC',
+		];
+
+		yield 'id map of fields and orders' => [
+			[ 'event_date' => 'ASC', ],
+			'event_date ASC, wp_posts.ID ASC',
+			'order_by_date'
+		];
+
+		yield 'id map of fields and orders w/ 2 entries' => [
+			[ 'event_date' => 'ASC', 'event_venue' => 'DESC' ],
+			'event_date ASC, event_venue DESC, wp_posts.ID ASC',
+			'order_by_multi'
+		];
+
+		yield 'id map of fields and orders w/ 2 entries, appending' => [
+			[ 'event_date' => 'ASC', 'event_venue' => 'DESC' ],
+			'wp_posts.ID ASC, event_date ASC, event_venue DESC',
+			'order_by_multi',
+			false,
+			true
+		];
+	}
+
+	/**
+	 * It should correctly handle orderby in diff formats
+	 *
+	 * @test
+	 * @dataProvider orderby_input_set
+	 */
+	public function should_correctly_handle_orderby_in_diff_formats(
+		$orderby_input,
+		$expected,
+		$id = null,
+		$override = false,
+		$after = false
+	) {
+		$orderby_sql = 'wp_posts.ID ASC';
+		$query       = new \WP_Query();
+
+		$filters = new Query_Filters();
+		$filters->set_query( $query );
+		$filters->orderby( $orderby_input, $id, false, $after );
+		$filtered = $filters->filter_posts_orderby( $orderby_sql, $query );
+
+		$this->assertEquals( $expected, $filtered );
+	}
 }


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/TCMN-32 

This PR adds tests to cover from regression the previously fixed issue of how `orderby` clauses would be handled by the Repository/ORM.

The reported issue was collaterally fixed while working on other code, but test coverage was missing.