### PR TITLE
feature(tracker): Adds a method to get the change date of a key.

### DIFF
--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -96,11 +96,7 @@ class Tribe__Tracker {
 		$modified = get_post_meta( $post_id, self::$field_key, true );
 
 		// If the key is missing or empty/null return false - no recorded change.
-		if ( empty( $modified[ $meta_key ] ) ) {
-			return false;
-		}
-
-		return $modified[ $meta_key ];
+		return Tribe__Utils__Array::get( $modified, $meta_key, false );
 	}
 
 	/**

--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -83,7 +83,28 @@ class Tribe__Tracker {
 	}
 
 	/**
-	 * Easy way to see currently which post types are been tracked by our code.
+	 * Get the date(timestamp) of last modification for a tracked field.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $meta_key The key for the meta field we're interested in.
+	 * @param int $post_id The ID of the post to check.
+	 *
+	 * @return boolean|string The change timestamp or false if the field is not found/empty.
+	 */
+	public function get_modified_date( $meta_key, $post_id ) {
+		$modified = get_post_meta( $post_id, self::$field_key, true );
+
+		// If the key is missing or empty/null return false - no recorded change.
+		if ( empty( $modified[ $meta_key ] ) ) {
+			return false;
+		}
+
+		return $modified[ $meta_key ];
+	}
+
+	/**
+	 * Easy way to see currently which post types are being tracked by our code.
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
The tracker's data is useful for determining when something happens.
This code adds a method that allows you to provide the post ID and a key and get back the timestamp of the change.
Useful for determining if something was changed before/after something else, such as publish date.

Part of [VE-17]

[VE-17]: https://moderntribe.atlassian.net/browse/VE-17