### PR TITLE
TCMN-73: : Make "tribe_upload_image" backwards compatible

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,7 @@
 * Feature - Added the `tribe_db_lock_use_msyql_functions` filter to control whether Database locks should be managed using MySQL functions (default, compatible with MySQL 5.6+) or SQL queries.
 * Tweak - Added case for manual control of field in dependency JS.
 * Fix - Prevent `$legacy_hook_name` and `$hook_name` template Actions and Filters to be fired if they are the same, preventing duplicated hook calls.
+* Fix - Backwards compatibility for `tribe_upload_image` allow to use the function on versionf of WordPress before 5.2.x`
 
 = [4.12.3] 2020-05-27 =
 

--- a/src/Tribe/Image/Uploader.php
+++ b/src/Tribe/Image/Uploader.php
@@ -153,11 +153,14 @@ class Tribe__Image__Uploader {
 		}
 
 		// Upload file into WP and leave WP handle the resize and such.
-		$attachment_id = media_handle_sideload( [
-			'name'           => $this->create_file_name( $file ),
-			'tmp_name'       => $file,
-			'post_mime_type' => 'image',
-		] );
+		$attachment_id = media_handle_sideload(
+			[
+				'name'           => $this->create_file_name( $file ),
+				'tmp_name'       => $file,
+				'post_mime_type' => 'image',
+			],
+			0
+		);
 
 		// Remove the temporary file as is no longer required at this point.
 		if ( ! $is_local && file_exists( $file ) ) {


### PR DESCRIPTION
As in the previous version of WordPress the parameter is not optional for
the $post_id, using zero (0) as post ID will effectively upload the image
without assigning the image to a post ID.

Ticket: [TCMN-73]

[TCMN-73]: https://moderntribe.atlassian.net/browse/TCMN-73