### PR TITLE
Add Context locations required by VE plugin.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * Tweak - Extended support for namespaced classes in the Autoloader.
 * Tweak - Make Customizer stylesheet enqueue filterable via `tribe_customizer_inline_stylesheets`. [TEC-3401]
 * Tweak - Normalize namespaced prefixes with trailing backslash when registering them in the Autoloader. [VE-14]
+* Tweak - Added the `bulk_edit` and `inline_save` locations to the Context. [VE-8]
 
 = [4.12.0] 2020-04-23 =
 

--- a/src/Tribe/Context/locations.php
+++ b/src/Tribe/Context/locations.php
@@ -136,4 +136,20 @@ return [
 			Tribe__Context::REQUEST_VAR => [ 'post_tag', 'tag' ],
 		],
 	],
+	'bulk_edit' => [
+		'read' => [
+			Tribe__Context::REQUEST_VAR => [ 'bulk_edit' ],
+		],
+	],
+	'inline_save' => [
+		'read' => [
+			Tribe__Context::FUNC => [
+				static function () {
+					return tribe_get_request_var( 'action', false ) === 'inline-save'
+						? true
+						: Tribe__Context::NOT_FOUND;
+				}
+			],
+		],
+	],
 ];


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/VE-8

In the context of the work done for VE we need some extra locations from the Context to streamline the code and allow for easier testing.

The locations are:

* `bulk_edit` - whether the current context is a bulk-edit request one or not.
* `inline_save` - whether the current context is an inline save one or not.