### PR TITLE
VE-135 Add attributes to inputs where they are missing

### DIFF
--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -71,8 +71,8 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$this->defaults = array(
 				'type'                => 'html',
 				'name'                => $id,
-				'fieldset_attributes' => array(),
-				'attributes'          => array(),
+				'fieldset_attributes' => [],
+				'attributes'          => [],
 				'class'               => null,
 				'label'               => null,
 				'label_attributes'    => null,
@@ -123,55 +123,55 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$placeholder = esc_attr( $args['placeholder'] );
 			$class = $this->sanitize_class_attribute( $args['class'] );
 			$label      = wp_kses(
-				$args['label'], array(
-					'a'      => array( 'href' => array(), 'title' => array() ),
-					'br'     => array(),
-					'em'     => array(),
-					'strong' => array(),
-					'b'      => array(),
-					'i'      => array(),
-					'u'      => array(),
-					'img'    => array(
-						'title' => array(),
-						'src'   => array(),
-						'alt'   => array(),
-					),
-					'span'      => array( 'class' => array() ),
-				)
+				$args['label'], [
+					'a'      => [ 'href' => [], 'title' => [] ],
+					'br'     => [],
+					'em'     => [],
+					'strong' => [],
+					'b'      => [],
+					'i'      => [],
+					'u'      => [],
+					'img'    => [
+						'title' => [],
+						'src'   => [],
+						'alt'   => [],
+					],
+					'span'      => [ 'class' => [] ],
+				]
 			);
 			$label_attributes = $args['label_attributes'];
 			$tooltip    = wp_kses(
-				$args['tooltip'], array(
-					'a'      => array( 'href' => array(), 'title' => array(), 'target' => array() ),
-					'br'     => array(),
-					'em'     => array(),
-					'strong' => array(),
-					'b'      => array(),
-					'i'      => array(),
-					'u'      => array(),
-					'img'    => array(
-						'title' => array(),
-						'src'   => array(),
-						'alt'   => array(),
-					),
-					'code'   => array( 'span' => array() ),
-					'span'   => array(),
-				)
+				$args['tooltip'], [
+					'a'      => [ 'href' => [], 'title' => [], 'target' => [] ],
+					'br'     => [],
+					'em'     => [],
+					'strong' => [],
+					'b'      => [],
+					'i'      => [],
+					'u'      => [],
+					'img'    => [
+						'title' => [],
+						'src'   => [],
+						'alt'   => [],
+					],
+					'code'   => [ 'span' => [] ],
+					'span'   => [],
+				]
 			);
-			$fieldset_attributes = array();
+			$fieldset_attributes = [];
 			if ( is_array( $args['fieldset_attributes'] ) ) {
 				foreach ( $args['fieldset_attributes'] as $key => $val ) {
 					$fieldset_attributes[ $key ] = esc_attr( $val );
 				}
 			}
-			$attributes = array();
+			$attributes = [];
 			if ( is_array( $args['attributes'] ) ) {
 				foreach ( $args['attributes'] as $key => $val ) {
 					$attributes[ $key ] = esc_attr( $val );
 				}
 			}
 			if ( is_array( $args['options'] ) ) {
-				$options = array();
+				$options = [];
 				foreach ( $args['options'] as $key => $val ) {
 					$options[ $key ] = $val;
 				}
@@ -459,6 +459,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$field .= $this->do_field_name();
 			$field .= $this->do_field_value();
 			$field .= $this->do_field_placeholder();
+			$field .= $this->do_field_attributes();
 			$field .= '/>';
 			$field .= $this->do_screen_reader_label();
 			$field .= $this->do_field_div_end();
@@ -478,6 +479,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$field .= $this->do_field_div_start();
 			$field .= '<textarea';
 			$field .= $this->do_field_name();
+			$field .= $this->do_field_attributes();
 			$field .= '>';
 			$field .= esc_html( stripslashes( $this->value ) );
 			$field .= '</textarea>';
@@ -560,7 +562,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 				if ( ! empty( $this->value ) ) {
 					$this->value = array( $this->value );
 				} else {
-					$this->value = array();
+					$this->value = [];
 				}
 			}
 
@@ -620,6 +622,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 				if ( empty( $this->allow_clear ) ) {
 					$field .= " data-prevent-clear='true'";
 				}
+				$field .= $this->do_field_attributes();
 				$field .= '>';
 				foreach ( $this->options as $option_id => $title ) {
 					$field .= '<option value="' . esc_attr( $option_id ) . '"';
@@ -772,7 +775,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		}
 
 		/**
-		 * Concatenatates an array of attributes to use in HTML tags.
+		 * Concatenates an array of attributes to use in HTML tags.
 		 *
 		 * Example usage:
 		 *
@@ -787,12 +790,12 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		 *
 		 * @return string The concatenated attributes.
 		 */
-		protected function concat_attributes( array $attributes = array() ) {
+		protected function concat_attributes( array $attributes = [] ) {
 			if ( empty( $attributes ) ) {
 				return '';
 			}
 
-			$concat = array();
+			$concat = [];
 			foreach ( $attributes as $attribute => $value ) {
 				if ( is_array( $value ) ) {
 					$value = implode( ' ', $value );
@@ -817,7 +820,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		}
 
 		/**
-		 * Sanitizes a space-separated or arrray of classes.
+		 * Sanitizes a space-separated or array of classes.
 		 *
 		 * @since 4.7.7
 		 *

--- a/src/Tribe/Settings_Tab.php
+++ b/src/Tribe/Settings_Tab.php
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Tribe__Settings_Tab' ) ) {
 			if ( is_array( $this->fields ) && ! empty( $this->fields ) ) {
 				foreach ( $this->fields as $key => $field ) {
 					if ( isset( $sent_data[ $key ] ) ) {
-						// if we just saved [or attempted to], get the value that was input
+						// If we just saved [or attempted to], get the value that was input.
 						$value = $sent_data[ $key ];
 					} else {
 						// Some options should always be stored at network level

--- a/src/Tribe/Settings_Tab.php
+++ b/src/Tribe/Settings_Tab.php
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Tribe__Settings_Tab' ) ) {
 			if ( is_array( $this->fields ) && ! empty( $this->fields ) ) {
 				foreach ( $this->fields as $key => $field ) {
 					if ( isset( $sent_data[ $key ] ) ) {
-						// if we just saved [or attempted to], get the value that was inputed
+						// if we just saved [or attempted to], get the value that was input
 						$value = $sent_data[ $key ];
 					} else {
 						// Some options should always be stored at network level


### PR DESCRIPTION
So we can add IDs for js targets.

Correct some spelling errors. Change some of our uses of `array()` to `[]`

[VE-135]

[VE-135]: https://moderntribe.atlassian.net/browse/VE-135