### PR TITLE
Spotfix/unifying read more strings

### DIFF
--- a/src/Tribe/Admin/Notice/Plugin_Download.php
+++ b/src/Tribe/Admin/Notice/Plugin_Download.php
@@ -121,7 +121,7 @@ class Tribe__Admin__Notice__Plugin_Download {
 
 		$notice_html_content = '<p>' . esc_html__( 'To begin using %2$s, please install and activate %3$s.', 'tribe-common' ) . '</p>';
 
-		$read_more_link = '<a href="http://m.tri.be/1aev" target="_blank">' . esc_html__( 'Read more.', 'tribe-common' ) . '</a>';
+		$read_more_link = '<a href="http://m.tri.be/1aev" target="_blank">' . esc_html__( 'Read more', 'tribe-common' ) . '.</a>';
 		$pue_notice_text = esc_html__( 'There’s a new version of %1$s available, but your license is expired. You’ll need to renew your license to get access to the latest version. If you plan to continue using your current version of the plugin(s), be sure to use a compatible version of The Events Calendar. %2$s', 'tribe-common' );
 		$pue_notice_html = '<p>' . sprintf( $pue_notice_text, $plugin_names_clean_text, $read_more_link ) . '</p>';
 

--- a/src/Tribe/PUE/Update_Prevention.php
+++ b/src/Tribe/PUE/Update_Prevention.php
@@ -178,7 +178,7 @@ class Update_Prevention {
 		$plugins_classes = array_keys( $incompatible_plugins );
 		$plugins_list_html = tribe( 'pue.notices' )->get_formatted_plugin_names_from_classes( $plugins_classes );
 
-		$link_read_more = '<a href="http://m.tri.be/1aev" target="_blank">' . esc_html__( 'Read More.', 'tribe-common' ) . '</a>';
+		$link_read_more = '<a href="http://m.tri.be/1aev" target="_blank">' . esc_html__( 'Read more', 'tribe-common' ) . '.</a>';
 
 		$message = sprintf(
 			esc_html__( 'Your update failed due to an incompatibility between the version (%1$s) of the %2$s you tried to update to and the version of %3$s that you are using. %4$s', 'tribe-common' ),


### PR DESCRIPTION
While going through translations I discovered that we have the string 'Read more' in several different ways in the code:

- Read more (twice, which I took as the correct one)
- Read More
- Read more.
- Read More.

In this PR, and another one in tribe common I have unified these to all say 'Read more'. If there is a period after the string, that has been moved out, so it does not show up in the translation.

Jira: https://moderntribe.atlassian.net/browse/BTRIA-307

The corresponding PR in TEC:
https://github.com/moderntribe/the-events-calendar/pull/3130