### PR TITLE
Fix handling of template paths on Win

### DIFF
--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -1097,6 +1097,7 @@ class Tribe__Template {
 		foreach ( $namespace_map as $namespace => $contains_string ) {
 			// Normalize the trailing slash to the current OS directory separator.
 			$contains_string = rtrim( $contains_string, '\\/' ) . DIRECTORY_SEPARATOR;
+
 			// Skip when we dont have the namespace path.
 			if ( false === strpos( $path, $contains_string ) ) {
 				continue;

--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -1095,6 +1095,8 @@ class Tribe__Template {
 		$namespace_map = (array) apply_filters( 'tribe_template_origin_namespace_map', [], $path, $this );
 
 		foreach ( $namespace_map as $namespace => $contains_string ) {
+			// Normalize the trailing slash to the current OS directory separator.
+			$contains_string = rtrim( $contains_string, '\\/' ) . DIRECTORY_SEPARATOR;
 			// Skip when we dont have the namespace path.
 			if ( false === strpos( $path, $contains_string ) ) {
 				continue;


### PR DESCRIPTION
Related to the issue: https://moderntribe.atlassian.net/browse/VE-110

This PR fixes an issue that would cause the template path to not work
correctly on Windows OS.
The issue is solved quite simply adapting an ending trailing slash to
the current OS.

[Screencast](https://drive.google.com/open?id=17hxcpxKLobyKWErIzr0_CBBZ6S1Zi6qq&authuser=luca%40tri.be&usp=drive_fs)