### PR TITLE
TCMN-46: Include required files to upload a file.

### DIFF
--- a/src/Tribe/Image/Uploader.php
+++ b/src/Tribe/Image/Uploader.php
@@ -124,6 +124,11 @@ class Tribe__Image__Uploader {
 			return false;
 		}
 
+		// These files need to be included as dependencies
+		require_once( ABSPATH . 'wp-admin/includes/image.php' );
+		require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		require_once( ABSPATH . 'wp-admin/includes/media.php' );
+
 		$is_local = false;
 		// This is a local file no need to fetch it from the wire.
 		if ( $allow_local_urls && file_exists( $file_url ) ) {


### PR DESCRIPTION
Fix issue when files where not loaded to upload a file, using same patterns from: https://codex.wordpress.org/Function_Reference/media_handle_upload.

```php
<?php

// Check that the nonce is valid, and the user can edit this post.
if ( 
	isset( $_POST['my_image_upload_nonce'], $_POST['post_id'] ) 
	&& wp_verify_nonce( $_POST['my_image_upload_nonce'], 'my_image_upload' )
	&& current_user_can( 'edit_post', $_POST['post_id'] )
) {
	// The nonce was valid and the user has the capabilities, it is safe to continue.

	// These files need to be included as dependencies when on the front end.
	require_once( ABSPATH . 'wp-admin/includes/image.php' );
	require_once( ABSPATH . 'wp-admin/includes/file.php' );
	require_once( ABSPATH . 'wp-admin/includes/media.php' );
	
	// Let WordPress handle the upload.
	// Remember, 'my_image_upload' is the name of our file input in our form above.
	$attachment_id = media_handle_upload( 'my_image_upload', $_POST['post_id'] );
	
	if ( is_wp_error( $attachment_id ) ) {
		// There was an error uploading the image.
	} else {
		// The image was uploaded successfully!
	}

} else {

	// The security check failed, maybe show the user an error.
}
```

Ticket: [TCMN-46]

Relates to https://github.com/moderntribe/tribe-common/pull/471 as well.

[TCMN-46]: https://moderntribe.atlassian.net/browse/TCMN-46