### PR TITLE
Use the default `datepickerFormat` value if the option hasn't been set yet when setting up datepicker from specific format

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,9 @@
 
 * Tweak - Add theme compatibility for the tribe dialog [ETP-156]
 * Fix - JavaScript error in tribe dialog when there are no dialogs. Change fallback from object to array. [TCMN-34]
-* Fix - Dialog wasn't working in Safari 12 mobile. [ETP-155]
+* Fix - Fix display of Dialogs in Safari 12 mobile. [ETP-155]
 * Fix - Bring back the dialog icons. [ETP-155]
+* Fix - Use the default `datepickerFormat` value if the option hasn't been set yet when saving tickets. [ET-727]
 
 = [4.11.1] 2020-02-12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@
 * Fix - JavaScript error in tribe dialog when there are no dialogs. Change fallback from object to array. [TCMN-34]
 * Fix - Fix display of Dialogs in Safari 12 mobile. [ETP-155]
 * Fix - Bring back the dialog icons. [ETP-155]
-* Fix - Use the default `datepickerFormat` value if the option hasn't been set yet when saving tickets. [ET-727]
+* Fix - Use the default `datepickerFormat` value if the option hasn't been set yet when setting up datepicker from specific format. [ET-727]
 
 = [4.11.1] 2020-02-12 =
 

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 */
 		public static function maybe_format_from_datepicker( $date, $datepicker = null ) {
 			if ( ! is_numeric( $datepicker ) ) {
-				$datepicker = tribe_get_option( 'datepickerFormat' );
+				$datepicker = self::get_datepicker_format_index();
 			}
 
 			if ( is_numeric( $datepicker ) ) {


### PR DESCRIPTION
[ET-727]

Screencast: https://share.getcloudapp.com/jkuKoPny

[ET-727]: https://moderntribe.atlassian.net/browse/ET-727