### PR TITLE
Add the snapshots test suite and base test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,3 +127,4 @@ script:
   - codecept run wpunit
   - codecept run muwpunit
   - codecept run dependency
+  - codecept run snapshots

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ before_script:
   - cd $PLUGIN_DIR
   # Reset HARD first to avoid changes we might have done while updating TEC stopping the checkout.
   - git reset HEAD --hard && git checkout origin/$CURRENT_BRANCH
-  - composer update
+  - composer install
 
   # get to the common dir
   - cd $PLUGIN_DIR

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "moderntribe/tribe-testing-facilities": "dev-master",
     "phpunit/phpunit": "~6.0",
     "wp-cli/checksum-command": "1.0.5",
-    "wp-coding-standards/wpcs": "^2.1"
+    "wp-coding-standards/wpcs": "^2.1",
+    "lucatume/codeception-snapshot-assertions": "^0.2.4"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "473a9f925f99415db699d1cc70c62ace",
+    "content-hash": "df9da8977071068f3eb2400365106f0f",
     "packages": [
         {
             "name": "faction23/a11y-dialog",
@@ -1168,12 +1168,12 @@
             "version": "1.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/facebook/php-webdriver.git",
+                "url": "https://github.com/php-webdriver/php-webdriver-archive.git",
                 "reference": "e43de70f3c7166169d0f14a374505392734160e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/e43de70f3c7166169d0f14a374505392734160e5",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver-archive/zipball/e43de70f3c7166169d0f14a374505392734160e5",
                 "reference": "e43de70f3c7166169d0f14a374505392734160e5",
                 "shasum": ""
             },
@@ -1221,7 +1221,53 @@
                 "selenium",
                 "webdriver"
             ],
+            "abandoned": "php-webdriver/webdriver",
             "time": "2019-06-13T08:02:18+00:00"
+        },
+        {
+            "name": "gajus/dindent",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gajus/dindent.git",
+                "reference": "d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gajus/dindent/zipball/d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c",
+                "reference": "d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Gajus\\Dindent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Gajus Kuizinas",
+                    "email": "gk@anuary.com"
+                }
+            ],
+            "description": "HTML indentation library for development and testing.",
+            "homepage": "https://github.com/gajus/dindent",
+            "keywords": [
+                "format",
+                "html",
+                "indent"
+            ],
+            "time": "2014-10-08T10:03:04+00:00"
         },
         {
             "name": "gumlet/php-image-resize",
@@ -1724,6 +1770,47 @@
             "time": "2019-07-29T11:03:54+00:00"
         },
         {
+            "name": "lucatume/codeception-snapshot-assertions",
+            "version": "0.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lucatume/codeception-snapshot-assertions.git",
+                "reference": "077108237a121d3ddcf7070aa8519dea25459a6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lucatume/codeception-snapshot-assertions/zipball/077108237a121d3ddcf7070aa8519dea25459a6a",
+                "reference": "077108237a121d3ddcf7070aa8519dea25459a6a",
+                "shasum": ""
+            },
+            "require": {
+                "codeception/codeception": "^2.5 || ^3.0 || ^4.0",
+                "ext-dom": "*",
+                "gajus/dindent": "^2.0"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "tad\\Codeception\\SnapshotAssertions\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "theAverageDev (Luca Tumedei)",
+                    "email": "luca@theaveragedev.com"
+                }
+            ],
+            "description": "Snapshot assertions sugar for Codeception.",
+            "time": "2020-02-05T20:17:49+00:00"
+        },
+        {
             "name": "lucatume/function-mocker-le",
             "version": "1.0.1",
             "source": {
@@ -2004,16 +2091,16 @@
         },
         {
             "name": "moderntribe/tribe-testing-facilities",
-            "version": "dev-spotfix/include-views-exclusion-for-data-attr-breakpoints",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/tribe-testing-facilities",
-                "reference": "239335c62f7c0ed0dcd572e7aacc76d61bef2a1b"
+                "reference": "e56f9268210214c422f0e15444d476c5191d44ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/239335c62f7c0ed0dcd572e7aacc76d61bef2a1b",
-                "reference": "239335c62f7c0ed0dcd572e7aacc76d61bef2a1b",
+                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/e56f9268210214c422f0e15444d476c5191d44ea",
+                "reference": "e56f9268210214c422f0e15444d476c5191d44ea",
                 "shasum": ""
             },
             "require": {
@@ -2022,8 +2109,10 @@
                 "php": ">=7.0"
             },
             "require-dev": {
+                "codeception/codeception": "^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "phpunit/phpunit": "^6.0",
+                "vlucas/phpdotenv": "^3.0",
                 "wordpress/wordpress": "dev-master",
                 "wp-coding-standards/wpcs": "^2.1"
             },
@@ -2075,7 +2164,7 @@
                 }
             ],
             "description": "Testing facilities, helpers and examples.",
