### PR TITLE
Add a default value for the datepicker format option. 

### DIFF
--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 */
 		public static function maybe_format_from_datepicker( $date, $datepicker = null ) {
 			if ( ! is_numeric( $datepicker ) ) {
-				$datepicker = tribe_get_option( 'datepickerFormat' );
+				$datepicker = tribe_get_option( 'datepickerFormat', self::get_datepicker_format_index() );
 			}
 
 			if ( is_numeric( $datepicker ) ) {


### PR DESCRIPTION
Without this dates cannot be parsed and do NOT save if the option value is not in the DB.

This is what was happening to me when trying to set the start/end sale dates.
https://share.getcloudapp.com/qGuo0XRY

I'm unsure why the option is not in the DB. 

