### PR TITLE
fix(Rewrite) drop non-scalar query vars from the match

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -418,6 +418,9 @@ class Tribe__Rewrite {
 		$query         = (string) parse_url( $url, PHP_URL_QUERY );
 		wp_parse_str( $query, $query_vars );
 
+		// Drop any query var that is not a scalar; it should not be handled.
+		$query_vars = array_filter( $query_vars, 'is_scalar' );
+
 		if ( isset( $query_vars['paged'] ) && 1 === (int) $query_vars['paged'] ) {
 			// Remove the `paged` query var if it's 1.
 			unset( $query_vars['paged'] );


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/ECP-343 

[Screencast](https://drive.google.com/open?id=13DwNBLzWvXFfUyR0yalXWEgVqFouQf2f&authuser=luca@tri.be&usp=drive_fs)

This PR fixes an issue I found in `Rewrite` while working on shortcode support for multiple category.
When a query var we're trying  to match is not a scalar, i.e. an array here, it should be dropped as we
would not handle that on a URL level.

So: `/?post_type=tribe_events&tribe_events_cat=cat-1` will map to `/events/category/cat-1`, but
`/?post_type=tribe_events&tribe_events_cat[]=cat-1&tribe_events_cat[]=cat-2` should map to `/events?tribe_events_cat[]=cat-1&tribe_events_cat[]=cat-2` and not to the category slug.

This change only affect the "inverse" lookup: plain to pretty permalink, not our rewrite rules.