### PR TITLE
Add With_Meta_Handling trait

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Feat - Added the `Tribe\Traits\With_Meta_Updates_Handling` trait to provide methods useful in handling with meta. 
+
 = [4.12.3] 2020-05-27 =
 
 * Fix - When using Block Editor we ensure that `apply_filters` for `the_content` on `tribe_get_the_content`, the lack of that filter prevented blocks from rendering. [TEC-3456]

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -1,9 +1,11 @@
 <?php
 
+use Tribe\Traits\With_Meta_Updates_Handling;
 use Tribe__Utils__Array as Arr;
 
 abstract class Tribe__Repository
 	implements Tribe__Repository__Interface {
+	use With_Meta_Updates_Handling;
 
 	const MAX_NUMBER_OF_POSTS_PER_PAGE = 99999999999;
 

--- a/src/Tribe/Traits/With_Meta_Updates_Handling.php
+++ b/src/Tribe/Traits/With_Meta_Updates_Handling.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Provides methods useful to deal with meta updates.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Traits
+ */
+
+namespace Tribe\Traits;
+
+/**
+ * Trait With_Meta_Updates_Handling
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Traits
+ */
+trait With_Meta_Updates_Handling {
+	/**
+	 * Returns a closure that should be hooked to the `udapte_post_metadata` filter to "unpack" arrays of meta
+	 * for a specific key.
+	 *
+	 * Providing an array of values in the context of `meta_input` will store them as a single array of values, not
+	 * as multiple values. This closure will unpack the meta on update to have multiple values in place of one.
+	 * This is the case, as an example, with Event Organizers, where we want a meta entry for each Organizer, not an
+	 * array of Organizer IDs in a single meta.
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $target_meta_key The meta key that should be "unpacked" for updates.
+	 * @param int|null $target_post_id  The specific post ID to target, or null to target the next update.
+	 *
+	 * @return \Closure The closure that will deal with the unpacked meta update.
+	 */
+	protected function unpack_meta_on_update( $target_meta_key, $target_post_id = null ) {
+		$closure = static function ( $update = null, $post_id = null, $meta_key = null, $meta_value = null ) use (
+			$target_post_id,
+			$target_meta_key,
+			&$closure
+		) {
+			if ( $target_meta_key !== $meta_key ) {
+				return $update;
+			}
+
+			if ( null !== $target_post_id && $target_post_id !== $post_id ) {
+				return $update;
+			}
+
+			remove_filter( 'update_post_metadata', $closure );
+
+			$values = (array) $meta_value;
+			delete_post_meta( $post_id, $target_meta_key );
+			foreach ( $values as $organizer_id ) {
+				add_post_meta( $post_id, $target_meta_key, $organizer_id );
+			}
+
+			// As in "we've dealt with it, do not update this meta."
+			return true;
+		};
+
+		add_filter( 'update_post_metadata', $closure, 10, 4 );
+
+		return $closure;
+	}
+}

--- a/tests/wpunit/Tribe/Traits/With_Meta_Updates_HandlingTest.php
+++ b/tests/wpunit/Tribe/Traits/With_Meta_Updates_HandlingTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tribe\Traits;
+
+class With_Meta_Updates_HandlingTest extends \Codeception\TestCase\WPTestCase {
+	use With_Meta_Updates_Handling;
+
+	/**
+	 * It should not unpack meta by default
+	 *
+	 * @test
+	 */
+	public function should_not_unpack_meta_by_default() {
+		$post_id = static::factory()->post->create();
+		wp_update_post( [
+			'ID'         => $post_id,
+			'meta_input' => [
+				'test' => [ 'one', 'two' ],
+			],
+		] );
+
+		$this->assertEquals( [ 'one', 'two' ], get_post_meta( $post_id, 'test', true ) );
+		$this->assertEquals( [ [ 'one', 'two' ] ], get_post_meta( $post_id, 'test', false ) );
+	}
+
+	/**
+	 * It should unpack meta using trait
+	 *
+	 * @test
+	 */
+	public function should_unpack_meta_using_trait() {
+		$post_id_1 = static::factory()->post->create();
+		$post_id_2 = static::factory()->post->create();
+		$this->unpack_meta_on_update( 'test', $post_id_2 );
+		wp_update_post( [
+			'ID'         => $post_id_1,
+			'meta_input' => [
+				'test' => [ 'one', 'two' ],
+			],
+		] );
+		wp_update_post( [
+			'ID'         => $post_id_2,
+			'meta_input' => [
+				'test' => [ 'one', 'two' ],
+			],
+		] );
+
+		$this->assertEquals( [ 'one', 'two' ], get_post_meta( $post_id_1, 'test', true ) );
+		$this->assertEquals( [ [ 'one', 'two' ] ], get_post_meta( $post_id_1, 'test', false ) );
+		$this->assertEquals( 'one', get_post_meta( $post_id_2, 'test', true ) );
+		$this->assertEquals( [ 'one', 'two' ], get_post_meta( $post_id_2, 'test', false ) );
+	}
+
+	/**
+	 * It should unpack next using trait if post ID not set
+	 *
+	 * @test
+	 */
+	public function should_unpack_next_using_trait_if_post_id_not_set() {
+		$post_id_1 = static::factory()->post->create();
+		$post_id_2 = static::factory()->post->create();
+		$this->unpack_meta_on_update( 'test' );
+		wp_update_post( [
+			'ID'         => $post_id_1,
+			'meta_input' => [
+				'test' => [ 'one', 'two' ],
+			],
+		] );
+		wp_update_post( [
+			'ID'         => $post_id_2,
+			'meta_input' => [
+				'test' => [ 'one', 'two' ],
+			],
+		] );
+
+		$this->assertEquals( 'one', get_post_meta( $post_id_1, 'test', true ) );
+		$this->assertEquals( [ 'one', 'two' ], get_post_meta( $post_id_1, 'test', false ) );
+		$this->assertEquals( [ 'one', 'two' ], get_post_meta( $post_id_2, 'test', true ) );
+		$this->assertEquals( [ [ 'one', 'two' ] ], get_post_meta( $post_id_2, 'test', false ) );
+	}
+}


### PR DESCRIPTION
This PR adds the `With_Meta_Handling` trait to the repository, and uses it in it to
provide a re-usable way to deal with those situations where, in updates or creation,
meta provided as array should not be stored as a single array, but as multiple entries.