### PR TITLE
Fix/tcmn 58 translation loading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,7 @@
 * Tweak - Add the `tribe_template_done` filter to be able to disable a template before rendering. [TEC-3385]
 * Fix - Blocks editor CSS compatibility with WordPress 5.4 with new module classes: `.block-editor-inner-blocks`
 * Fix - Add style override for <ul> in Divi due to theme use of IDs [TEC-3235]
+* Fix - Change text domain loading to occur on 'init' hook instead of 'plugins_loaded'. Added new `tribe_load_text_domain` action hook for our other plugins to use for their own text domain loading on 'init' as well. [TCMN-58]
 
 = [4.11.5.1] 2020-03-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@
 * Tweak - Add the `tribe_template_done` filter to be able to disable a template before rendering. [TEC-3385]
 * Fix - Blocks editor CSS compatibility with WordPress 5.4 with new module classes: `.block-editor-inner-blocks`
 * Fix - Add style override for <ul> in Divi due to theme use of IDs [TEC-3235]
-* Fix - Change text domain loading to occur on 'init' hook instead of 'plugins_loaded'. Added new `tribe_load_text_domain` action hook for our other plugins to use for their own text domain loading on 'init' as well. [TCMN-58]
+* Fix - Change text domain loading to occur on 'init' hook instead of 'plugins_loaded'. Added new `tribe_load_text_domains` action hook for our other plugins to use for their own text domain loading on 'init' as well. [TCMN-58]
 
 = [4.11.5.1] 2020-03-23 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -360,7 +360,7 @@ class Tribe__Main {
 
 		// Register for the assets to be available everywhere
 		add_action( 'tribe_common_loaded', [ $this, 'load_assets' ], 1 );
-		add_action( 'init', [ $this, 'common_load_text_domain' ] );
+		add_action( 'init', [ $this, 'hook_load_text_domain' ] );
 		add_action( 'init', [ $this, 'load_localize_data' ] );
 		add_action( 'plugins_loaded', [ 'Tribe__Admin__Notices', 'instance' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'store_admin_notices' ] );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -96,8 +96,6 @@ class Tribe__Main {
 	 */
 	public function plugins_loaded() {
 
-		$this->load_text_domain( 'tribe-common', basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/' );
-
 		$this->init_autoloading();
 
 		$this->bind_implementations();
@@ -261,11 +259,42 @@ class Tribe__Main {
 			'admin_enqueue_scripts',
 			[
 				'conditionals' => [ $this, 'should_load_common_admin_css' ],
-				'priority' => 5,
+				'priority'     => 5,
 			]
 		);
 
 		tribe( Tribe__Admin__Help_Page::class )->register_assets();
+	}
+
+	/**
+	 * Load Common's text domain, then fire the hook for other plugins to do the same.
+	 *
+	 * Make sure this fires on 'init', per WordPress best practices.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function common_load_text_domain() {
+		$loaded = $this->load_text_domain(
+			'tribe-common',
+			basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/'
+		);
+
+		/**
+		 * After attempting (hopefully successfully) to load Common's text domain.
+		 *
+		 * Load other plugin text domains on this hook, but make sure they're setup on this hook prior to 'init'.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $loaded Whether or not Common's text domain was loaded.
+		 *
+		 * @return bool
+		 */
+		do_action( 'tribe_common_load_text_domain', $loaded );
+
+		return $loaded;
 	}
 
 	/**
@@ -331,6 +360,7 @@ class Tribe__Main {
 
 		// Register for the assets to be available everywhere
 		add_action( 'tribe_common_loaded', [ $this, 'load_assets' ], 1 );
+		add_action( 'init', [ $this, 'common_load_text_domain' ] );
 		add_action( 'init', [ $this, 'load_localize_data' ] );
 		add_action( 'plugins_loaded', [ 'Tribe__Admin__Notices', 'instance' ], 1 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'store_admin_notices' ] );
@@ -410,7 +440,7 @@ class Tribe__Main {
 	 * @since  4.2   Included $domain and $dir params.
 	 *
 	 * @param string       $domain The text domain that will be loaded.
-	 * @param string|false $dir    What directory should be used to try to load if the default doesnt work.
+	 * @param string|false $dir    What directory should be used to try to load if the default doesn't work.
 	 *
 	 * @return bool  If it was able to load the text domain.
 	 */

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -275,7 +275,7 @@ class Tribe__Main {
 	 *
 	 * @return bool
 	 */
-	public function common_load_text_domain() {
+	public function hook_load_text_domain() {
 		$loaded = $this->load_text_domain(
 			'tribe-common',
 			basename( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) ) . '/common/lang/'

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -292,7 +292,7 @@ class Tribe__Main {
 		 *
 		 * @return bool
 		 */
-		do_action( 'tribe_common_load_text_domain', $loaded );
+		do_action( 'tribe_load_text_domains', $loaded );
 
 		return $loaded;
 	}


### PR DESCRIPTION
[TCMN-58] move text domain loading from 'plugins_loaded' to 'init'

See [ET's implementation PR](https://github.com/moderntribe/event-tickets/pull/1642) for artifact of it working

[TCMN-58]: https://moderntribe.atlassian.net/browse/TCMN-58