-            "time": "2020-02-05T04:31:52+00:00"
+            "time": "2020-06-19T14:48:33+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -2943,6 +3032,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -3319,7 +3409,7 @@
                 "array_column",
                 "column"
             ],
-            "abandoned": true,
+            "abandoned": "it-for-free/array_column",
             "time": "2015-03-20T22:07:39+00:00"
         },
         {
@@ -5145,6 +5235,7 @@
             ],
             "description": "Composer plugin for splitting a generated autoloader into two distinct parts.",
             "homepage": "https://wp-cli.org",
+            "abandoned": true,
             "time": "2017-08-03T08:40:16+00:00"
         },
         {
@@ -6960,6 +7051,7 @@
             ],
             "description": "Handlebars processor for php",
             "homepage": "https://github.com/XaminProject/handlebars.php",
+            "abandoned": true,
             "time": "2016-12-12T13:51:02+00:00"
         }
     ],

--- a/tests/_support/Helper/Snapshots.php
+++ b/tests/_support/Helper/Snapshots.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Snapshots extends \Codeception\Module
+{
+
+}

--- a/tests/_support/SnapshotsTester.php
+++ b/tests/_support/SnapshotsTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause()
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class SnapshotsTester extends \Codeception\Actor
+{
+    use _generated\SnapshotsTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/snapshots.suite.dist.yml
+++ b/tests/snapshots.suite.dist.yml
@@ -1,0 +1,18 @@
+actor: SnapshotsTester
+bootstrap: _bootstrap.php
+modules:
+    enabled:
+        - \Helper\Snapshots
+        - WPLoader:
+              wpRootFolder: %WP_ROOT_FOLDER%
+              dbName: %TEST_DB_NAME%
+              dbHost: %TEST_DB_HOST%
+              dbUser: %TEST_DB_USER%
+              dbPassword: %TEST_DB_PASSWORD%
+              domain: %WP_DOMAIN%
+              adminEmail: admin@%WP_DOMAIN%
+              title: 'Event Common Tests'
+              plugins:
+                  - the-events-calendar/the-events-calendar.php
+              activatePlugins:
+                  - the-events-calendar/the-events-calendar.php

--- a/tests/snapshots/Snapshot_Test_Case.php
+++ b/tests/snapshots/Snapshot_Test_Case.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * The base test case that snapshot test cases should extend for a minimum amount of required setup.
+ *
+ * @package Tribe\Tests\Snapshots
+ */
+
+namespace Tribe\Tests\Snapshots;
+
+use Tribe__Template as Template;
+
+/**
+ * Class Snapshot_Test_Case
+ */
+class Snapshot_Test_Case extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @var string The path, either relative to the `/src` directory or absolute, to the template to test.
+	 */
+	protected $template_path;
+
+	/**
+	 * @var Template The template instance, set up on the template path.
+	 */
+	protected $template;
+
+	/**
+	 * Sets up the template that will be used in the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		if ( empty( $this->template_path ) ) {
+			throw new \RuntimeException( 'Extending test cases should define the "template_path" property.' );
+		}
+
+		$template_file = is_dir( $this->template_path )
+			? $this->template_path
+			: dirname( __DIR__ ) . '/../src/' . ltrim( $this->template_path, '\\/' );
+
+		if ( ! is_file( $template_file ) ) {
+			throw new \RuntimeException( "The {$template_file} file does not exist." );
+		}
+
+		$template_file = realpath( $template_file );
+		if ( false === $template_file ) {
+			throw new \RuntimeException( "Could not resolve template file {$template_file} to real file." );
+		}
+
+		// To streamline the set up create the template as instance of an anonymous class set up for success.
+		$this->template = new class( $template_file ) extends Template {
+			protected $template_context_extract = true;
+
+			public function __construct( string $template_file ) {
+				$this->template_file = $template_file;
+			}
+
+			public function get_template_file( $name ) {
+				return $this->template_file;
+			}
+		};
+	}
+
+	/**
+	 * Renders the template with the provided context array and returns the output it produced.
+	 *
+	 * @param array<string,mixed> $context The template render context, a map of values.
+	 *
+	 * @return string|false Either the final content HTML or `false` if no template could be found.
+	 */
+	protected function render( array $context = [] ) {
+		return $this->template->template( $this->template_path, $context, false );
+	}
+}

