### PR TITLE
Update our PCSS to handle with the changes made to WP 5.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.11.6] TBD =
 
+* Fix - Blocks editor CSS compatibility with WordPress 5.4 with new module classes: `.block-editor-inner-blocks`
 
 = [4.11.5.1] 2020-03-23 =
 

--- a/src/modules/components/plugin-block-hooks/style.pcss
+++ b/src/modules/components/plugin-block-hooks/style.pcss
@@ -1,5 +1,6 @@
 .tribe-common__plugin-block-hook {
 
+	& .block-editor-inner-blocks,
 	& .editor-inner-blocks {
 
 		& .editor-block-list__layout {


### PR DESCRIPTION
Using: https://github.com/mcsf/find-deprecated-css-in-wp52 we determined which CSS rules would need changes. 

We might have some other changes to make, will update this PR once I am sure of that.