### PR TITLE
[ETP-496] correct docblock for template’s get()

### DIFF
--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -283,17 +283,17 @@ class Tribe__Template {
 	}
 
 	/**
-	 * Sets a Index inside of the global or local context
-	 * Final to prevent extending the class when the `get` already exists on the child class
+	 * Sets an Index inside of the global or local context.
+	 * Final to prevent extending the class when the `get` already exists on the child class.
+	 *
+	 * @see    Tribe__Utils__Array::set()
 	 *
 	 * @since  4.6.2
 	 *
-	 * @see    Tribe__Utils__Array::set
-	 *
-	 * @param  array    $index     Specify each nested index in order.
-	 *                             Example: array( 'lvl1', 'lvl2' );
-	 * @param  mixed    $default   Default value if the search finds nothing.
-	 * @param  boolean  $is_local  Use the Local or Global context
+	 * @param array|string $index    Specify each nested index in order.
+	 *                               Example: array( 'lvl1', 'lvl2' );
+	 * @param mixed        $default  Default value if the search finds nothing.
+	 * @param boolean      $is_local Use the Local or Global context.
 	 *
 	 * @return mixed The value of the specified index or the default if not found.
 	 */
@@ -310,14 +310,15 @@ class Tribe__Template {
 		 *
 		 * @since  4.6.2
 		 *
-		 * @param  mixed    $value     The value that will be filtered
-		 * @param  array    $index     Specify each nested index in order.
-		 *                             Example: array( 'lvl1', 'lvl2' );
-		 * @param  mixed    $default   Default value if the search finds nothing.
-		 * @param  boolean  $is_local  Use the Local or Global context
-		 * @param  self     $template  Current instance of the Tribe__Template
+		 * @param mixed        $value    The value that will be filtered.
+		 * @param array|string $index    Specify each nested index in order.
+		 *                               Example: array( 'lvl1', 'lvl2' );
+		 * @param mixed        $default  Default value if the search finds nothing.
+		 * @param boolean      $is_local Use the Local or Global context,
+		 * @param self         $template Current instance of the Tribe__Template.
 		 */
 		$value = apply_filters( 'tribe_template_context_get', null, $index, $default, $is_local, $this );
+
 		if ( null !== $value ) {
 			return $value;
 		}

--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -314,7 +314,7 @@ class Tribe__Template {
 		 * @param array|string $index    Specify each nested index in order.
 		 *                               Example: array( 'lvl1', 'lvl2' );
 		 * @param mixed        $default  Default value if the search finds nothing.
-		 * @param boolean      $is_local Use the Local or Global context,
+		 * @param boolean      $is_local Use the Local or Global context.
 		 * @param self         $template Current instance of the Tribe__Template.
 		 */
 		$value = apply_filters( 'tribe_template_context_get', null, $index, $default, $is_local, $this );


### PR DESCRIPTION
:ticket: [ETP-496]

Related: https://github.com/moderntribe/event-tickets/pull/1802

Before:
![image](https://user-images.githubusercontent.com/1812179/96338663-58063b00-1055-11eb-83b4-fc39bb4e2ae1.png)


After:
![image](https://user-images.githubusercontent.com/1812179/96338666-5d638580-1055-11eb-9888-ce7e17b7be58.png)


[ETP-496]: https://moderntribe.atlassian.net/browse/ETP-496