### PR TITLE
hen using Block Editor we ensure that `apply_filters` for `the_content` on `tribe_get_the_content`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [TBD] TBD =
 
+* Fix - When using Block Editor we ensure that `apply_filters` for `the_content` on `tribe_get_the_content`, the lack of that filter prevented blocks from rendering. [TEC-3456]
 * Tweak - Added the `bulk_edit` and `inline_save` locations to the Context. [VE-8]
 
 = [4.12.1] 2020-05-11 =

--- a/src/functions/template-tags/post.php
+++ b/src/functions/template-tags/post.php
@@ -30,7 +30,7 @@ function tribe_get_the_content( $more_link_text = null, $strip_teaser = false, $
 		$content = get_the_content( $more_link_text, $strip_teaser );
 	}
 
-	$has_blocks = false;
+	$has_blocks = function_exists( 'has_blocks' ) && has_blocks( $content );
 	// If blocks are present we need to run the content filter.
 	if ( function_exists( 'has_blocks' ) ) {
 		$has_blocks = has_blocks( $content );

--- a/src/functions/template-tags/post.php
+++ b/src/functions/template-tags/post.php
@@ -31,7 +31,7 @@ function tribe_get_the_content( $more_link_text = null, $strip_teaser = false, $
 	}
 
 	$has_blocks = false;
-	// If blocks are present we need to for sure pass the content filter.
+	// If blocks are present we need to run the content filter.
 	if ( function_exists( 'has_blocks' ) ) {
 		$has_blocks = has_blocks( $content );
 	}

--- a/src/functions/template-tags/post.php
+++ b/src/functions/template-tags/post.php
@@ -32,9 +32,6 @@ function tribe_get_the_content( $more_link_text = null, $strip_teaser = false, $
 
 	$has_blocks = function_exists( 'has_blocks' ) && has_blocks( $content );
 	// If blocks are present we need to run the content filter.
-	if ( function_exists( 'has_blocks' ) ) {
-		$has_blocks = has_blocks( $content );
-	}
 
 	if ( $has_blocks || ! doing_filter( 'the_content' ) ) {
 		/**

--- a/src/functions/template-tags/post.php
+++ b/src/functions/template-tags/post.php
@@ -30,7 +30,13 @@ function tribe_get_the_content( $more_link_text = null, $strip_teaser = false, $
 		$content = get_the_content( $more_link_text, $strip_teaser );
 	}
 
-	if ( ! doing_filter( 'the_content' ) ) {
+	$has_blocks = false;
+	// If blocks are present we need to for sure pass the content filter.
+	if ( function_exists( 'has_blocks' ) ) {
+		$has_blocks = has_blocks( $content );
+	}
+
+	if ( $has_blocks || ! doing_filter( 'the_content' ) ) {
 		/**
 		 * Filters the post content.
 		 *


### PR DESCRIPTION
🎟 [TEC-3456]
---
This bug was introduced on [ECP-345], I still feel like this feels a bit hacky compared to just running the `apply_filters` every time like the default WordPress `the_content()` does.

[TEC-3456]: https://moderntribe.atlassian.net/browse/TEC-3456
[ECP-345]: https://moderntribe.atlassian.net/browse/ECP-345