### PR TITLE
When using tribe_register_rest_route we default to having a __return_true to the permission callback

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]
 * Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` and `pluck_combine` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
 * Tweak - Adjust verbosity level to report connection issues with Promoter [PRMTR-404]
+* Tweak - Modify default params on `tribe_register_rest_route` for callback to prevent notices on WordPress 5.5
 * Tweak - Add the `tribe_asset_print_group` function to allow printing scripts or styles managed by the `tribe_assets` function in the page HTML. [ECP-374, ECP-376]
 * Tweak - Add the `Tribe__Customizer::get_styles_scripts` method to allow getting the Theme Customizer scripts or styles managed managed by the plugins. [ECP-374, ECP-376]
 * Tweak - Adjust verbosity level to report connection issues with Promoter. [PRMTR-404]

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]
 * Feature - Added the `pluck`, `pluck_field`, `pluck_taxonomy` and `pluck_combine` methods to the `Tribe__Utils__Post_Collection` class to allow  more flexible result handling when dealing with ORM result sets. [TEC-3548]
 * Tweak - Adjust verbosity level to report connection issues with Promoter [PRMTR-404]
-* Tweak - Modify default params on `tribe_register_rest_route` for callback to prevent notices on WordPress 5.5
+* Tweak - Modify default parameters on `tribe_register_rest_route` for `permission_callback` to prevent notices on WordPress 5.5.
 * Tweak - Add the `tribe_asset_print_group` function to allow printing scripts or styles managed by the `tribe_assets` function in the page HTML. [ECP-374, ECP-376]
 * Tweak - Add the `Tribe__Customizer::get_styles_scripts` method to allow getting the Theme Customizer scripts or styles managed managed by the plugins. [ECP-374, ECP-376]
 * Tweak - Adjust verbosity level to report connection issues with Promoter. [PRMTR-404]

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -645,6 +645,15 @@ if ( ! function_exists( 'tribe_register_rest_route' ) ) {
 		 */
 		$args = apply_filters( 'tribe_register_rest_route_args', $args, $namespace, $route, $override );
 
+		// Compatibility with version 5.5 of WordPress to avoid notices.
+		if (
+			! empty( $args['callback'] )
+			&& is_callable( $args['callback'] )
+			&& empty( $args['permission_callback'] )
+		) {
+			$args['permission_callback'] = '__return_true';
+		}
+
 		return register_rest_route( $namespace, $route, $args, $override );
 	}
 }


### PR DESCRIPTION
📹 https://i.bordoni.me/X6uomRXG

Related PRs:
https://github.com/moderntribe/event-tickets-plus/pull/1009
https://github.com/moderntribe/event-tickets/pull/1727 
https://github.com/moderntribe/tribe-common/pull/1413
https://github.com/moderntribe/the-events-calendar/pull/3245