### PR TITLE
[GTRIA-275] Fix/modal button props

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,10 @@
 
 * Fix - Added IE11 compatibility for the toggles styles using `tribe-common-form-control-toggle` CSS class. [ET-865]
 
+= [TBD] TBD =
+
+* Fix - Pass extra props down to Modal component to allow addition of extra properties. [GTRIA-275]
+
 = [4.12.6] 2020-07-27 =
 
 * Feature - Added the `tribe_normalize_orderby` function to parse and build WP_Query `orderby` in a normalized format. [TEC-3548]

--- a/src/modules/elements/label-with-modal/element.js
+++ b/src/modules/elements/label-with-modal/element.js
@@ -26,6 +26,7 @@ const LabelWithModal = ( {
 	onClick,
 	onClose,
 	onOpen,
+	...restProps,
 } ) => (
 	<LabeledItem
 		className={ classNames( 'tribe-editor__label-with-modal', className ) }
@@ -43,6 +44,7 @@ const LabelWithModal = ( {
 			onClick={ onClick }
 			onClose={ onClose }
 			onOpen={ onOpen }
+			{ ...restProps }
 		/>
 	</LabeledItem>
 );

--- a/src/modules/elements/modal-button/element.js
+++ b/src/modules/elements/modal-button/element.js
@@ -58,15 +58,23 @@ class ModalButton extends PureComponent {
 
 	renderModal = () => {
 		const {
+			className,
+			disabled,
+			isOpen,
+			label,
+			onClick,
+			onClose,
+			onOpen,
 			modalClassName,
 			modalContent,
 			modalOverlayClassName,
 			modalTitle,
+			...restProps
 		} = this.props;
 
-		const isOpen = this.props.isOpen !== undefined ? this.props.isOpen : this.state.isOpen;
+		const isModalOpen = isOpen !== undefined ? isOpen : this.state.isOpen;
 
-		return ( isOpen && (
+		return ( isModalOpen && (
 			<Modal
 				className={ classNames(
 					'tribe-editor__modal-button__modal-content',
@@ -78,6 +86,7 @@ class ModalButton extends PureComponent {
 					modalOverlayClassName,
 				) }
 				title={ modalTitle }
+				{ ...restProps }
 			>
 				{ modalContent }
 			</Modal>


### PR DESCRIPTION
**Ticket:** [GTRIA-275]

This PR passes extra props down to the WordPress modal component which we have created our own component as a wrapper for.

**Screencast:** https://drive.google.com/file/d/10EeJFXlGK3ahvDx3LGVQI1XEHl5Rilo9/view?usp=sharing

[GTRIA-275]: https://moderntribe.atlassian.net/browse/GTRIA-275