### PR TITLE
Add the tribe_normalize_orderby function

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format.
+
 = [4.12.5] 2020-06-24 =
 
 * Feature - Added the `Tribe\Traits\With_Db_Lock` trait to provide methods useful to acquire and release database locks.

--- a/src/functions/query.php
+++ b/src/functions/query.php
@@ -54,3 +54,44 @@ if ( ! function_exists( 'tribe_filter_meta_query' ) ) {
 		return $filtered;
 	}
 }
+
+if ( ! function_exists( 'tribe_normalize_orderby' ) ) {
+
+	/**
+	 * Normalizes an `orderby` string or array to an map of keys and orders.
+	 *
+	 * Note the function and the variables use the "orderby" (no spaces) name to stick
+	 * with the WordPress query standard.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string,string> $orderby Either an `orderby` key, a list of `orderby`
+	 *                                             keys or a map of `orderby` clauses.
+	 * @param string                      $order   The default order that should be applied to `orderby` entries that
+	 *                                             lack one.
+	 *
+	 * @return array The normalized `orderby` array, in the format supported by WordPress queries:
+	 *               `[ <key_1> => <order>, <key_2> => <order>, ... ]`.
+	 */
+	function tribe_normalize_orderby( $orderby, $order = 'ASC' ) {
+		// Make the `orderby` part an array.
+		$orderby_arr = (array) $orderby;
+		$normalized  = [];
+
+		foreach ( $orderby_arr as $by_key => $direction ) {
+			if ( empty( $direction ) ) {
+				continue;
+			}
+
+			if ( is_numeric( $by_key ) ) {
+				// It's an entry where the key is just listed, relying on the default order.
+				$by_key    = $direction;
+				$direction = $order;
+			}
+
+			$normalized[ $by_key ] = $direction;
+		}
+
+		return $normalized;
+	}
+}

--- a/tests/wpunit/Tribe/functions/queryTest.php
+++ b/tests/wpunit/Tribe/functions/queryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tribe\functions;
+
+class queryTest extends \Codeception\TestCase\WPTestCase {
+	public function test_tribe_normalize_orderby_data_provider() {
+		return [
+			'empty_string'                 => [ '', [] ],
+			'empty_array'                  => [ [], [] ],
+			'array_w_empty_string'         => [ [ '' ], [] ],
+			'array_of_keys'                => [
+				[ 'title', 'event_date', 'foo' ],
+				[ 'title' => 'ASC', 'event_date' => 'ASC', 'foo' => 'ASC' ],
+			],
+			'array_of_keys_and_directions' => [
+				[ 'title' => 'ASC', 'event_date' => 'DESC', 'foo' => 'DESC' ],
+				[ 'title' => 'ASC', 'event_date' => 'DESC', 'foo' => 'DESC' ],
+			],
+			'mixed_array'                  => [
+				[ 'title', 'event_date' => 'DESC', 'event_duration' => 'ASC', 'venue' ],
+				[ 'title' => 'ASC', 'event_date' => 'DESC', 'event_duration' => 'ASC', 'venue' => 'ASC' ],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider test_tribe_normalize_orderby_data_provider
+	 */
+	public function test_tribe_normalize_orderby( $input, $expected ) {
+		$this->assertEquals( $expected, tribe_normalize_orderby( $input, 'ASC' ) );
+	}
+}


### PR DESCRIPTION
This PR supports the https://github.com/moderntribe/the-events-calendar/pull/3228
one by adding the `tribe_normalize_orderby` function.

The function normalizes an `orderby` clause from the formats supported by
WordPress (a key, a list of keys or a map of keys with order) to a map of
keys with order.

See the tests in the PR to understand.