### PR TITLE
Fix/ecp 450 shortcode customizer styles

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,7 @@
 * Tweak - Adjust verbosity level to report connection issues with Promoter. [PRMTR-404]
 * Fix - Set proper timezone on block editor when creating a new event. [TEC-3543]
 * Fix - Properly enqueue the customizer styles to allow overriding of theme styles. [TEC-3531]
+* Fix - Allow customizer styles to be applied on shortcode events views. [ECP-450]
 
 = [4.12.5] 2020-06-24 =
 

--- a/src/Tribe/Customizer.php
+++ b/src/Tribe/Customizer.php
@@ -122,6 +122,7 @@ final class Tribe__Customizer {
 		// front end styles from customizer
 		add_action( 'wp_enqueue_scripts', array( $this, 'inline_style' ), 15 );
 		add_action( 'tribe_events_pro_widget_render', array( $this, 'inline_style' ), 101 );
+		add_action( 'wp_print_footer_scripts', array( $this, 'inline_style' ), 5 );
 
 		add_filter( "default_option_{$this->ID}", array( $this, 'maybe_fallback_get_option' ) );
 	}


### PR DESCRIPTION
Ticket: [ECP-450]

Prints customizer styles on shortcodes when styles are enqueued to footer.

![image](https://user-images.githubusercontent.com/16699941/87641400-9d774b80-c77a-11ea-85ab-da9c3ce59a9c.png)


[ECP-450]: https://moderntribe.atlassian.net/browse/ECP-450