### PR TITLE
Updates sysinfo opt-in endpoint | BTRIA-387

### DIFF
--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -409,10 +409,6 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 
 			$url   = $url ? $url : urlencode( str_replace( array( 'http://', 'https://' ), '', get_site_url() ) );
 
-			if ( defined( 'TEC_URL' ) ) {
-				$teccom_url = trailingslashit( TEC_URL );
-			}
-
 			$query = 'https://support-api.tri.be/sysinfo/optin/' . $optin_key . '/' . $url;
 
 			if ( $remove ) {

--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -409,13 +409,11 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 
 			$url   = $url ? $url : urlencode( str_replace( array( 'http://', 'https://' ), '', get_site_url() ) );
 
-			$teccom_url = 'https://theeventscalendar.com/';
-
 			if ( defined( 'TEC_URL' ) ) {
 				$teccom_url = trailingslashit( TEC_URL );
 			}
 
-			$query = $teccom_url . 'wp-json/tribe_system/v2/customer-info/' . $optin_key . '/' . $url;
+			$query = 'https://support-api.tri.be/sysinfo/optin/' . $optin_key . '/' . $url;
 
 			if ( $remove ) {
 				$query .= '?status=remove';


### PR DESCRIPTION
This (draft) change updates the URL used during sysinfo opt-in and opt-out.

[BTRIA-387]

[BTRIA-387]: https://moderntribe.atlassian.net/browse/BTRIA-387