--- a/tests/snapshots/_bootstrap.php
+++ b/tests/snapshots/_bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+use Codeception\Util\Autoload;
+
+// Register the suite namespace in Codeception auto-loader.
+Autoload::addNamespace( 'Tribe\\Tests\\Snapshots', __DIR__ );

--- a/tests/snapshots/views/dialog/__snapshots__/alertTest__test_w_title__0.snapshot.html
+++ b/tests/snapshots/views/dialog/__snapshots__/alertTest__test_w_title__0.snapshot.html
@@ -1,0 +1,14 @@
+<button
+	class="test-alert__button test-alert__button-red"
+	data-content="dialog-content-test-alert"
+	data-js="trigger-dialog-test-alert"
+					>Understood</button>
+<script data-js="dialog-content-test-alert" type="text/template">
+	<div  class="test-alert__content" >
+					<h2  class="test-alert__title" >A test alert</h2>
+		
+		<p>Lorem alert</p>		<div class="tribe-dialog__button_wrap">
+			<button class="tribe-button tribe-alert__continue">Alert</button>
+		</div>
+	</div>
+</script>

--- a/tests/snapshots/views/dialog/__snapshots__/alertTest__test_wo_title__0.snapshot.html
+++ b/tests/snapshots/views/dialog/__snapshots__/alertTest__test_wo_title__0.snapshot.html
@@ -1,0 +1,13 @@
+<button
+	class="test-alert__button test-alert__button-red"
+	data-content="dialog-content-test-alert"
+	data-js="trigger-dialog-test-alert"
+					>Understood</button>
+<script data-js="dialog-content-test-alert" type="text/template">
+	<div  class="test-alert__content" >
+		
+		<p>Lorem alert</p>		<div class="tribe-dialog__button_wrap">
+			<button class="tribe-button tribe-alert__continue">Alert</button>
+		</div>
+	</div>
+</script>

--- a/tests/snapshots/views/dialog/alertTest.php
+++ b/tests/snapshots/views/dialog/alertTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tribe\Tests\Snapshots\views\dialog;
+
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use Tribe\Tests\Snapshots\Snapshot_Test_Case;
+
+class alertTest extends Snapshot_Test_Case {
+	use SnapshotAssertions;
+
+	/**
+	 * @var string The path to the template, either relative to the `/src` directory, or absolute.
+	 */
+	protected $template_path = '/views/dialog/alert.php';
+
+	public function test_w_title() {
+		$html = $this->render( [
+			'title'             => 'A test alert',
+			'title_classes'     => 'test-alert__title',
+			'id'                => 'test-alert',
+			'button_classes'    => 'test-alert__button test-alert__button-red',
+			'button_text'       => 'Understood',
+			'content_classes'   => 'test-alert__content',
+			'content'           => '<p>Lorem alert</p>',
+			'alert_button_text' => 'Alert',
+		] );
+
+		$this->assertMatchesHtmlSnapshot( $html );
+	}
+
+	public function test_wo_title() {
+		$html = $this->render( [
+			'id'                => 'test-alert',
+			'button_classes'    => 'test-alert__button test-alert__button-red',
+			'button_text'       => 'Understood',
+			'content_classes'   => 'test-alert__content',
+			'content'           => '<p>Lorem alert</p>',
+			'alert_button_text' => 'Alert',
+		] );
+
+		$this->assertMatchesHtmlSnapshot( $html );
+	}
+}


### PR DESCRIPTION
This PR adds the `snapshots` test suite and with it the base test case and an example.j

[Screenshot of tests running in `tric` contex](https://drive.google.com/open?id=1DMJsCAdqXx9QW9FFfFwlr6PtkJKf-Gms&authuser=luca%40tri.be&usp=drive_fs)