### PR TITLE
Prevent addons that are later in the list from breaking the earlier ones

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.11.2.1] 2020-02-24 =
 
+* Fix - Plugin dependency registration with `Plugin_Register` will not prevent loading of all plugins in list if the last loaded fails. [FBAR-78]
 
 = [4.11.2] 2020-02-19 =
 

--- a/src/Tribe/Dependency.php
+++ b/src/Tribe/Dependency.php
@@ -521,18 +521,17 @@ if ( ! class_exists( 'Tribe__Dependency' ) ) {
 		 * @return bool  returns false if any dependency is invalid
 		 */
 		protected function check_addon_dependencies( $main_class ) {
-
-			$addon_dependencies = 0;
+			$addon_dependencies = [];
 
 			foreach ( $this->registered_plugins as $registered ) {
 				if ( empty( $registered['dependencies']['addon-dependencies'][ $main_class ] ) ) {
 					continue;
 				}
 
-				$addon_dependencies = $this->has_valid_dependencies( $registered, $registered['dependencies']['addon-dependencies'], true );
+				$addon_dependencies[ $main_class ] = $this->has_valid_dependencies( $registered, $registered['dependencies']['addon-dependencies'], true );
 			}
 
-			return $addon_dependencies;
+			return in_array( true,  $addon_dependencies, true );
 		}
 
 		/**

--- a/src/Tribe/Dependency.php
+++ b/src/Tribe/Dependency.php
@@ -409,11 +409,11 @@ if ( ! class_exists( 'Tribe__Dependency' ) ) {
 		 *
 		 * @since 4.9
 		 *
-		 * @param       $file_path
-		 * @param       $main_class
-		 * @param       $version
-		 * @param array $classes_req
-		 * @param array $dependencies
+		 * @param string $file_path    Full file path to the base plugin file
+		 * @param string $main_class   The Main/base class for this plugin
+		 * @param string $version      The version
+		 * @param array  $classes_req  Any Main class files/tribe plugins required for this to run
+		 * @param array  $dependencies an array of dependencies to check
 		 */
 		public function register_plugin( $file_path, $main_class, $version, $classes_req = array(), $dependencies = array() ) {
 			/**
@@ -475,11 +475,7 @@ if ( ! class_exists( 'Tribe__Dependency' ) ) {
 		 *
 		 * @since 4.9
 		 *
-		 * @param string $file_path    Full file path to the base plugin file
 		 * @param string $main_class   The Main/base class for this plugin
-		 * @param string $version      The version
-		 * @param array  $classes_req  Any Main class files/tribe plugins required for this to run
-		 * @param array  $dependencies an array of dependencies to check
 		 *
 		 * @return bool Indicates if plugin should continue initialization
 		 */

--- a/src/Tribe/Dependency.php
+++ b/src/Tribe/Dependency.php
@@ -409,11 +409,11 @@ if ( ! class_exists( 'Tribe__Dependency' ) ) {
 		 *
 		 * @since 4.9
 		 *
-		 * @param string $file_path    Full file path to the base plugin file
-		 * @param string $main_class   The Main/base class for this plugin
-		 * @param string $version      The version
-		 * @param array  $classes_req  Any Main class files/tribe plugins required for this to run
-		 * @param array  $dependencies an array of dependencies to check
+		 * @param string $file_path    Full file path to the base plugin file.
+		 * @param string $main_class   The Main/base class for this plugin.
+		 * @param string $version      The plugin version.
+		 * @param array  $classes_req  Any Main class files/tribe plugins required for this to run.
+		 * @param array  $dependencies an array of dependencies to check.
 		 */
 		public function register_plugin( $file_path, $main_class, $version, $classes_req = array(), $dependencies = array() ) {
 			/**


### PR DESCRIPTION
🎟 [FBAR-78]
---
📹 https://i.bordoni.me/v1urmx5b
Due to how the code was set up before if a given Addon Dependency that was on the end of the list returned `false` it would block the loading for all dependencies as if they all failed, instead of just warning us about the fail on for example Filterbar.

[FBAR-78]: https://moderntribe.atlassian.net/browse/FBAR-78