### PR TITLE
Draft common link object for discussion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "lucatume/function-mocker-le": "^1.0",
     "lucatume/wp-browser": "^2.2.4",
+    "lucatume/codeception-snapshot-assertions": "0.*",
     "moderntribe/tribalscents": "dev-master",
     "moderntribe/tribe-testing-facilities": "dev-master",
     "phpunit/phpunit": "~6.0",

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.12.7] TBD =
+
+* Fix - Correctly handle array format query arguments while generating clean, or canonical, URLs; this solves some issues with Filter Bar and Views v2 where filters would be dropped when changing Views, paginating or using the datepicker. [FBAR-74, FBAR-85, FBAR-86]
+
 = [4.12.6] 2020-07-27 =
 
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -412,6 +412,17 @@ class Tribe__Rewrite {
 			return $home_url;
 		}
 
+		// Passthru vars are additional salts for the cache that would render it useless: parse them here.
+		$query = (string) parse_url( $url, PHP_URL_QUERY );
+		wp_parse_str( $query, $query_vars );
+		// Non-scalar value query vars should not be handled, but they should survive the resolution and not be cached.
+		$scalar_query_vars = array_filter( $query_vars, 'is_scalar' );
+		$passthru_vars     = array_diff_key( $query_vars, $scalar_query_vars );
+		// Remove the passthru query vars from the URL to match the correct cache.
+		$url = remove_query_arg( array_keys( $passthru_vars ), $url );
+		// Normalize the URL to make sure there's a trailing slash at the end of the path, before the query or fragment.
+		$url = preg_replace( '~(?<!/)([?#])~', '/$1', $url );
+
 		if ( ! $force ) {
 			$this->warmup_cache(
 				'canonical_url',
@@ -419,15 +430,12 @@ class Tribe__Rewrite {
 				Listener::TRIGGER_GENERATE_REWRITE_RULES
 			);
 			if ( isset( $this->canonical_url_cache[ $url ] ) ) {
-				return $this->canonical_url_cache[ $url ];
+				// Re-apply passthru vars now, if any.
+				return add_query_arg( $passthru_vars, $this->canonical_url_cache[ $url ] );
 			}
 		}
 
-		$query         = (string) parse_url( $url, PHP_URL_QUERY );
-		wp_parse_str( $query, $query_vars );
-
-		// Drop any query var that is not a scalar; it should not be handled.
-		$query_vars = array_filter( $query_vars, 'is_scalar' );
+		$query_vars = array_intersect_key( $query_vars, $scalar_query_vars );
 
 		if ( isset( $query_vars['paged'] ) && 1 === (int) $query_vars['paged'] ) {
 			// Remove the `paged` query var if it's 1.
@@ -588,6 +596,9 @@ class Tribe__Rewrite {
 			// Since we're caching let's not cache unmatched rules to allow for their later, valid resolution.
 			$this->canonical_url_cache[ $url ] = $resolved;
 		}
+
+		// Re-apply passthru vars now, if any. After the caching to allow salting the cache key too much.
+		$resolved = add_query_arg( $passthru_vars, $resolved );
 
 		return $resolved;
 	}

--- a/src/Tribe/Utils/Links.php
+++ b/src/Tribe/Utils/Links.php
@@ -1,30 +1,78 @@
 <?php
 /**
- * Link utilities
+ * Link Utilities
+ *
+ * @since   TBD
+ * @package Tribe\Utils
  */
-class Tribe__Utils__Links {
+
+namespace Tribe\Utils;
+class Links {
 	public $local_host;
 
+	/**
+	 * Register allthethings!
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
 	public function register() {
 		$this->local_host = strtolower( wp_parse_url( home_url() ) );
 	}
 
+	/**
+	 * Get the link host.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return string The host portion of the URL.
+	 */
 	public function get_link_host( $url ) {
 		$url_components   = wp_parse_url( $url );
 
 		return strtolower( $url_components['host'] );
 	}
 
+	/**
+	 * Determine if a URL is relative.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return boolean
+	 */
 	public function is_relative_url( $url ) {
 		$url_host = trim( $this->get_link_host( $url ) );
 
 		return empty( $url_host );
 	}
 
+	/**
+	 * Determine if a URL is a local subdomain.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return boolean
+	 */
 	public function is_local_subdomain( $url ) {
 		return (bool) strrpos( $this->get_link_host( $url ), '.' . $this->local_host );
 	}
 
+	/**
+	 * Determine if a link is local to the site.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return boolean
+	 */
 	public function is_local_link( $url ) {
 		$url_host = $this->get_link_host( $url );
 
@@ -33,6 +81,15 @@ class Tribe__Utils__Links {
 				|| $this->is_local_subdomain( $url );
 	}
 
+	/**
+	 * Get the appropriate rel attribute for a link.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return string The value of the rel attribute.
+	 */
 	public function get_rel_attr( $url ) {
 		// The rel attribute by default is empty.
 		$rel = '';
@@ -50,6 +107,15 @@ class Tribe__Utils__Links {
 		return add_filter( 'tribe_get_link_rel_attribute', $rel );
 	}
 
+	/**
+	 * Get teh appropriate target for a link.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url The URL to assess.
+	 *
+	 * @return string The value of the target attribute.
+	 */
 	public function get_target_attr( $url ) {
 		// The default target is _self -> the same window/tab.
 		$target = "_self";
@@ -58,14 +124,75 @@ class Tribe__Utils__Links {
 		return add_filter( 'tribe_get_link_target_attribute', $target );
 	}
 
-	public function render( $url, $label, $echo ) {
-		$target = empty( $this->get_target_attr( $url ) ) ? '' : 'target=" ' . esc_attr( $this->get_target_attr( $url ) ) . ' "';
-		$rel    = empty( $this->get_rel_attr( $url ) ) ? '' : 'rel=" ' . esc_attr( $this->get_rel_attr( $url ) ) . ' "';
+	public function build( $url, $args = [] ) {
+		$default_args = [
+			'target' => empty( $this->get_target_attr( $url ) ) ? '' : 'target=" ' . esc_attr( $this->get_target_attr( $url ) ) . ' "',
+			'rel'    => empty( $this->get_rel_attr( $url ) ) ? '' : 'rel=" ' . esc_attr( $this->get_rel_attr( $url ) ) . ' "',
+		];
+
+		return wp_parse_args( $args, $default_args );
+	}
+
+	public function build_arg_string( $args ) {
+		if ( empty( $args ) ) {
+			return;
+		}
+
+		$args = implode(
+			' ',
+			array_map(
+				function ( $key, $val ) {
+					// Explicitly setting false skips the attribute.
+					if ( false === $val ) {
+						return;
+					}
+
+					// Using preg_replace since for the key we don't want to convert special chars, but remove them.
+					$key = preg_replace('/[^A-Za-z_]/', '', $key);
+
+					// Setting true or an empty string is a no-value attribute.
+					if ( true === $val || '' === $val ) {
+						return $key;
+					}
+
+					//$key="$value" attribute.
+					return $key .'="'. esc_attr( $val ) .'"';
+				},
+				array_keys($args),
+				$args
+			)
+		);
+
+		return $args;
+	}
+
+	/**
+	 * Get the HTML for a link
+	 *
+	 * @since TBD
+	 *
+	 * @param string  $url   The URL to assess.
+	 * @param string  $label The link text.
+	 * @param array   $args  Additional arguments. This should be additional attributes in format
+	 * 							[
+	 *								'class' => 'fnord',
+	 *								'download' => false,
+	 * 							]
+	 * 							Where false values will be purposefully ignored.
+	 * @param boolean $echo  Echo or return the string.
+	 *
+	 * @return string|void HTML string return, or echo, determined by $echo, above.
+	 */
+	public function render( $url, $label, $args = [], $echo = false ) {
+		$args = $this->build( $url, $args );
+
+
+
+
 		$html   = sprintf(
 			'<a href="%s" target="%s" rel="%s">%s</a>',
-			esc_attr( esc_url( $url ) ),
-			$target,
-			$rel,
+			esc_url( $url ),
+			$args,
 			esc_html( $label )
 		);
 

--- a/src/Tribe/Utils/Links.php
+++ b/src/Tribe/Utils/Links.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Link utilities
+ */
+class Tribe__Utils__Links {
+	public $local_host;
+
+	public function register() {
+		$this->local_host = strtolower( wp_parse_url( home_url() ) );
+	}
+
+	public function get_link_host( $url ) {
+		$url_components   = wp_parse_url( $url );
+
+		return strtolower( $url_components['host'] );
+	}
+
+	public function is_relative_url( $url ) {
+		$url_host = trim( $this->get_link_host( $url ) );
+
+		return empty( $url_host );
+	}
+
+	public function is_local_subdomain( $url ) {
+		return (bool) strrpos( $this->get_link_host( $url ), '.' . $this->local_host );
+	}
+
+	public function is_local_link( $url ) {
+		$url_host = $this->get_link_host( $url );
+
+		return 0 === strcasecmp( $url_host, $this->local_host )
+				|| $this->is_relative_url( $url )
+				|| $this->is_local_subdomain( $url );
+	}
+
+	public function get_rel_attr( $url ) {
+		// The rel attribute by default is empty.
+		$rel = '';
+
+		// For external links, use "external"
+		if ( ! $this->is_local_link( $url ) ) {
+			$rel = 'external';
+		}
+
+		// Safety dance!
+		if ( '_blank' === $this->get_target_attr( $url ) ) {
+			$rel = 'noopener noreferrer';
+		}
+
+		return add_filter( 'tribe_get_link_rel_attribute', $rel );
+	}
+
+	public function get_target_attr( $url ) {
+		// The default target is _self -> the same window/tab.
+		$target = "_self";
+
+
+		return add_filter( 'tribe_get_link_target_attribute', $target );
+	}
+
+	public function render( $url, $label, $echo ) {
+		$target = empty( $this->get_target_attr( $url ) ) ? '' : 'target=" ' . esc_attr( $this->get_target_attr( $url ) ) . ' "';
+		$rel    = empty( $this->get_rel_attr( $url ) ) ? '' : 'rel=" ' . esc_attr( $this->get_rel_attr( $url ) ) . ' "';
+		$html   = sprintf(
+			'<a href="%s" target="%s" rel="%s">%s</a>',
+			esc_attr( esc_url( $url ) ),
+			$target,
+			$rel,
+			esc_html( $label )
+		);
+
+		if ( empty( $echo ) ) {
+			return $html;
+		}
+
+		echo $html;
+	}
+
+}

--- a/tests/wpunit/Tribe/Utils/LinkTest.php
+++ b/tests/wpunit/Tribe/Utils/LinkTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tribe\Utils;
+
+use Tribe\Utils\Links;
+
+class LinksTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * It should correctly identify the host
+	 */
+
+	/**
+	 * It should correctly identify a local subdomain
+	 */
+
+	/**
+	 * It should not identify a remote subdomain as local
+	 */
+
+	/**
+	 * It should correctly identify a relative url
+	 */
+
+	/**
+	 * It should correctly identify a local url
+	 */
+
+	/**
+	 * It should correctly output a local rel attribute
+	 */
+
+	/**
+	 * It should correctly output an external rel attribute
+	 */
+
+	/**
+	 * It should correctly output a rel attribute for target="blank"
+	 */
+}

--- a/tests/wpunit/Tribe/Utils/LinkTest.php
+++ b/tests/wpunit/Tribe/Utils/LinkTest.php
@@ -3,38 +3,333 @@
 namespace Tribe\Utils;
 
 use Tribe\Utils\Links;
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 
 class LinksTest extends \Codeception\TestCase\WPTestCase {
+	use SnapshotAssertions;
+
+	public function setUp() {
+		// before.
+		parent::setUp();
+		add_filter( 'home_url', function() { return 'http://www.subgenius.com/'; } );
+
+		$this->link_Object             = new Links;
+		$this->link_Object->local_host = 'http://www.subgenius.com/';
+		$this->local_host              = 'http://www.subgenius.com/';
+		$this->local_subdomain         = 'http://www.fnord.subgenius.com/';
+		$this->remote_subdomain        = 'https://support.theeventscalendar.com';
+		$this->url                     = 'https://theeventscalendar.com/knowledgebase/k/embedding-calendar-views-with-the-tribe_events-shortcode/';
+	}
+
+	public function tearDown() {
+		// your tear down methods here.
+
+		// then.
+		parent::tearDown();
+	}
+
+	public function set_target_blank() {
+		add_filter(
+			'tribe_get_link_target_attribute',
+			function() {
+				return '_blank';
+			}
+		);
+	}
 
 	/**
-	 * It should correctly identify the host
+	 * @test
+	 * It should correctly identify the host.
 	 */
+	public function it_should_correctly_identify_the_host() {
+		$this->assertEquals( 'theeventscalendar.com', $this->link_Object->get_link_host( $this->url ) );
+		$this->assertNotEquals( 'theeventscalendar.com', $this->link_Object->get_link_host( $this->local_host ) );
+	}
 
 	/**
-	 * It should correctly identify a local subdomain
+	 * @test
+	 * It should correctly identify a local host.
 	 */
+	public function it_should_correctly_identify_a_local_host() {
+		$this->assertTrue( $this->link_Object->is_local_link( $this->local_host ) );
+		$this->assertFalse( $this->link_Object->is_local_link( $this->url ) );
+	}
+
 
 	/**
-	 * It should not identify a remote subdomain as local
+	 * @test
+	 * It should correctly identify a local subdomain.
 	 */
+	public function it_should_correctly_identify_a_local_subdomain() {
+		$this->assertTrue( $this->link_Object->is_local_subdomain( $this->local_subdomain ) );
+		$this->assertFalse( $this->link_Object->is_local_subdomain( $this->remote_subdomain ) );
+	}
 
 	/**
-	 * It should correctly identify a relative url
+	 * @test
+	 * It should correctly identify a relative url.
 	 */
+	public function it_should_correctly_identify_a_relative_url() {
+		$this->assertTrue( $this->link_Object->is_relative_url( '/' ) );
+		$this->assertFalse( $this->link_Object->is_relative_url( $this->url ) );
+	}
 
 	/**
-	 * It should correctly identify a local url
+	 * @test
+	 * It should correctly identify a local url.
 	 */
+	public function it_should_correctly_identify_a_local_url() {
+		$this->assertTrue( $this->link_Object->is_local_link( $this->local_host ) );
+		$this->assertTrue( $this->link_Object->is_local_link( $this->local_subdomain ) );
+		$this->assertFalse( $this->link_Object->is_local_link( $this->url ) );
+	}
 
 	/**
-	 * It should correctly output a local rel attribute
+	 * @test
+	 * It should correctly identify a relative url as local.
 	 */
+	public function it_should_correctly_identify_a_relative_url_as_local() {
+		$this->assertTrue( $this->link_Object->is_local_link( '/' ) );
+	}
 
 	/**
-	 * It should correctly output an external rel attribute
+	 * @test
+	 * It should correctly output a local rel attribute.
 	 */
+	public function it_should_correctly_output_a_local_rel_attribute() {
+		$this->assertEmpty( $this->link_Object->get_rel_attr( $this->local_host ) );
+	}
 
 	/**
-	 * It should correctly output a rel attribute for target="blank"
+	 * @test
+	 * It should correctly output an external rel attribute.
 	 */
+	public function it_should_correctly_output_an_external_rel_attribute() {
+		$this->assertEquals( 'external', $this->link_Object->get_rel_attr( $this->url ) );
+	}
+
+	/**
+	 * @test
+	 * It should correctly output a default target.
+	 */
+	public function it_should_correctly_output_a_default_target() {
+		$this->assertEquals( '_self', $this->link_Object->get_target_attr( $this->url ) );
+	}
+
+	/**
+	 * @test
+	 * It should correctly output a filtered target.
+	 */
+	public function it_should_correctly_output_a_filtered_target() {
+		$this->set_target_blank();
+		$this->assertEquals( '_blank', $this->link_Object->get_target_attr( $this->url ) );
+	}
+
+	/**
+	 * @test
+	 * It should correctly output a rel attribute for target="blank" on an internal link.
+	 */
+	public function it_should_correctly_output_a_rel_attribute_for_target_blank_internal() {
+		$this->set_target_blank();
+		$this->assertEquals( 'noopener noreferrer', $this->link_Object->get_rel_attr( $this->local_subdomain ) );
+	}
+
+	/**
+	 * @test
+	 * It should correctly output a rel attribute for target="blank" on an external link.
+	 */
+	public function it_should_correctly_output_a_rel_attribute_for_target_blank_external() {
+		$this->set_target_blank();
+
+		$this->assertEquals( 'external noopener noreferrer', $this->link_Object->get_rel_attr( $this->url ) );
+	}
+
+	/**
+	 * @test
+	 * Build should handle default args for internal links.
+	 */
+	public function build_should_handle_default_args_internal() {
+		$build = $this->link_Object->build( $this->local_host );
+
+		$this->assertEquals(
+			[
+				'rel'    => false,
+				'target' => '_self',
+			],
+			$build
+		);
+	}
+
+	/**
+	 * @test
+	 * Build should handle default args for internal links with target _blank.
+	 */
+	public function build_should_handle_default_args_internal_for_target_blank() {
+		$args  = [];
+		$this->set_target_blank();
+		$build = $this->link_Object->build( $this->local_host, $args );
+
+		$this->assertEquals(
+			[
+				'rel'    => 'noopener noreferrer',
+				'target' => '_blank',
+			],
+			$build
+		);
+	}
+
+	/**
+	 * @test
+	 * Build should handle default args for external links.
+	 */
+	public function build_should_handle_default_args_external() {
+		$args  = [];
+		$build = $this->link_Object->build( $this->url, $args );
+
+		$this->assertEquals(
+			[
+				'target' => '_self',
+      			'rel'    => 'external',
+			],
+			$build
+		);
+	}
+
+	/**
+	 * @test
+	 * Build should handle additional args.
+	 */
+	public function build_should_handle_additional_args() {
+		$args  = [
+			'disabled' => true,
+			'title' => 'Title'
+		];
+		$build = $this->link_Object->build( $this->url, $args );
+
+		$this->assertEquals(
+			[
+				'disabled' => true,
+				'rel'      => 'external',
+				'target'   => '_self',
+				'title'    => 'Title',
+			],
+			$build
+		);
+	}
+
+	/**
+	 * @test
+	 * Build attr string should handle default args for internal links.
+	 */
+	public function build_attr_string_should_handle_default_args_internal() {
+		$build = $this->link_Object->build_attr_string( $this->local_host );
+
+		$this->assertEquals( 'target="_self"', $build );
+	}
+
+	/**
+	 * @test
+	 * Build attr string should handle default args for external links.
+	 */
+	public function build_attr_string_should_handle_default_args_external() {
+		$build = $this->link_Object->build_attr_string( $this->url );
+
+		$this->assertEquals( 'target="_self" rel="external"', $build );
+	}
+
+	/**
+	 * @test
+	 * Build attr string should handle additional args for links.
+	 */
+	public function build_attr_string_should_handle_additional_args() {
+		$args = [
+			'disabled' => true,
+			'media'    => 'screen',
+			'target' => '_blank',
+		];
+
+		$build = $this->link_Object->build_attr_string( $this->url, $args );
+
+		$this->assertEquals( 'target="_blank" rel="external" disabled media="screen"', $build );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render internal link correctly.
+	 */
+	public function it_should_render_internal_link_correctly() {
+		$render = $this->link_Object->render( $this->local_host, 'Test' );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render internal link correctly with target _blank.
+	 */
+	public function it_should_render_internal_link_correctly_with_target_blank() {
+		$this->set_target_blank();
+		$render = $this->link_Object->render( $this->local_host, 'Test' );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render internal link correctly with added attributes.
+	 */
+	public function it_should_render_internal_link_correctly_with_added_attributes() {
+		$args = [
+			'disabled' => true,
+			'media'    => 'screen',
+
+		];
+		$render = $this->link_Object->render( $this->local_host, 'Test', $args );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render external link correctly.
+	 */
+	public function it_should_render_external_link_correctly() {
+		$render = $this->link_Object->render( $this->url, 'Test' );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render external link correctly with target _blank.
+	 */
+	public function it_should_render_external_link_correctly_with_target_blank() {
+		$this->set_target_blank();
+		$render = $this->link_Object->render( $this->url, 'Test' );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
+
+	/**
+	 * @test
+	 *
+	 * It should render external link correctly with added attributes.
+	 */
+	public function it_should_render_external_link_correctly_with_added_attributes() {
+		$args = [
+			'disabled' => true,
+			'media'    => 'screen',
+			'target'   => '_blank,'
+
+		];
+
+		$render = $this->link_Object->render( $this->url, 'Test', $args );
+
+		$this->assertMatchesHtmlSnapshot( $render );
+	}
 }

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="https://theeventscalendar.com/knowledgebase/k/embedding-calendar-views-with-the-tribe_events-shortcode/" target="_self" rel="external">Test</a>

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly_with_added_attributes__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly_with_added_attributes__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="https://theeventscalendar.com/knowledgebase/k/embedding-calendar-views-with-the-tribe_events-shortcode/" target="_blank," rel="external" disabled media="screen">Test</a>

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly_with_target_blank__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_external_link_correctly_with_target_blank__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="https://theeventscalendar.com/knowledgebase/k/embedding-calendar-views-with-the-tribe_events-shortcode/" target="_blank" rel="external noopener noreferrer">Test</a>

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="http://www.subgenius.com/" target="_self">Test</a>

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly_with_added_attributes__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly_with_added_attributes__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="http://www.subgenius.com/" target="_self" disabled media="screen">Test</a>

--- a/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly_with_target_blank__0.snapshot.html
+++ b/tests/wpunit/Tribe/Utils/__snapshots__/LinksTest__it_should_render_internal_link_correctly_with_target_blank__0.snapshot.html
@@ -1,0 +1,1 @@
+<a href="http://www.subgenius.com/" target="_blank" rel="noopener noreferrer">Test</a>


### PR DESCRIPTION
Utility object for link building.

"Intelligently" adds required attributes (rel, target) as needed.

Allows passing extra arguments as an array in the format:
```php
[
    'media'         => 'screen', // key => value for most attributes.
    'disabled      => true, // key => true for  no-value attributes.
    'disabled      =>'', // key => '' also works for no-value attributes.
    'crossorigin' => false, // key => false for forcing removal of attributes.
]
```

Also added snapshot tests to common so I could use them.

Note, this would make https://github.com/moderntribe/tribe-common/pull/1383 obsolete. This is more robust.