### PR TITLE
Added a `setup_view` method to the abstract class.

### DIFF
--- a/src/Tribe/Widget/Widget_Abstract.php
+++ b/src/Tribe/Widget/Widget_Abstract.php
@@ -115,6 +115,15 @@ abstract class Widget_Abstract extends \WP_Widget implements Widget_Interface {
 	public abstract function setup();
 
 	/**
+	 * Setup the widget.
+	 *
+	 * @since  TBD
+	 *
+	 * @param array<string,mixed> $arguments The widget arguments, as set by the user in the widget string.
+	 */
+	public abstract function setup_view( $arguments );
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function form( $instance ) {


### PR DESCRIPTION
Since it calls it internally and it shouldn't call methods it doesn't define?

[TEC-3614]

[TEC-3614]: https://moderntribe.atlassian.net/browse/TEC-3614