### PR TITLE
Correctly handle query arguments merge

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,11 @@
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correctly handle mutltiple calls to the Repository `by` or `where` method that would cause issues in some Views [ECP-357]
+* Tweak - Add the `Tribe__Utils__Array::merge_recursive_query_vars` method to correctly recursively merge nested arrays in the format used by `WP_Query` [ECP-357]
+
 = [4.12.12] 2020-10-22 =
 
 * Tweak - Add the `tribe_suspending_filter` function to run a callback detaching and reattaching a filter. [TEC-3587]

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -1125,20 +1125,11 @@ abstract class Tribe__Repository
 					 */
 					$this->query_args = array_merge( $this->query_args, $query_modifier );
 				} else {
-					$query_args = $this->query_args;
-
-					// Handle relation separately because we do not want that to merge recursively
-					foreach ( $this->relation_query_args as $query_arg ) {
-						if ( isset( $query_args[ $query_arg ]['relation'], $query_modifier[ $query_arg ]['relation'] ) ) {
-							unset( $query_args[ $query_arg ]['relation'] );
-						}
-					}
-
 					/**
 					 * We do a recursive merge to allow "stacking" of same kind of queries;
-					 * e.g. two or more `tax_query`.
+					 * e.g. two or more `tax_query` or `meta_query` entries should merge into one.
 					 */
-					$this->query_args = array_merge_recursive( $query_args, $query_modifier );
+					$this->query_args = Arr::merge_recursive_query_vars( $this->query_args, $query_modifier );
 				}
 			} else {
 				/**

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -521,5 +521,139 @@ if ( ! class_exists( 'Tribe__Utils__Array' ) ) {
 
 			return $result;
 		}
+
+		/**
+		 * Stringifies the numeric keys of an array.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<int|string,mixed> $input  The input array whose keys should be stringified.
+		 * @param string|null             $prefix The prefix that should be use to stringify the keys, if not provided
+		 *                                        then it will be generated.
+		 *
+		 * @return array<string,mixed> The input array with each numeric key stringified.
+		 */
+		public static function stringify_keys( array $input, $prefix = null ) {
+			$prefix  = null === $prefix ? uniqid( 'sk_', true ) : $prefix;
+			$visitor = static function ( $key, $value ) use ( $prefix ) {
+				$string_key = is_numeric( $key ) ? $prefix . $key : $key;
+
+				return [ $string_key, $value ];
+			};
+
+			return static::array_visit_recursive( $input, $visitor );
+		}
+
+		public static function destringify_keys( array $input, $prefix = 'sk_' ) {
+			$visitor = static function ( $key, $value ) use ( $prefix ) {
+				$destringified_key = 0 === self::strpos( $key, $prefix ) ? null : $key;
+
+				return [ $destringified_key, $value ];
+			};
+
+			return static::array_visit_recursive( $input, $visitor );
+		}
+
+		/**
+		 * Recursively visits all elements of an array applying the specified callback to each element
+		 * key and value.
+		 *
+		 * @since TBD
+		 *
+		 * @param         array $input The input array whose nodes should be visited.
+		 * @param callable $visitor A callback function that will be called on each array item; the callback will
+		 *                          receive the item key and value as input and should return an array that contains
+		 *                          the update key and value in the shape `[ <key>, <value> ]`. Returning a `null`
+		 *                          key will cause the element to be removed from the array.
+		 */
+		public static function array_visit_recursive( $input, callable $visitor ) {
+			if ( ! is_array( $input ) ) {
+				return $input;
+			}
+
+			$return = [];
+
+			foreach ( $input as $key => &$value ) {
+				if ( is_array( $value ) ) {
+					$value = static::array_visit_recursive( $value, $visitor );
+				}
+				// Ensure visitors can quickly return `null` to remove an element.
+				list( $updated_key, $update_value ) = array_replace( [ $key, $value ], (array) $visitor( $key, $value ) );
+				if ( false === $updated_key ) {
+					// Visitor will be able to remove an element by returning a `false` key for it.
+					continue;
+				}
+				if ( null === $updated_key ) {
+					// Automatically assign the first available numeric index to the element.
+					$return[] = $update_value;
+				} else {
+					$return[ $updated_key ] = $update_value;
+				}
+			}
+
+			return $return;
+		}
+
+		/**
+		 * Recursively remove associative, non numeric, keys from an array.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string|int,mixed> $input The input array.
+		 *
+		 * @return array<int|mixed> An array that only contains integer keys at any of its levels.
+		 */
+		public static function remove_numeric_keys_recursive( array $input ) {
+			return self::array_visit_recursive(
+				$input,
+				static function ( $key ) {
+					return is_numeric( $key ) ? false : $key;
+				}
+			);
+		}
+
+		/**
+		 * Recursively remove numeric keys from an array.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string|int,mixed> $input The input array.
+		 *
+		 * @return array<string,mixed> An array that only contains non numeric keys at any of its levels.
+		 */
+		public static function remove_string_keys_recursive( array $input ) {
+			return self::array_visit_recursive(
+				$input,
+				static function ( $key ) {
+					return !is_numeric( $key ) ? false : $key;
+				}
+			);
+		}
+
+		/**
+		 * Merges two or more arrays in the nested format used by WP_Query arguments preserving and merging them correctly.
+		 *
+		 * The method will recursively replace named keys and merge numeric keys. The method takes its name from its intended
+		 * primary use, but it's not limited to query arguments only.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string|int,mixed> ...$arrays A set of arrays to merge.
+		 *
+		 * @return array<string|int,mixed> The recursively merged array.
+		 */
+		public static function merge_recursive_query_vars( array ...$arrays ) {
+			if ( ! count( $arrays ) ) {
+				return [];
+			}
+
+			// Temporarily transform numeric keys to string keys generated with time-related randomness.
+			$stringified = array_map( [ static::class, 'stringify_keys' ], $arrays );
+			// Replace recursive will recursively replace any entry that has the same string key, stringified keys will never match due to randomness.
+			$merged = array_replace_recursive( ...$stringified );
+
+			// Finally destringify the keys to return something that will resemble, in shape, the original arrays.
+			return static::destringify_keys( $merged );
+		}
 	}
 }

