### PR TITLE
Improve the Post_Collection plucking

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 = [TBD] TBD =
 
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]
-* Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
+* Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` and `pluck_combine` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
 
 = [4.12.5] 2020-06-24 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,8 @@
 
 = [TBD] TBD =
 
-* Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format.
+* Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]
+* Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
 
 = [4.12.5] 2020-06-24 =
 

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -1,11 +1,13 @@
 <?php
 
 use Tribe\Traits\With_Meta_Updates_Handling;
+use Tribe\Traits\With_Post_Attribute_Detection;
 use Tribe__Utils__Array as Arr;
 
 abstract class Tribe__Repository
 	implements Tribe__Repository__Interface {
 	use With_Meta_Updates_Handling;
+	use With_Post_Attribute_Detection;
 
 	const MAX_NUMBER_OF_POSTS_PER_PAGE = 99999999999;
 
@@ -1410,43 +1412,6 @@ abstract class Tribe__Repository
 	}
 
 	/**
-	 * Whether the key is a field of the posts table or not.
-	 *
-	 * @since 4.7.19
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
-	 */
-	protected function is_a_post_field( $key ) {
-		return in_array( $key, array(
-			'ID',
-			'post_author',
-			'post_date',
-			'post_date_gmt',
-			'post_content',
-			'post_title',
-			'post_excerpt',
-			'post_status',
-			'comment_status',
-			'ping_status',
-			'post_password',
-			'post_name',
-			'to_ping',
-			'pinged',
-			'post_modified',
-			'post_modified_gmt',
-			'post_content_filtered',
-			'post_parent',
-			'guid',
-			'menu_order',
-			'post_type',
-			'post_mime_type',
-			'comment_count',
-		), true );
-	}
-
-	/**
 	 * Whether the current key is a date one requiring a converted key pair too or not.
 	 *
 	 * @param string $key
@@ -1474,19 +1439,6 @@ abstract class Tribe__Repository
 			$postarr[ $this->to_local_time_map[ $key ] ] = Tribe__Timezones::to_tz( $value, Tribe__Timezones::wp_timezone_string() );
 		}
 		$postarr[ $key ] = $value;
-	}
-
-	/**
-	 * Whether the current key identifies one of the supported taxonomies or not.
-	 *
-	 * @since 4.7.19
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
-	 */
-	protected function is_a_taxonomy( $key ) {
-		return in_array( $key, $this->taxonomies, true );
 	}
 
 	/**

--- a/src/Tribe/Traits/With_Post_Attribute_Detection.php
+++ b/src/Tribe/Traits/With_Post_Attribute_Detection.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Provides methods to detect whether a field is a post field, a taxonomy or a custom field in relation to a post type.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Traits
+ */
+
+namespace Tribe\Traits;
+
+/**
+ * Trait With_Post_Attribute_Detection
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Traits
+ */
+trait With_Post_Attribute_Detection {
+
+	/**
+	 * Whether the key is a field of the posts table or not.
+	 *
+	 * @since 4.7.19 Created in the `Tribe__Repository` class.
+	 * @since TBD Refactored out of the `Tribe__Repository` class into this trait.
+	 *
+	 * @param string $key The field to check.
+	 *
+	 * @return bool Whether the key indicates a post field, a column in the `posts` table, or not.
+	 */
+	protected function is_a_post_field( $key ) {
+		return in_array( $key, [
+			'ID',
+			'post_author',
+			'post_date',
+			'post_date_gmt',
+			'post_content',
+			'post_title',
+			'post_excerpt',
+			'post_status',
+			'comment_status',
+			'ping_status',
+			'post_password',
+			'post_name',
+			'to_ping',
+			'pinged',
+			'post_modified',
+			'post_modified_gmt',
+			'post_content_filtered',
+			'post_parent',
+			'guid',
+			'menu_order',
+			'post_type',
+			'post_mime_type',
+			'comment_count',
+		], true );
+	}
+
+	/**
+	 * Whether the current key identifies one of the supported taxonomies or not.
+	 *
+	 * @since 4.7.19 Created in the `Tribe__Repository` class.
+	 * @since TBD Refactored out of the `Tribe__Repository` class into this trait.
+	 *
+	 * @param string $key The field to check.
+	 *
+	 * @return bool Whether the key indicates a taxonomy of the post type or not.
+	 */
+	protected function is_a_taxonomy( $key ) {
+		if(!isset($this->taxonomies))	{
+			// If we're here, then the developer made an error: throw an excpetion to bring this up as early as possible.
+			throw new \RuntimeException('The '. __TRAIT__ . ' trait requires the user class to define a $taxonomies array parameter.');
+		}
+
+		return in_array( $key, $this->taxonomies, true );
+	}
+
+}

--- a/src/Tribe/Traits/With_Post_Attribute_Detection.php
+++ b/src/Tribe/Traits/With_Post_Attribute_Detection.php
@@ -2,6 +2,9 @@
 /**
  * Provides methods to detect whether a field is a post field, a taxonomy or a custom field in relation to a post type.
  *
+ * Note that the trait does not include a `is_a_custom_field` method as that's implied from a field not being
+ * a post field and not being a taxonomy.
+ *
  * @since   TBD
  *
  * @package Tribe\Traits
@@ -67,12 +70,13 @@ trait With_Post_Attribute_Detection {
 	 * @return bool Whether the key indicates a taxonomy of the post type or not.
 	 */
 	protected function is_a_taxonomy( $key ) {
-		if(!isset($this->taxonomies))	{
-			// If we're here, then the developer made an error: throw an excpetion to bring this up as early as possible.
-			throw new \RuntimeException('The '. __TRAIT__ . ' trait requires the user class to define a $taxonomies array parameter.');
+		if ( ! isset( $this->taxonomies ) ) {
+			// If we're here, then the developer made an error: throw an exception to bring this up as early as possible.
+			throw new \RuntimeException(
+				'The ' . __TRAIT__ . ' trait requires the user class to define a $taxonomies array parameter.'
+			);
 		}
 
 		return in_array( $key, $this->taxonomies, true );
 	}
-
 }

--- a/src/Tribe/Utils/Post_Collection.php
+++ b/src/Tribe/Utils/Post_Collection.php
@@ -55,27 +55,28 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 	 *                                                        a map of fields to fetch, each defining a `single` and
 	 *                                                        `args` key to define the pluck `$single` and `$args`
 	 *                                                        parameters where applicable.
+	 *                                                        Additionally an `as` parameter can be specifed to alias
+	 *                                                        the field in the results.
 	 *
 	 * @return array<int|string,string|array> A list of plucked fields or a map of plucked fields keyed by the
 	 *                                        specified
 	 *                                        field.
 	 */
-	public function pluck_combine( $key_field = '#', $value_fields ) {
+	public function pluck_combine( $key_field = '#', $value_fields = 'post_title' ) {
 		$value_fields = (array) $value_fields;
 		if ( 1 === count( $value_fields ) ) {
-			list( $single, $args ) = $this->parse_field_args( $value_fields[0] );
+			list( $as, $single, $args ) = $this->parse_field_args( $value_fields[0] );
 			$values = $this->pluck( $value_fields[0], $single, $args );
 		} else {
 			$rows        = [];
 			$field_names = [];
 			$field_index = 0;
 			foreach ( $value_fields as $k => $field ) {
-				list( $single, $args ) = $this->parse_field_args( $field );
-				if ( is_array( $field ) ) {
-					$field                       = $k;
-					$field_names[ $field_index ] = $field;
-				}
-				$rows[ $field ] = $this->pluck( $field, $single, $args );
+				list( $as, $single, $args ) = $this->parse_field_args( $field );
+				$field                       = is_array( $field ) ? $k : $field;
+				$field_name                  = null === $as ? $field : $as;
+				$field_names[ $field_index ] = $field_name;
+				$rows[ $field_name ]         = $this->pluck( $field, $single, $args );
 				$field_index ++;
 			}
 			$values      = [];
@@ -100,11 +101,14 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 	 *
 	 * @param string|array<string,string|array> $field The field name or the field arguments map.
 	 *
-	 * @return array<string,array> The `$single` and `$args` parameters extracted from the field.
+	 * @return array<string,string,array> The `$as`, `$single` and `$args` parameters extracted from the field.
 	 */
 	protected function parse_field_args( $field ) {
 		$field = (array) $field;
 
+		$as     = isset( $field['as'] )
+			? (string) $field['as']
+			: null;
 		$single = isset( $field['single'] )
 			? (bool) $field['single']
 			: true;
@@ -112,7 +116,7 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 			? (array) $field['args']
 			: null;
 
-		return [ $single, $args ];
+		return [ $as, $single, $args ];
 	}
 
 	/**

--- a/src/Tribe/Utils/Post_Collection.php
+++ b/src/Tribe/Utils/Post_Collection.php
@@ -86,7 +86,7 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 			}
 		}
 
-		// If the key field i
+		// If the key field is `#` then use a progressive number as key, else use the specified field.
 		$keys = '#' === $key_field
 			? range( 0, count( $this->items ) - 1 )
 			: $this->pluck( $key_field, true );

