### PR TITLE
Fix/tec 3543 date time block timezone

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,8 @@
 
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]
 * Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` and `pluck_combine` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
-* Tweak - Adjust verbosity level to report connection issues with Promoter [PRMTR-404]
+* Tweak - Adjust verbosity level to report connection issues with Promoter. [PRMTR-404]
+* Fix - Set proper timezone on block editor when creating a new event. [TEC-3543]
 
 = [4.12.5] 2020-06-24 =
 

--- a/src/modules/utils/globals.js
+++ b/src/modules/utils/globals.js
@@ -32,6 +32,7 @@ export const priceSettings = () => tec().priceSettings || {};
 export const tecDateSettings = () => tec().dateSettings || {};
 export const timezoneHtml = () => tec().timezoneHTML || '';
 export const defaultTimes = () => tec().defaultTimes || {};
+export const timezone = () => tec().timezone || {};
 
 // PRO
 export const pro = () => config().eventsPRO || {};

--- a/src/modules/utils/globals.js
+++ b/src/modules/utils/globals.js
@@ -32,7 +32,7 @@ export const priceSettings = () => tec().priceSettings || {};
 export const tecDateSettings = () => tec().dateSettings || {};
 export const timezoneHtml = () => tec().timezoneHTML || '';
 export const defaultTimes = () => tec().defaultTimes || {};
-export const timezone = () => tec().timezone || {};
+export const timezone = () => tec().timeZone || {};
 
 // PRO
 export const pro = () => config().eventsPRO || {};


### PR DESCRIPTION
Ticket: [TEC-3543]

Adds the timezone configuration to the JS window object.
Works together with https://github.com/moderntribe/the-events-calendar/pull/3235

Screencast: https://drive.google.com/file/d/1Qms8bzctgx7V5AU5KdPrLtKBAnpA6CUv/view?usp=sharing

[TEC-3543]: https://moderntribe.atlassian.net/browse/TEC-3543