### PR TITLE
Prevent warnings from Rest Route permission callback

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,7 @@
 * Tweak - Add the `tribe_template_common_path` filter to allow controlling the path of the template file provided by common. [FBAR-148]
 * Tweak - Add the `tribe_without_filters` function to run a callback or closure suspending a set of filters and actions. [TEC-3579]
 * Tweak - Added hover and focus colors, update default colors to make them accessible. [FBAR-165]
+* Fix - Prevent `register_rest_route` from throwing notices related to `permission_callback` (props @hanswitteprins)
 
 = [4.12.7] 2020-08-24 =
 

--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -355,10 +355,15 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 		public static function create_sysinfo_endpoint() {
 			$optin_key = get_option( 'tribe_systeminfo_optin' );
 			if ( $optin_key ) {
-				register_rest_route( 'tribe_events/v2', '/(?P<key>[a-z0-9\-]+)/sysinfo/', array(
-					'methods'  => 'GET',
-					'callback' => array( 'Tribe__Support', 'sysinfo_query' ),
-				) );
+				register_rest_route(
+					'tribe_events/v2',
+					'/(?P<key>[a-z0-9\-]+)/sysinfo/',
+					[
+						'methods'              => 'GET',
+						'callback'            => [ 'Tribe__Support', 'sysinfo_query' ],
+						'permission_callback' => '__return_true',
+					]
+				);
 			}
 		}
 


### PR DESCRIPTION
Resolves the warning for `register_rest_route` that was not using our `tribe_register_rest_route`.

_Reported on:_
https://wordpress.org/support/topic/solve-log-warnings-by-adding-permission_callback-to-register_rest_route-call/