### PR TITLE
fix(Debug_Bar) class name for back-compat

### DIFF
--- a/src/Tribe/Debug_Bar/Panels/Json_Ld.php
+++ b/src/Tribe/Debug_Bar/Panels/Json_Ld.php
@@ -1,15 +1,13 @@
 <?php
 /**
- * ${CARET}
+ * JSON-LD information Debug Bar panel.
  *
  * @since   TBD
  *
  * @package Tribe\Debug_Bar\Panels
  */
 
-namespace Tribe\Debug_Bar\Panels;
-
-class Json_Ld extends \Debug_Bar_Panel {
+class Tribe__Debug_Bar__Panels__Json_Ld extends Debug_Bar_Panel {
 	/**
 	 * Returns the Panel name.
 	 *
@@ -59,8 +57,21 @@ class Json_Ld extends \Debug_Bar_Panel {
 			         '</a>' .
 			         ' to test it using the Code Snippet option.</p><br>';
 
-			foreach ( $json_ld_data as $json_ld_entry ) {
-				$html .= sprintf( '<pre><code>%s</code></pre>', esc_html( $json_ld_entry ) );
+			foreach ( $json_ld_data as $full_entry ) {
+				preg_match(
+					'/(?<open>^\\s*<script[^>]*?>\\s*)(?<json>.*)(?<close>\\s<\\/script>)$/uism',
+					$full_entry,
+					$frags
+				);
+
+				if ( isset( $frags['open'], $frags['json'], $frags['close'] ) ) {
+					// Let's try and format it if we've got all the pieces.
+					$full_entry = $frags['open']
+					              . json_encode( json_decode( $frags['json'], true ), JSON_PRETTY_PRINT )
+					              . $frags['close'];
+				}
+
+				$html .= sprintf( '<pre><code>%s</code></pre>', esc_html( $full_entry ) );
 			}
 
 			$html .= '</div>';

--- a/src/Tribe/Service_Providers/Debug_Bar.php
+++ b/src/Tribe/Service_Providers/Debug_Bar.php
@@ -1,7 +1,5 @@
 <?php
 
-use Tribe\Debug_Bar\Panels\Json_Ld;
-
 /**
  * Hooks and manages the plugins Debug Bar integrations.
  *
@@ -37,7 +35,7 @@ class Tribe__Service_Providers__Debug_Bar extends tad_DI52_ServiceProvider {
 		 */
 		$tribe_panels = apply_filters( 'tribe_debug_bar_panels', array(
 			new Tribe__Debug_Bar__Panels__Context(),
-			new Json_Ld(),
+			new Tribe__Debug_Bar__Panels__Json_Ld(),
 		) );
 
 		if ( count( $tribe_panels ) > 0 ) {


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/TEC-3241

This PR updates the code responsible for rendering the Events page
JSON-LD output on the page.

While it was working correctly w/ Query Monitor, I found out Debug
Bar requires older class name format to work.

The PR tries to format the output too, if possible.

<img width="1121" alt="debug-bar-json-ld-output" src="https://user-images.githubusercontent.com/2749650/74731788-12d10580-5249-11ea-8d69-c07e4c51b9ac.png">
