### PR TITLE
Add is_plain_permalink to Rewrite class

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@
 = [TBD] TBD =
 
 * Tweak - Add some visibility-related methods to the `Tribe__Admin__Notices` class [TEC-2994]
+* Tweak - Include Rewrites::is_plain_permalink() with proper caching [TEC-3120]
 
 = [4.11.1] TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,12 +5,12 @@
 = [TBD] TBD =
 
 * Tweak - Add some visibility-related methods to the `Tribe__Admin__Notices` class [TEC-2994]
+* Tweak - Include Rewrites::is_plain_permalink() with proper caching [TEC-3120]
 
 = [4.11.1] TBD =
 
 * Fix - Fix style overrides for new view shortcodes for Genesis theme. [ECP-316]
 * Fix - Fix style overrides for new view shortcodes for Enfold theme. [ECP-315]
-* Tweak - Include Rewrites::is_plain_permalink() with proper caching [TEC-3120]
 * Tweak - Update `adjustStart()` function in moment utils to allow start and end time to be the same. [TEC-3009]
 
 = [4.11.0.1] 2020-02-05 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,12 +5,12 @@
 = [TBD] TBD =
 
 * Tweak - Add some visibility-related methods to the `Tribe__Admin__Notices` class [TEC-2994]
-* Tweak - Include Rewrites::is_plain_permalink() with proper caching [TEC-3120]
 
 = [4.11.1] TBD =
 
 * Fix - Fix style overrides for new view shortcodes for Genesis theme. [ECP-316]
 * Fix - Fix style overrides for new view shortcodes for Enfold theme. [ECP-315]
+* Tweak - Include Rewrites::is_plain_permalink() with proper caching [TEC-3120]
 * Tweak - Update `adjustStart()` function in moment utils to allow start and end time to be the same. [TEC-3009]
 
 = [4.11.0.1] 2020-02-05 =

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -190,6 +190,25 @@ class Tribe__Rewrite {
 	}
 
 	/**
+	 * Determines if we have plain permalink.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool If we use plain permalink or not.
+	 */
+	public function is_plain_permalink() {
+		/* @var $cache Tribe__Cache */
+		$cache = tribe( 'cache' );
+		$permalink = $cache['rewrite_permalink_structure'];
+
+		if ( false === $permalink ) {
+			$permalink = get_option( 'permalink_structure' );
+		}
+
+		return empty( $permalink );
+	}
+
+	/**
 	 * Get the base slugs for the rewrite rules.
 	 *
 	 * WARNING: Don't mess with the filters below if you don't know what you are doing


### PR DESCRIPTION
🎟 [EC-3120]
---
We needed a check that was cached for plain permalinks.

Related to https://github.com/moderntribe/the-events-calendar/pull/3061