### PR TITLE
Add return type to Canonical_Formatter::format() (to stop promoter breaking Woocommerce Checkout)

### DIFF
--- a/src/Tribe/Log/Canonical_Formatter.php
+++ b/src/Tribe/Log/Canonical_Formatter.php
@@ -24,7 +24,7 @@ class Canonical_Formatter extends LineFormatter {
 	 *
 	 * @return mixed The formatted record.
 	 */
-	public function format( array $record ) {
+	public function format( array $record ) : string {
 		$has_context = ! empty( $record['context'] );
 
 		if ( $has_context ) {


### PR DESCRIPTION
Tl;dr adds return type of `string` to LineFormatter::format, so it matches what monolog expects.

`Declaration of Tribe\Log\Canonical_Formatter::format(array $record) must be compatible with Monolog\Formatter\LineFormatter::format(array $record): string`.

---
Longer version:

The newer versions of Event Tickets Plus was breaking Woocommerce, because Promotor was throwing an exception. `['ticket_purchased', 'License Key must be present].

Normally this should be ignored (I for example use the nonprofit license, so we dont have promoter), but issue with monolog were causing a fatal error:

`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Monolog\Handler\ErrorLogHandler::__construct() must be of the type int, null given, called in /var/www/thegsc/wp-content/plugins/the-events-calendar/common/src/Tribe/Log/Service_Provider.php on line 73.`

That's a separate issue, and i'm not familiar enough with Tribe's Logger, but I changed ` new ErrorLogHandler( null, $level_threshold );` to `new ErrorLongHandler( 0, $level_threshold)`, since [thats the default value provided by Monolog](https://github.com/Seldaek/monolog/blob/bb99e4c699bd5abe2609cace3c2daf0e45fdb673/src/Monolog/Handler/ErrorLogHandler.php#L25)...

Then I got hit with another error, and that's what this fix addresses

```
PHP Fatal error:  Declaration of Tribe\Log\Canonical_Formatter::format(array $record) must be compatible with Monolog\Formatter\LineFormatter::format(array $record): string in /var/www/thegsc/wp-content/plugins/the-events-calendar/common/src/Tribe/Log/Canonical_Formatter.php on line 27
[08-Oct-2020 16:30:43 UTC] PHP Stack trace:
[08-Oct-2020 16:30:43 UTC] PHP   1. {main}() /var/www/thegsc/index.php:0
[08-Oct-2020 16:30:43 UTC] PHP   2. require() /var/www/thegsc/index.php:17
[08-Oct-2020 16:30:43 UTC] PHP   3. require_once() /var/www/thegsc/wp-blog-header.php:19
[08-Oct-2020 16:30:43 UTC] PHP   4. do_action() /var/www/thegsc/wp-includes/template-loader.php:13
[08-Oct-2020 16:30:43 UTC] PHP   5. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP   6. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP   7. WC_AJAX::do_wc_ajax() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP   8. do_action() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-ajax.php:89
[08-Oct-2020 16:30:43 UTC] PHP   9. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  10. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  11. WC_AJAX::checkout() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP  12. WC_Checkout->process_checkout() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-ajax.php:464
[08-Oct-2020 16:30:43 UTC] PHP  13. WC_Checkout->process_order_payment() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-checkout.php:1159
[08-Oct-2020 16:30:43 UTC] PHP  14. WC_Gateway_COD->process_payment() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-checkout.php:956
[08-Oct-2020 16:30:43 UTC] PHP  15. Automattic\WooCommerce\Admin\Overrides\Order->update_status() /var/www/thegsc/wp-content/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php:326
[08-Oct-2020 16:30:43 UTC] PHP  16. Automattic\WooCommerce\Admin\Overrides\Order->save() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-order.php:333
[08-Oct-2020 16:30:43 UTC] PHP  17. Automattic\WooCommerce\Admin\Overrides\Order->status_transition() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-order.php:221
[08-Oct-2020 16:30:43 UTC] PHP  18. do_action() /var/www/thegsc/wp-content/plugins/woocommerce/includes/class-wc-order.php:373
[08-Oct-2020 16:30:43 UTC] PHP  19. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  20. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  21. Tribe__Tickets_Plus__Commerce__WooCommerce__Main->delayed_ticket_generation() /var/www/thegsc/wp-includes/class-wp-hook.php:289
[08-Oct-2020 16:30:43 UTC] PHP  22. Tribe__Tickets_Plus__Commerce__WooCommerce__Main->generate_tickets() /var/www/thegsc/wp-content/plugins/event-tickets-plus/src/Tribe/Commerce/WooCommerce/Main.php:795
[08-Oct-2020 16:30:43 UTC] PHP  23. do_action() /var/www/thegsc/wp-content/plugins/event-tickets-plus/src/Tribe/Commerce/WooCommerce/Main.php:973
[08-Oct-2020 16:30:43 UTC] PHP  24. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  25. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  26. Tribe__Tickets_Plus__Commerce__WooCommerce__Promoter_Observer->ticket_created() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP  27. Tribe__Tickets_Plus__Commerce__WooCommerce__Promoter_Observer->trigger() /var/www/thegsc/wp-content/plugins/event-tickets-plus/src/Tribe/Commerce/WooCommerce/Promoter_Observer.php:70
[08-Oct-2020 16:30:43 UTC] PHP  28. do_action() /var/www/thegsc/wp-content/plugins/event-tickets-plus/src/Tribe/Commerce/WooCommerce/Promoter_Observer.php:95
[08-Oct-2020 16:30:43 UTC] PHP  29. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  30. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  31. Tribe\Tickets\Promoter\Triggers\Factory->build_attendee() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP  32. do_action() /var/www/thegsc/wp-content/plugins/event-tickets/src/Tribe/Promoter/Triggers/Factory.php:40
[08-Oct-2020 16:30:43 UTC] PHP  33. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  34. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  35. Tribe\Tickets\Promoter\Triggers\Dispatcher->trigger() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP  36. do_action() /var/www/thegsc/wp-content/plugins/event-tickets/src/Tribe/Promoter/Triggers/Dispatcher.php:90
[08-Oct-2020 16:30:43 UTC] PHP  37. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:478
[08-Oct-2020 16:30:43 UTC] PHP  38. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[08-Oct-2020 16:30:43 UTC] PHP  39. Tribe\Log\Service_Provider->dispatch_log() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[08-Oct-2020 16:30:43 UTC] PHP  40. Tribe__Container->make() /var/www/thegsc/wp-content/plugins/the-events-calendar/common/src/Tribe/Log/Service_Provider.php:130
[08-Oct-2020 16:30:43 UTC] PHP  41. Tribe\Log\Service_Provider->build_logger() /var/www/thegsc/wp-content/plugins/the-events-calendar/common/vendor/lucatume/di52/src/tad/DI52/Container.php:279
[08-Oct-2020 16:30:43 UTC] PHP  42. spl_autoload_call() /var/www/thegsc/wp-content/plugins/the-events-calendar/common/src/Tribe/Log/Service_Provider.php:85
[08-Oct-2020 16:30:43 UTC] PHP  43. Composer\Autoload\ClassLoader->loadClass() /var/www/thegsc/wp-content/plugins/the-events-calendar/common/src/Tribe/Log/Service_Provider.php:85
[08-Oct-2020 16:30:43 UTC] PHP  44. Composer\Autoload\includeFile() /var/www/thegsc/wp-content/plugins/event-tickets/vendor/composer/ClassLoader.php:322
[08-Oct-2020 16:30:43 UTC] PHP  45. include() /var/www/thegsc/wp-content/plugins/event-tickets/vendor/composer/ClassLoader.php:444
```