### PR TITLE
fix(translations): Clear the cache when the language setting changes.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@
 
 = [4.12.0] TBD =
 
-* Fix - Clear the views HTML cache on language settings changes to ensure we don't mix up translated strings [TEC-3326]
-* Tweak - Added homepage settings to system information
+* Fix - Clear the views HTML cache on language settings changes to ensure we don't mix up translated strings. [TEC-3326]
+* Tweak - Added homepage settings to system information.
 * Tweak - Add the `tribe_template_done` filter to be able to disable a template before rendering. [TEC-3385]
 * Fix - Blocks editor CSS compatibility with WordPress 5.4 with new module classes: `.block-editor-inner-blocks`
 * Fix - Add style override for <ul> in Divi due to theme use of IDs [TEC-3235]

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.11.6] TBD =
 
+* Fix - Clear the views HTML cache on language settings changes to ensure we don't mix up translated strings [TEC-3326]
 * Tweak - Add the `tribe_template_done` filter to be able to disable a template before rendering. [TEC-3385]
 
 = [4.11.5.1] 2020-03-23 =

--- a/src/Tribe/Cache_Listener.php
+++ b/src/Tribe/Cache_Listener.php
@@ -117,6 +117,7 @@
 				'sidebars_widgets'              => true,
 				'stylesheet'                    => true,
 				'template'                      => true,
+				'WPLANG'                        => true,
 			];
 
 			if ( ! empty( $triggers[ $option_name ] ) ) {


### PR DESCRIPTION
Ensure we clear the cache when the language setting/option changes so that HTML caching doesn't mix language strings.

[TEC-3326]

[TEC-3326]: https://moderntribe.atlassian.net/browse/TEC-3326