--- a/src/Tribe/Utils/Post_Collection.php
+++ b/src/Tribe/Utils/Post_Collection.php
@@ -59,8 +59,7 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 	 *                                                        the field in the results.
 	 *
 	 * @return array<int|string,string|array> A list of plucked fields or a map of plucked fields keyed by the
-	 *                                        specified
-	 *                                        field.
+	 *                                        specified field.
 	 */
 	public function pluck_combine( $key_field = '#', $value_fields = 'post_title' ) {
 		$value_fields = (array) $value_fields;

--- a/src/Tribe/Utils/Post_Collection.php
+++ b/src/Tribe/Utils/Post_Collection.php
@@ -5,12 +5,24 @@
  * @since 4.9.5
  */
 
+use Tribe\Traits\With_Post_Attribute_Detection;
+
 /**
  * Class Tribe__Utils__Post_Collection
  *
  * @since 4.9.5
  */
 class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
+	use With_Post_Attribute_Detection;
+
+	/**
+	 * A list of the taxonomies supported by the post types in the collection.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string>
+	 */
+	protected $taxonomies;
 
 	/**
 	 * Tribe__Utils__Post_Collection constructor.
@@ -22,6 +34,105 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 	 */
 	public function __construct( array $items ) {
 		parent::__construct( array_filter( array_map( 'get_post', $items ) ) );
+	}
+
+	/**
+	 * Plucks a post field, a taxonomy or a custom field from the collection.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key      The name of the field to pluck; the method will try to detect the type of field
+	 *                         from its name. If any issues might arise due to fields of different types with the
+	 *                         same name, then use the `pluck_<type>` methods directly.
+	 * @param bool   $single   Whether to pluck a single taxonomy term or custom fields or an array of all the taxonomy
+	 *                         terms or custom fields for each post.
+	 * @param array  $args     A list of n optional arguments that will be passed down to the `pluck_<type>` methods.
+	 *                         Currently only the the `pluck_taxonomy` will support one more argument to define the
+	 *                         query arguments for the term query.
+	 *
+	 * @return array<string>|array<array> Either an array of plucked fields when plucking post fields or single
+	 *                                    custom fields or taxonomy terms, or an array of arrays, each one a list
+	 *                                    of all the taxonomy terms or custom fields entries for each post.
+	 */
+	public function pluck( $key, $single = true, ...$args ) {
+		$type = $this->detect_field_type( $key );
+
+		switch ( $type ) {
+			case 'post_field':
+				return $this->pluck_field( $key );
+				break;
+			case 'taxonomy':
+				return $this->pluck_taxonomy( $key, $single, ...$args );
+				break;
+			default:
+				return $this->pluck_meta( $key, $single );
+				break;
+		}
+	}
+
+	/**
+	 * Detects the type of a post field from its name.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The name of the field to check.
+	 *
+	 * @return string The type of field detected for the key, either `post_field`, `taxonomy` or `custom_field`.
+	 */
+	protected function detect_field_type( $key ) {
+		if ( $this->is_a_post_field( $key ) ) {
+			return 'post_field';
+		}
+
+		// Init taxonomies as late as possible and only once.
+		$this->init_taxonomies();
+
+		if ( $this->is_a_taxonomy( $key ) ) {
+			return 'taxonomy';
+		}
+
+		return 'custom_field';
+	}
+
+	/**
+	 * Initialize the post collection taxonomies by filling up the `$taxonomies` property.
+	 *
+	 * Note the collection will use the first post in the collection to fill the taxonomies array,
+	 * this assumes the collection is homogeneous in its post types.
+	 *
+	 * @since TBD
+	 */
+	protected function init_taxonomies() {
+		if ( ! empty( $this->taxonomies ) ) {
+			// Already set up, return.
+			return;
+		}
+
+		if ( empty( $this->items ) ) {
+			// We cannot detect taxonomies from an empty list of items.
+			$this->taxonomies = [];
+
+			return;
+		}
+
+		// Use the first post to detect the taxonomies.
+		$this->taxonomies = get_object_taxonomies( reset($this->items), 'names' );
+	}
+
+	/**
+	 * Plucks a post field from all posts in the collection.
+	 *
+	 * Note: there is no check on the name of the plucked post field: if a non-existing post field is requested, then
+	 * the method will return an empty array.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $field The name of the post field to pluck.
+	 *
+	 * @return array<string> A list of the plucked post fields from each item in the collection.
+	 */
+	public function pluck_field( $field ) {
+		return wp_list_pluck( $this->items, $field );
 	}
 
 	/**
@@ -40,10 +151,41 @@ class Tribe__Utils__Post_Collection extends Tribe__Utils__Collection {
 	 *               string value.
 	 */
 	public function pluck_meta( $meta_key, $single = true ) {
-		$plucked = array();
+		$plucked = [];
 
 		foreach ( $this as $item ) {
 			$plucked[] = get_post_meta( $item->ID, $meta_key, $single );
+		}
+
+		return $plucked;
+	}
+
+	/**
+	 * Plucks taxonomy terms assigned to the posts in the collection.
+	 *
+	 * Note: there is no check on the taxonomy being an existing one or not; that responsibility
+	 * is on the user code.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $taxonomy The name of the post taxonomy to pluck terms for.
+	 * @param bool   $single   Whether to return only the first results or all of them.
+	 * @param array  $args     A set of arguments as supported by the `WP_Term_Query::__construct` method.
+	 *
+	 * @return array<mixed>|array<array> Either an array of the requested results if `$single` is `true`
+	 *                                   or an array of arrays if `$single` is `false`.
+	 */
+	public function pluck_taxonomy( $taxonomy, $single = true, array $args = [ 'fields' => 'names' ] ) {
+		$plucked = [];
+
+		if ( $single ) {
+			// Let's avoid wasting queries.
+			$args['limit'] = 1;
+		}
+
+		foreach ( $this as $item ) {
+			$terms     = wp_get_object_terms( $item->ID, $taxonomy, $args );
+			$plucked[] = $single ? reset( $terms ) : $terms;
 		}
 
 		return $plucked;

--- a/tests/wpunit/Tribe/Utils/Post_CollectionTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_CollectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tribe\Utils;
+
+use Tribe__Utils__Post_Collection as Collection;
+
+class Post_CollectionTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * It should return plucked post fields when requested
+	 *
+	 * @test
+	 */
+	public function should_return_plucked_post_fields_when_requested() {
+		$posts   = [];
+		$posts[] = static::factory()->post->create( [ 'post_title' => 'Post 1' ] );
+		$posts[] = static::factory()->post->create( [ 'post_title' => 'Post 2' ] );
+		$posts[] = static::factory()->post->create( [ 'post_title' => 'Post 3' ] );
+
+		$collection = new Collection( $posts );
+
+		$titles = [ 'Post 1', 'Post 2', 'Post 3' ];
+		$this->assertEquals( $titles, $collection->pluck( 'post_title' ) );
+		$this->assertEquals( $titles, $collection->pluck_field( 'post_title' ) );
+	}
+
+	/**
+	 * It should return plucked custom fields when requested
+	 *
+	 * @test
+	 */
+	public function should_return_plucked_custom_fields_when_requested() {
+		$posts   = [];
+		$posts[] = static::factory()->post->create( [ 'meta_input' => [ '_test' => 'Post 1' ] ] );
+		$posts[] = static::factory()->post->create( [ 'meta_input' => [ '_test' => 'Post 2' ] ] );
+		$posts[] = static::factory()->post->create( [ 'meta_input' => [ '_test' => 'Post 3' ] ] );
+
+		$collection = new Collection( $posts );
+
+		$titles = [ 'Post 1', 'Post 2', 'Post 3' ];
+		$this->assertEquals( $titles, $collection->pluck( '_test' ) );
+		$this->assertEquals( $titles, $collection->pluck_meta( '_test' ) );
+	}
+
+	/**
+	 * It should return list of plucked custom fields when requested
+	 *
+	 * @test
+	 */
+	public function should_return_list_of_plucked_custom_fields_when_requested() {
+		$posts   = [];
+		$posts[] = static::factory()->post->create();
+		$posts[] = static::factory()->post->create();
+		$posts[] = static::factory()->post->create();
+		// The factory would add `meta_input` arrays as serialized arrays, use this method to add them as multiple rows.
+		foreach ( $posts as $id ) {
+			add_post_meta( $id, '_multi_test', 'one' );
+			add_post_meta( $id, '_multi_test', 'two' );
+			add_post_meta( $id, '_multi_test', 'three' );
+		}
+
+		$collection = new Collection( $posts );
+
+		$expected_single = ( [ 'one', 'one', 'one' ] );
+		$expected_multi  = ( array_fill( 0, 3, [ 'one', 'two', 'three' ] ) );
+		$this->assertEquals( $expected_single, $collection->pluck( '_multi_test', true ) );
+		$this->assertEquals( $expected_single, $collection->pluck_meta( '_multi_test', true ) );
+		$this->assertEquals( $expected_multi, $collection->pluck( '_multi_test', false ) );
+		$this->assertEquals( $expected_multi, $collection->pluck_meta( '_multi_test', false ) );
+	}
+
+	/**
+	 * It should return plucked taxonomy terms
+	 *
+	 * @test
+	 */
+	public function should_return_plucked_taxonomy_terms() {
+		// Become an administrator to add taxonomy terms during post insertion.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$posts   = [];
+		$posts[] = static::factory()->post->create();
+		$posts[] = static::factory()->post->create();
+		$posts[] = static::factory()->post->create();
+		// The `tax_input` creation argument works in tricky ways, avoid it completely and use explict assignment.
+		foreach ( $posts as $id ) {
+			foreach (
+				[
+					'post_tag' => [ 'tag1', 'tag2', 'tag3' ],
+					'category' => [ 'cat1', 'cat2', 'meow' ]
+				] as $tax => $terms
+			) {
+				wp_set_object_terms( $id, $terms, $tax );
+			}
+		}
+
+		$collection = new Collection( $posts );
+
+		$args                = [ 'fields' => 'names' ];
+		$expected_single_tag = array_fill( 0, 3, 'tag1' );
+		$expected_multi_tag  = array_fill( 0, 3, [ 'tag1', 'tag2', 'tag3' ] );
+		$expected_single_cat = array_fill( 0, 3, 'cat1' );
+		$expected_multi_cat  = array_fill( 0, 3, [ 'cat1', 'cat2', 'meow' ] );
+		$this->assertEquals( $expected_single_tag, $collection->pluck( 'post_tag', true ) );
+		$this->assertEquals( $expected_single_tag, $collection->pluck_taxonomy( 'post_tag', true ) );
+		$this->assertEquals( $expected_multi_tag, $collection->pluck( 'post_tag', false, $args ) );
+		$this->assertEquals( $expected_multi_tag, $collection->pluck_taxonomy( 'post_tag', false, $args ) );
+		$this->assertEquals( $expected_single_cat, $collection->pluck( 'category', true ) );
+		$this->assertEquals( $expected_single_cat, $collection->pluck_taxonomy( 'category', true ) );
+		$this->assertEquals( $expected_multi_cat, $collection->pluck( 'category', false, $args ) );
+		$this->assertEquals( $expected_multi_cat, $collection->pluck_taxonomy( 'category', false, $args ) );
+	}
+}

--- a/tests/wpunit/Tribe/Utils/Post_CollectionTest.php
+++ b/tests/wpunit/Tribe/Utils/Post_CollectionTest.php
@@ -140,6 +140,7 @@ class Post_CollectionTest extends \Codeception\TestCase\WPTestCase {
 			array_combine( $posts, array_fill( 0, 3, 'tag1' ) ),
 			$collection->pluck_combine( 'ID', 'post_tag' )
 		);
+
 		$this->assertEquals(
 			[
 				$posts[0] => [ 'post_title' => 'Post 1', 'post_tag' => 'tag1' ],
@@ -148,10 +149,7 @@ class Post_CollectionTest extends \Codeception\TestCase\WPTestCase {
 			],
 			$collection->pluck_combine( 'ID', [ 'post_title', 'post_tag' ] )
 		);
-		$combined_pluck = $collection->pluck_combine(
-			'ID',
-			[ 'post_title', 'post_tag', 'category' => [ 'single' => false, 'args' => [ 'fields' => 'names' ] ] ]
-		);
+
 		$this->assertEquals(
 			[
 				$posts[0] => [
@@ -170,7 +168,38 @@ class Post_CollectionTest extends \Codeception\TestCase\WPTestCase {
 					'category'   => [ 'cat1', 'cat2', 'meow' ]
 				],
 			],
-			$combined_pluck
+			$collection->pluck_combine(
+				'ID',
+				[ 'post_title', 'post_tag', 'category' => [ 'single' => false, 'args' => [ 'fields' => 'names' ] ] ]
+			)
+		);
+
+		$this->assertEquals(
+			[
+				$posts[0] => [
+					'title' => 'Post 1',
+					'tag'   => 'tag1',
+					'category'   => [ 'cat1', 'cat2', 'meow' ]
+				],
+				$posts[1] => [
+					'title' => 'Post 2',
+					'tag'   => 'tag1',
+					'category'   => [ 'cat1', 'cat2', 'meow' ]
+				],
+				$posts[2] => [
+					'title' => 'Post 3',
+					'tag'   => 'tag1',
+					'category'   => [ 'cat1', 'cat2', 'meow' ]
+				],
+			],
+			$collection->pluck_combine(
+				'ID',
+				[
+					'post_title' => [ 'as' => 'title' ],
+					'post_tag'   => [ 'as' => 'tag' ],
+					'category'   => [ 'single' => false, 'args' => [ 'fields' => 'names' ] ]
+				]
+			)
 		);
 	}
 }


### PR DESCRIPTION
This PR adds the following methods to the `Tribe__Utils__Post_Collection` class:

* `pluck` to pluck a post field, taxonomy or custom field from the post collection.
* `pluck_taxonomy` to pluck one or more taxonomy terms from each post in the collection.
* `pluck_field` to pluck a post field (e.g. the `post_title`) from all posts in the collection.

The collection is used to create sets of results from the `Tribe__Repository::collect` method:

```php
// List all titles of the found posts.
$titles = tribe_events()->where('starts_after', 'today')->collect()->pluck('post_title');

// The same could be written using the `pluck_field` method to skip the field type detection.
$parents = tribe_events()->where('starts_after', 'today')->collect()->pluck_field('post_parent');

// Get the names of the tags assigned to each post in the collection.
$single = false;
$tags = tribe_events()->where('starts_after', 'today')->collect()->pluck('post_tag', $single);

// The same could be written using the `pluck_taxonomy` method to skip the field type detection.
$tags = tribe_events()->where('starts_after', 'today')->collect()->pluck_taxonomy('post_tag', $single);

// Get the UTC start date of each event in the collection.
$utc = tribe_events()->where('starts_after', 'now')->collect()->pluck('_EventStartDateUTC');

// Same as...
$utc = tribe_events()->where('starts_after', 'now')->collect()->pluck_meta('_EventStartDateUTC');

// Get a list of Organizer IDs for each event in the collection.
$single = false;
$orgs = tribe_events()->where('starts_after', 'now')->collect()->pluck('_EventOrganizerID', $single);

// Same as...
$orgs = tribe_events()->where('starts_after', 'now')->collect()->pluck_meta('_EventOrganizerID', $single);
```

See more in the tests.