### PR TITLE
Task/delay init store

### DIFF
--- a/src/modules/utils/globals.js
+++ b/src/modules/utils/globals.js
@@ -3,6 +3,9 @@
  */
 export const get = ( key, defaultValue ) => window[ key ] || defaultValue;
 export const google = () => get( 'google' );
+export const wpApi = wp.api;
+export const wpApiRequest = wp.apiRequest;
+export const wpData = wp.data;
 
 // Localized Config
 export const config = () => get( 'tribe_editor_config', {} );


### PR DESCRIPTION
[TEC-3181]

This task is the first task of setting up allowing us to set the initial state of our block editor application through the reducer rather than via mounting of the blocks.

Related to:
* https://github.com/moderntribe/the-events-calendar/pull/3093
* https://github.com/moderntribe/events-pro/pull/1510
* ET PR to come
* ET+ PR to come

[TEC-3181]: https://moderntribe.atlassian.net/browse/TEC-3181