### PR TITLE
Rollback composer to version 1S

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ env:
     - WP_ADMIN_PASSWORD="password"
 
 before_install:
+  # Rollback Composer to version 1.
+  - composer self-update --rollback
+
   # create the databases needed for the tests
   - mysql -e "create database IF NOT EXISTS $DB_NAME;" -uroot
   - mysql -e "create database IF NOT EXISTS $TEST_DB_NAME;" -uroot


### PR DESCRIPTION
Issue: n/a

This PR ensures the Composer version used by Travis CI to
install PHP dependencies will be the `1.0`, not the newer
`2.0`.