--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -544,6 +544,18 @@ if ( ! class_exists( 'Tribe__Utils__Array' ) ) {
 			return static::array_visit_recursive( $input, $visitor );
 		}
 
+		/**
+		 * The inverse of the `stringify_keys` method, it will restore numeric keys for previously
+		 * stringified keys.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<int|string,mixed> $input  The input array whose stringified keys should be
+		 *                                        destringified.
+		 * @param string                  $prefix The prefix that should be used to target only specific string keys.
+		 *
+		 * @return array<int|string,mixed> The input array, its stringified keys destringified.
+		 */
 		public static function destringify_keys( array $input, $prefix = 'sk_' ) {
 			$visitor = static function ( $key, $value ) use ( $prefix ) {
 				$destringified_key = 0 === self::strpos( $key, $prefix ) ? null : $key;

--- a/tests/wpunit/Tribe/Repository/ReadTest.php
+++ b/tests/wpunit/Tribe/Repository/ReadTest.php
@@ -1176,4 +1176,26 @@ class ReadTest extends ReadTestBase {
 
 		return $reviews;
 	}
+
+	public function test_multiple_by_meta_not_exists_call(  ) {
+		$book_w_popularity = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		update_post_meta( $book_w_popularity, '_popularity', 23 );
+		$book_wo_popularity = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		delete_post_meta( $book_wo_popularity, '_popularity' );
+		$book_w_zero_popularity = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		update_post_meta( $book_w_zero_popularity, '_popularity', 0 );
+
+		// Sanity checks.
+		$this->assertEqualSets( [ $book_wo_popularity ], $this->repository()->by( 'meta_not_exists', '_popularity' )->get_ids() );
+		$this->assertEqualSets( [ $book_w_popularity, $book_w_zero_popularity ], $this->repository()->by( 'meta_exists', '_popularity' )->get_ids() );
+
+		$repository = $this->repository();
+		$repository->by( 'meta_not_exists', '_popularity' );
+		$repository->by( 'meta_not_exists', '_popularity' );
+		$this->assertEquals(
+			[ $book_wo_popularity ],
+			$repository->by( 'meta_not_exists', '_popularity' )->get_ids(),
+			'Adding the same meta_not_exists clause multiple times should work as if adding it once'
+		);
+	}
 }

--- a/tests/wpunit/Tribe/Utils/ArrayTest.php
+++ b/tests/wpunit/Tribe/Utils/ArrayTest.php
@@ -2,6 +2,9 @@
 
 namespace Tribe\Utils;
 
+use PHPUnit\Framework\AssertionFailedError;
+use Tribe__Utils__Array as Arr;
+
 class ArrayTest extends \Codeception\TestCase\WPTestCase {
 	public function list_to_array_inputs() {
 		return [
@@ -63,12 +66,12 @@ class ArrayTest extends \Codeception\TestCase\WPTestCase {
 
 	public function unprefix_keys() {
 		return [
-			'a_string'  => [ 'foo', 'foo' ],
-			'null'      => [ null, null ],
-			'an_object' => [ (object) [ '_foo' => 'bar' ], (object) [ '_foo' => 'bar' ] ],
-			'no_prefix' => [ [ 'foo' => 'bar' ], [ 'foo' => 'bar' ] ],
-			'w_prefix'  => [ [ '_foo' => 'bar' ], [ '_foo' => 'bar', 'foo' => 'bar' ] ],
-			'w_prefix_nested' => [
+			'a_string'                     => [ 'foo', 'foo' ],
+			'null'                         => [ null, null ],
+			'an_object'                    => [ (object) [ '_foo' => 'bar' ], (object) [ '_foo' => 'bar' ] ],
+			'no_prefix'                    => [ [ 'foo' => 'bar' ], [ 'foo' => 'bar' ] ],
+			'w_prefix'                     => [ [ '_foo' => 'bar' ], [ '_foo' => 'bar', 'foo' => 'bar' ] ],
+			'w_prefix_nested'              => [
 				[ '_foo' => [ 'bar' => 23, '_baz' => 89 ] ],
 				[
 					'_foo' => [ 'bar' => 23, '_baz' => 89, 'baz' => 89 ],
@@ -84,25 +87,26 @@ class ArrayTest extends \Codeception\TestCase\WPTestCase {
 				]
 			],
 		];
-}
+	}
+
 	/**
 	 * Test unprefix array keys
 	 * @dataProvider unprefix_keys
 	 */
-	public function test_unprefix_array_keys($input, $expected, bool $recursive = false) {
+	public function test_unprefix_array_keys( $input, $expected, bool $recursive = false ) {
 		$this->assertEquals( $expected, \Tribe__Utils__Array::add_unprefixed_keys_to( $input, $recursive ) );
 	}
 
 	public function get_first_set_data_sets() {
 		return [
 			// $input, $indexes, $default, $expected
-			'empty' => [ [], [ 'tree', 'car' ], null, null ],
-			'first_element' => [ ['tree'=>'pine','animal'=>'bear'], [ 'tree', 'car' ], null, 'pine' ],
-			'second_element' => [ ['animal'=>'bear','tree'=>'pine'], [ 'tree', 'car' ], null, 'pine' ],
-			'first_index_set_second' => [ ['car'=>'VW Golf','tree'=>'pine'], [ 'tree', 'car' ], null, 'pine' ],
-			'first_index_set_first' => [ ['car'=>'VW Golf','tree'=>'pine'], [ 'car', 'tree' ], null, 'VW Golf' ],
-			'not_set_wo_default' => [ ['car'=>'VW Golf','tree'=>'pine'], [ 'one', 'two' ], null, null ],
-			'not_set_w_default' => [ ['car'=>'VW Golf','tree'=>'pine'], [ 'one', 'two' ], 'default', 'default' ],
+			'empty'                  => [ [], [ 'tree', 'car' ], null, null ],
+			'first_element'          => [ [ 'tree' => 'pine', 'animal' => 'bear' ], [ 'tree', 'car' ], null, 'pine' ],
+			'second_element'         => [ [ 'animal' => 'bear', 'tree' => 'pine' ], [ 'tree', 'car' ], null, 'pine' ],
+			'first_index_set_second' => [ [ 'car' => 'VW Golf', 'tree' => 'pine' ], [ 'tree', 'car' ], null, 'pine' ],
+			'first_index_set_first'  => [ [ 'car' => 'VW Golf', 'tree' => 'pine' ], [ 'car', 'tree' ], null, 'VW Golf' ],
+			'not_set_wo_default'     => [ [ 'car' => 'VW Golf', 'tree' => 'pine' ], [ 'one', 'two' ], null, null ],
+			'not_set_w_default'      => [ [ 'car' => 'VW Golf', 'tree' => 'pine' ], [ 'one', 'two' ], 'default', 'default' ],
 		];
 	}
 
@@ -167,5 +171,247 @@ class ArrayTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_parse_associative_array_alias( $original, $alias_map, $expected ) {
 		$this->assertEquals( $expected, \Tribe__Utils__Array::parse_associative_array_alias( $original, $alias_map ) );
+	}
+
+	public function key_fitering_data_provider() {
+		return [
+			'empty array'                                  => [
+				'input'                => [],
+				'expected_numeric'     => [],
+				'expected_associative' => []
+			],
+			'only implicit numeric keys array'             => [
+				'input'                => [ 'foo', 'bar', [ 'baz_1', 'baz_2', [ 'lorem', 'dolor' ] ] ],
+				'expected_numeric'     => [ 'foo', 'bar', [ 'baz_1', 'baz_2', [ 'lorem', 'dolor' ] ] ],
+				'expected_associative' => [],
+			],
+			'mix of implicit numeric keys and string keys' => [
+				'input'                => [
+					'foo',
+					'bar',
+					[ 'baz_1', 'baz_2', [ 'lorem', 'dolor' ] ],
+					'string_1' => [ 'string_1_1' => 23 ],
+					[ 'string_2' => 89, 'lorem' ]
+				],
+				'expected_numeric'     => [ 'foo', 'bar', [ 'baz_1', 'baz_2', [ 'lorem', 'dolor' ] ], [ 'lorem' ] ],
+				'expected_associative' => [ 'string_1' => [ 'string_1_1' => 23 ] ],
+			],
+			'explicit numeric keys only'                   => [
+				'input'                => [ 23 => 'foo', 89 => 'bar', 121 => [ 1 => 'baz_1', 2 => 'baz_2', 142 => [ 3 => 'lorem', 4 => 'dolor' ] ] ],
+				'expected_numeric'     => [ 23 => 'foo', 89 => 'bar', 121 => [ 1 => 'baz_1', 2 => 'baz_2', 142 => [ 3 => 'lorem', 4 => 'dolor' ] ] ],
+				'expected_associative' => [],
+			],
+			'mix of explicit numeric keys and string keys' => [
+				'input'                => [
+					1          => 'foo',
+					2          => 'bar',
+					3          => [ 11 => 'baz_1', 12 => 'baz_2', 13 => [ 14 => 'lorem', 15 => 'dolor' ] ],
+					'string_1' => [ 'string_1_1' => 23 ],
+					4          => [ 'string_2' => 89, 17 => 'lorem' ]
+				],
+				'expected_numeric'     => [
+					1 => 'foo',
+					2 => 'bar',
+					3 => [ 11 => 'baz_1', 12 => 'baz_2', 13 => [ 14 => 'lorem', 15 => 'dolor' ] ],
+					4 => [ 17 => 'lorem' ]
+				],
+				'expected_associative' => [ 'string_1' => [ 'string_1_1' => 23 ] ],
+			],
+			'string arrays only'                           => [
+				'input'                => [
+					'string_1' => 'lorem',
+					'string_2' => [ 'string_2_1' => 'lorem', 'string_2_2' => [ 'string_2_2_1' => 'lorem', 'string_2_2_2' => 'dolor' ] ]
+				],
+				'expected_numeric'     => [],
+				'expected_associative' => [
+					'string_1' => 'lorem',
+					'string_2' => [
+						'string_2_1' => 'lorem',
+						'string_2_2' => [ 'string_2_2_1' => 'lorem', 'string_2_2_2' => 'dolor' ]
+					]
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider key_fitering_data_provider
+	 */
+	public function test_key_filtering( $input, $expected_numeric,$expected_associative ) {
+		$this->assertEquals( $expected_numeric, Arr::remove_string_keys_recursive( $input ) );
+		$this->assertEquals( $expected_associative, Arr::remove_numeric_keys_recursive( $input ) );
+	}
+
+	public function merge_wp_query_args_data_provider() {
+		return [
+//			'no input arrays'                         => [
+//				'inputs'   => [],
+//				'expected' => [],
+//			],
+//			'meta_query with numeric keys'            => [
+//				'inputs'   => [
+//					[ 'p' => 23, 'name' => 'foo', 'meta_query' => [ [ 'key' => '_key_1', 'compare' => '>', 'value' => 23 ] ] ],
+//					[ 'p' => 89, 'meta_query' => [ 'relation' => 'OR', [ 'key' => '_key_1', 'compare' => '<', 'value' => 89 ] ] ],
+//					[ 'name' => 'lorem', 'meta_query' => [ [ 'key' => '_key_2', 'compare' => 'EXISTS', 'value' => 'n' ] ] ],
+//				],
+//				'expected' => [
+//					'p'          => 89,
+//					'name'       => 'lorem',
+//					'meta_query' => [
+//						[ 'key' => '_key_1', 'compare' => '>', 'value' => 23 ],
+//						'relation' => 'OR',
+//						[ 'key' => '_key_1', 'compare' => '<', 'value' => 89 ],
+//						[ 'key' => '_key_2', 'compare' => 'EXISTS', 'value' => 'n' ],
+//					],
+//				],
+//			],
+			'meta_query with string and numeric keys' => [
+				'inputs'   => [
+					[ 'p' => 23, 'name' => 'foo', 'meta_query' => [ [ 'key' => 'karma', 'compare' => '>', 'value' => 23 ] ] ],
+					[
+						'p'          => 89,
+						'meta_query' => [
+							'karma' => [
+								'karma_gt_10'  => [ 'key' => 'karma', 'compare' => '>', 'value' => 10 ],
+								'relation'     => 'AND',
+								'karma_lt_100' => [ 'key' => 'karma', 'compare' => '>', 'value' => 10 ],
+							],
+							[ 'key' => 'testability', 'value' => 'n', 'compare' => 'EXISTS' ]
+						],
+					],
+					[ 'name' => 'lorem', 'meta_query' => [ [ 'key' => '_key_2', 'compare' => 'EXISTS', 'value' => 'n' ] ] ],
+					[
+						'meta_query' => [ [ 'key' => 'votes', 'compare' => '<=', 'value' => 89  ] ],
+					],
+					[
+						'meta_query' => [
+							'votes' => [
+								'votes_gt_10'  => [ 'key'     => 'votes', 'compare' => '>', 'value'   => 10 ],
+								'relation'     => 'OR',
+								'votes_lt_200' => [ 'key'     => 'votes', 'compare' => '<', 'value'   => 200 ],
+							],
+						],
+					],
+				],
+				'expected' => [
+					'p'          => 89,
+					'name'       => 'lorem',
+					'meta_query' => [
+						0       => [ 'key' => 'karma', 'compare' => '>', 'value' => 23, ],
+						'karma' => [
+							'karma_gt_10'  => [ 'key' => 'karma', 'compare' => '>', 'value' => 10, ],
+							'relation'     => 'AND',
+							'karma_lt_100' => [ 'key' => 'karma', 'compare' => '>', 'value' => 10, ],
+						],
+						1       => [ 'key' => 'testability', 'value' => 'n', 'compare' => 'EXISTS', ],
+						2       => [ 'key' => '_key_2', 'compare' => 'EXISTS', 'value' => 'n', ],
+						3       => [ 'key' => 'votes', 'compare' => '<=', 'value' => 89, ],
+						'votes' => [
+							'votes_gt_10'  => [ 'key' => 'votes', 'compare' => '>', 'value' => 10, ],
+							'relation'     => 'OR',
+							'votes_lt_200' => [ 'key' => 'votes', 'compare' => '<', 'value' => 200, ],
+						],
+					],
+				],
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider merge_wp_query_args_data_provider
+	 */
+	public function test_merge_wp_query_args( array $inputs, array $expected ) {
+		$merged = Arr::merge_recursive_query_vars( ...$inputs );
+		$this->assertEquals( $expected, $merged );
+	}
+
+	public function array_visit_recursive_data_provider() {
+		$throw_on_call = static function () {
+			throw new AssertionFailedError( 'This function should not be called' );
+		};
+
+		$drop_even = static function ( $key, $value ) {
+			if ( $value % 2 === 0 ) {
+				return false;
+			}
+		};
+
+		return [
+			'empty input'                => [
+				'input'    => [],
+				'visitor'  => $throw_on_call,
+				'expected' => [],
+			],
+			'drop even values'           => [
+				'input'    => [ 1, 2, 3, 4, 5, 6 ],
+				'visitor'  => $drop_even,
+				'expected' => [ 1, 3, 5 ],
+			],
+			'recursive drop even values' => [
+				'input'    => [ 1, 2, 3, 4, 5, 6, [ 1, 2, 3 ], [ 4, 5, 6 ] ],
+				'visitor'  => $drop_even,
+				'expected' => [ 1, 3, 5, [ 1, 2 => 3 ], [ 1 => 5 ] ],
+			],
+			'recursive visit'            => [
+				'input'    => [
+					'lorem' => [
+						1,
+						2,
+						3,
+					],
+					[
+						'foo',
+						'baz',
+						'bar',
+					],
+					'dolor' => [
+						'sit' => [ 'woot' => 23, 'waz' ]
+					],
+				],
+				'visitor'  => static function ( $key, $value ) {
+					$new_key   = is_numeric( $key ) ? 'n_' . $key : 's_' . $key;
+					if ( ! is_array( $value ) ) {
+						$new_value = is_string( $value ) ? 'is_string' : 'not_string';
+					} else {
+						$new_value = $value;
+					}
+
+					if ( $key === 'foo' ) {
+						return false;
+					}
+
+					return [ $new_key, $new_value ];
+				},
+				'expected' => [
+					's_lorem' =>
+						[
+							'n_0' => 'not_string',
+							'n_1' => 'not_string',
+							'n_2' => 'not_string',
+						],
+					'n_0'     =>
+						[
+							'n_0' => 'is_string',
+							'n_1' => 'is_string',
+							'n_2' => 'is_string',
+						],
+					's_dolor' =>
+						[
+							's_sit' =>
+								[
+									's_woot' => 'not_string',
+									'n_0'    => 'is_string',
+								],
+						],
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider array_visit_recursive_data_provider
+	 */
+	public function test_array_visit_recursive( $input, $visitor, $expected ) {
+		$this->assertEqualSets( $expected, Arr::array_visit_recursive( $input, $visitor ) );
 	}
 }


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/ECP-357 

This fix originates from the issue above; while investigating it I ran into some issues
while trying to set up Week View and investigated.
	
The issues originated from mis-handling, in the Repository code, of the merging of query
args leading to wrongly built `meta_query` entries like this one:

```php
$args = [
	'meta_query' => [
		'_eventhiddenfromupcoming_not_exists => [
			'key' => [
				'_foo',
				'_foo',
			],
			'compare' => [
				'NOT EXISTS',
				'NOT EXISTS',
			],
			'value' => [
				'n/a',
				'n/a',
		],
	],
];
```

Each entry of that array should NOT be an array, of course.
That would be caused by simple code like this:

```php
tribe_events()->where('meta_not_exists', '_foo)->where('meta_not_exists', '_foo')->get_ids();
```

While the double call to `where` is nonsense, that might happen (and was happening) and our code should
survive it. It did not and would create wrongly built entries.

Look at the tests to have a better idea.

The PR adds another set of methods to the `Tribe__Utils__Array` class that leverage Closures and
the visitor pattern.