### PR TITLE
feat(Autoloader) support flat and nested namespaced classes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Extended support for namespaced classes in the Autoloader.
+
 = [4.12.0] 2020-04-23 =
 
 * Feature - Management of Shortcodes now are fully controlled by Common Manager classes [TCMN-56]

--- a/src/Tribe/Autoloader.php
+++ b/src/Tribe/Autoloader.php
@@ -163,11 +163,25 @@
 
 			protected function get_prefixed_path( $class ) {
 				foreach ( $this->prefixes as $prefix => $dirs ) {
+					$is_namespaced = false !== strpos( $prefix, '\\' );
+
+					if ( $is_namespaced ) {
+						// If the prefix is a namespace, then normalize it.
+						$prefix = trim( $prefix, '\\' ) . '\\';
+					}
+
 					if ( strpos( $class, $prefix ) !== 0 ) {
 						continue;
 					}
+
 					$class_name = str_replace( $prefix, '', $class );
-					$class_path_frag = implode( '/', explode( $this->dir_separator, $class_name ) ) . '.php';
+
+					if ( ! $is_namespaced ) {
+						$class_path_frag = implode( '/', explode( $this->dir_separator, $class_name ) ) . '.php';
+					} else {
+						$class_path_frag = implode( '/', explode( '\\', $class_name ) ) . '.php';
+					}
+
 					foreach ( $dirs as $dir ) {
 						$path = $dir . '/' . $class_path_frag;
 						if ( ! file_exists( $path ) ) {

--- a/tests/_data/Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/SubTwo.php
+++ b/tests/_data/Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/SubTwo.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested\CCNestedSubOne\CCNestedSubTwo;
+
+class SubTwo {
+
+}

--- a/tests/_data/Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/Sub_Two.php
+++ b/tests/_data/Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/Sub_Two.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested\CCNestedSubOne\CCNestedSubTwo;
+
+class Sub_Two {
+
+}

--- a/tests/_data/Tribe/CCNested/CCNestedSubOne/SubOne.php
+++ b/tests/_data/Tribe/CCNested/CCNestedSubOne/SubOne.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested\CCNestedSubOne;
+
+class SubOne {
+
+}

--- a/tests/_data/Tribe/CCNested/CCNestedSubOne/Sub_One.php
+++ b/tests/_data/Tribe/CCNested/CCNestedSubOne/Sub_One.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested\CCNestedSubOne;
+
+class Sub_One {
+
+}

--- a/tests/_data/Tribe/CCNested/Class_One.php
+++ b/tests/_data/Tribe/CCNested/Class_One.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested;
+
+class Class_One {
+
+}

--- a/tests/_data/Tribe/CCNested/One.php
+++ b/tests/_data/Tribe/CCNested/One.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\CCNested;
+
+class One {
+
+}

--- a/tests/_data/Tribe/Flat/One.php
+++ b/tests/_data/Tribe/Flat/One.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Tribe\Flat;
+
+class One {
+}

--- a/tests/_data/Tribe/Nested/Level_One/CamelcaseClassOne.php
+++ b/tests/_data/Tribe/Nested/Level_One/CamelcaseClassOne.php
@@ -1,0 +1,5 @@
+<?php
+namespace Tribe\Nested\Level_One;
+
+class CamelcaseClassOne {
+}

--- a/tests/_data/Tribe/Nested/Level_One/Class_One.php
+++ b/tests/_data/Tribe/Nested/Level_One/Class_One.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested\Level_One;
+
+class Class_One {
+
+}

--- a/tests/_data/Tribe/Nested/Level_One/Level_Two/CamelcaseClassTwo.php
+++ b/tests/_data/Tribe/Nested/Level_One/Level_Two/CamelcaseClassTwo.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested\Level_One\Level_Two;
+
+class CamelcaseClassTwo {
+
+}

--- a/tests/_data/Tribe/Nested/Level_One/Level_Two/Class_Two.php
+++ b/tests/_data/Tribe/Nested/Level_One/Level_Two/Class_Two.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested\Level_One\Level_Two;
+
+class Class_Two {
+
+}

--- a/tests/_data/Tribe/Nested/Level_One/Level_Two/Level_Three/CamelcaseClassThree.php
+++ b/tests/_data/Tribe/Nested/Level_One/Level_Two/Level_Three/CamelcaseClassThree.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested\Level_One\Level_Two\Level_Three;
+
+class CamelcaseClassThree {
+
+}

--- a/tests/_data/Tribe/Nested/Level_One/Level_Two/Level_Three/Class_Three.php
+++ b/tests/_data/Tribe/Nested/Level_One/Level_Two/Level_Three/Class_Three.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested\Level_One\Level_Two\Level_Three;
+
+class Class_Three {
+
+}

--- a/tests/_data/Tribe/Nested/Root.php
+++ b/tests/_data/Tribe/Nested/Root.php
@@ -1,0 +1,6 @@
+<?php
+namespace Tribe\Nested;
+
+class Root {
+
+}

--- a/tests/_data/Tribe/README.md
+++ b/tests/_data/Tribe/README.md
@@ -1,0 +1,3 @@
+This is just a test data directory to test support for namespaced class names in the autoloader.  
+
+Nothing really interesting here.

--- a/tests/unit/Tribe/Utils/AutoloaderTest.php
+++ b/tests/unit/Tribe/Utils/AutoloaderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tribe\Test;
+
+use Codeception\Test\Unit;
+use Tribe__Autoloader as Autoloader;
+
+class AutoloaderTest extends Unit {
+	public function root_level_ns_class_data_provider() {
+		return [
+			'w/ leading slash'              => [ '\\Tribe\\Flat' ],
+			'w/o leading slash'             => [ 'Tribe\\Flat' ],
+			'w/ trailing slash'             => [ 'Tribe\\Flat\\' ],
+			'w/ leading and trailing slash' => [ '\\Tribe\\Flat\\' ],
+		];
+	}
+
+	/**
+	 * It should correctly locate namespaced classes at root level
+	 *
+	 * @test
+	 * @dataProvider root_level_ns_class_data_provider
+	 */
+	public function should_correctly_locate_namespaced_classes_at_root_level( $prefix ) {
+		$autoloader = new Autoloader();
+		$autoloader->register_prefix( $prefix, codecept_data_dir( 'Tribe/Flat' ) );
+
+		$class_path = $autoloader->get_class_path( 'Tribe\\Flat\\One' );
+
+		$this->assertEquals( codecept_data_dir( 'Tribe/Flat/One.php' ), $class_path );
+	}
+
+	public function nested_level_ns_class_data_provider() {
+		return [
+			'w/ leading slash'              => [ '\\Tribe\\Nested' ],
+			'w/o leading slash'             => [ 'Tribe\\Nested' ],
+			'w/ trailing slash'             => [ 'Tribe\\Nested\\' ],
+			'w/ leading and trailing slash' => [ '\\Tribe\\Nested\\' ],
+		];
+	}
+
+	/**
+	 * It should correctly locate classes in nested namespaces
+	 *
+	 * @test
+	 * @dataProvider nested_level_ns_class_data_provider
+	 */
+	public function should_correctly_locate_classes_in_nested_namespaces( $prefix ) {
+		$autoloader = new Autoloader();
+		$autoloader->register_prefix( $prefix, codecept_data_dir( 'Tribe/Nested' ) );
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Root.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Root' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/Class_One.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\Class_One' )
+		);
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/CamelcaseClassOne.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\CamelcaseClassOne' )
+		);
+
+		$class_path = $autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\Level_Two\\Class_Two' );
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/Level_Two/Class_Two.php' ),
+			$class_path
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/Level_Two/CamelcaseClassTwo.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\Level_Two\\CamelcaseClassTwo' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/Level_Two/Level_Three/Class_Three.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\Level_Two\\Level_Three\\Class_Three' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/Nested/Level_One/Level_Two/Level_Three/CamelcaseClassThree.php' ),
+			$autoloader->get_class_path( 'Tribe\\Nested\\Level_One\\Level_Two\\Level_Three\\CamelcaseClassThree' )
+		);
+	}
+
+	public function cc_namespace_data_provider() {
+		return [
+			'w/ leading slash'              => [ '\\Tribe\\CCNested' ],
+			'w/o leading slash'             => [ 'Tribe\\CCNested' ],
+			'w/ trailing slash'             => [ 'Tribe\\CCNested\\' ],
+			'w/ leading and trailing slash' => [ '\\Tribe\\CCNested\\' ],
+		];
+	}
+
+	/**
+	 * It should correctly locate classes in camelcase namespaces
+	 *
+	 * @test
+	 * @dataProvider cc_namespace_data_provider
+	 */
+	public function should_correctly_locate_classes_in_camelcase_namespaces( $prefix ) {
+		$autoloader = new Autoloader();
+		$autoloader->register_prefix( $prefix, codecept_data_dir( 'Tribe/CCNested' ) );
+
+		$class_path = $autoloader->get_class_path( 'Tribe\\CCNested\\One' );
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/One.php' ),
+			$class_path
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/Class_One.php' ),
+			$autoloader->get_class_path( 'Tribe\\CCNested\\Class_One' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/CCNestedSubOne/Sub_One.php' ),
+			$autoloader->get_class_path( 'Tribe\\CCNested\\CCNestedSubOne\\Sub_One' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/CCNestedSubOne/SubOne.php' ),
+			$autoloader->get_class_path( 'Tribe\\CCNested\\CCNestedSubOne\\SubOne' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/Sub_Two.php' ),
+			$autoloader->get_class_path( 'Tribe\\CCNested\\CCNestedSubOne\\CCNestedSubTwo\\Sub_Two' )
+		);
+
+		$this->assertEquals(
+			codecept_data_dir( 'Tribe/CCNested/CCNestedSubOne/CCNestedSubTwo/SubTwo.php' ),
+			$autoloader->get_class_path( 'Tribe\\CCNested\\CCNestedSubOne\\CCNestedSubTwo\\SubTwo' )
+		);
+	}
+}


### PR DESCRIPTION
This PR adds support for namespaced classes in the Autoloader.

While we had a "kinda" working support that would rely on:

1. the prefix had to be set to one w/o the leading `\` slash.
2. the directory structure of the namespaced classes had to be falt, w/o sub-directories.

This PRs allows registering prefixes in all the diff. ways and adds support for nested
directory structures.