### PR TITLE
Passthru, do not remove, non-scalar query args

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.12.7] TBD =
+
+* Fix - Correctly handle array format query arguments while generating clean, or canonical, URLs; this solves some issues with Filter Bar and Views v2 where filters would be dropped when changing Views, paginating or using the datepicker. [FBAR-74, FBAR-85, FBAR-86]
+
 = [4.12.6] 2020-07-27 =
 
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]


### PR DESCRIPTION
Issues: 
* https://moderntribe.atlassian.net/browse/FBAR-74 
* https://moderntribe.atlassian.net/browse/FBAR-85
* https://moderntribe.atlassian.net/browse/FBAR-86

[Screencap of View change](https://drive.google.com/open?id=1AB-gPOiEF4p48eSggRbnqe-ww-Ms-Z8r&authuser=luca%40tri.be&usp=drive_fs)
[Screencap of View pagination](https://drive.google.com/open?id=1ABkBWEgqJAJH9Iw_9EQA81UuC254b6Pc&authuser=luca%40tri.be&usp=drive_fs)
[Screencap of Date Picker use](https://drive.google.com/open?id=1AFHXTXLljcPBPdNTUTeZKeem8iImGD85&authuser=luca%40tri.be&usp=drive_fs)

This is a second attempt at solving the issue that make Filter Bar
filters not be carried over from View to View when changing in any way.
In the current Rewrite code, non-scalar query vars are dropped as they
would never be correctly resolved to a "pretty" URL.
Filter Bar will use query vars like `?tribe_eventcategory[0]=23` that,
being non-scalar, would be dropped during the generation of clean URLs
from any View.

This PR changes the behavior to **not** drop those non-scalar query vars
to, simply, making them pass-through.

From my first tests, not nearly exhaustive enough, this seems to solve the issues
reported in the 3 tickets above.

Tests to cover this code are, due to the nature of the Rewrite component,
in [the TEC PR](https://github.com/moderntribe/the-events-calendar/pull/3248).