### PR TITLE
Task/store init from window

### DIFF
--- a/src/modules/utils/globals.js
+++ b/src/modules/utils/globals.js
@@ -38,3 +38,6 @@ export const editorDefaults = () => pro().defaults || {};
 
 // Tickets
 export const tickets = () => config().tickets || {};
+
+// Post Objects
+export const postObjects = () => config().post_objects || {};


### PR DESCRIPTION
[TEC-3339]

This task is the first task of setting up allowing us to set the initial state of our block editor application through the reducer rather than via mounting of the blocks

Related to:
* https://github.com/moderntribe/the-events-calendar/pull/3114
* https://github.com/moderntribe/events-pro/pull/1522

[TEC-3339]: https://moderntribe.atlassian.net/browse/TEC-3339