### PR TITLE
Events list widget theme overrides

### DIFF
--- a/src/resources/postcss/base/full/typography/_anchors.pcss
+++ b/src/resources/postcss/base/full/typography/_anchors.pcss
@@ -26,7 +26,8 @@
 		 * Theme Overrides - Twenty Seventeen
 		 * ------------------------------------------------------------------------- */
 
-		.tribe-theme-twentyseventeen & {
+		.tribe-theme-twentyseventeen &,
+		.tribe-theme-twentyseventeen .site-footer .widget-area & {
 			box-shadow: none;
 
 			&:hover,
@@ -92,6 +93,19 @@
 			&:focus {
 				color: var(--color-accent-primary);
 			}
+		}
+	}
+
+	.tribe-theme-twentyseventeen .site-footer .widget-area & {
+
+		.tribe-common-anchor,
+		.tribe-common-anchor-thin {
+			transition: var(--transition-border-color);
+		}
+
+		.tribe-common-anchor-alt,
+		.tribe-common-anchor-thin-alt {
+			transition: var(--transition-color);
 		}
 	}
 }

--- a/src/resources/postcss/base/full/typography/_anchors.pcss
+++ b/src/resources/postcss/base/full/typography/_anchors.pcss
@@ -27,7 +27,8 @@
 		 * ------------------------------------------------------------------------- */
 
 		.tribe-theme-twentyseventeen &,
-		.tribe-theme-twentyseventeen .site-footer .widget-area & {
+		.tribe-theme-twentyseventeen .site-footer .widget-area &,
+		.theme-twentyseventeen .site-footer .widget-area & {
 			box-shadow: none;
 
 			&:hover,
@@ -96,7 +97,8 @@
 		}
 	}
 
-	.tribe-theme-twentyseventeen .site-footer .widget-area & {
+	.tribe-theme-twentyseventeen .site-footer .widget-area &,
+	.theme-twentyseventeen .site-footer .widget-area & {
 
 		.tribe-common-anchor,
 		.tribe-common-anchor-thin {

--- a/src/resources/postcss/base/full/typography/_anchors.pcss
+++ b/src/resources/postcss/base/full/typography/_anchors.pcss
@@ -46,6 +46,22 @@
 		.tribe-theme-twentynineteen .entry & {
 			text-decoration: none;
 		}
+
+		/* -------------------------------------------------------------------------
+		 * Theme Overrides - Enfold
+		 * ------------------------------------------------------------------------- */
+
+		.tribe-theme-enfold &,
+		.theme-enfold & {
+			color: var(--color-text-primary);
+
+			&:hover,
+			&:focus,
+			&:active,
+			&:visited {
+				color: var(--color-text-primary);
+			}
+		}
 	}
 
 	/* -------------------------------------------------------------------------


### PR DESCRIPTION
**Ticket:** [TEC-3649]

This PR fixes theme overrides for the events list widget.

**Artifacts:**

Enfold:

![image](https://user-images.githubusercontent.com/16699941/98970834-5ee87680-254b-11eb-9661-4384fa097895.png)

Twenty Seventeen:

![image](https://user-images.githubusercontent.com/16699941/98970965-87707080-254b-11eb-85d0-7bde6520308a.png)

Astra:

![image](https://user-images.githubusercontent.com/16699941/98971258-dfa77280-254b-11eb-875e-45685b5bcbb1.png)

Divi:

![image](https://user-images.githubusercontent.com/16699941/98971349-fd74d780-254b-11eb-8a92-9d370c337df0.png)


[TEC-3649]: https://moderntribe.atlassian.net/browse/TEC-3649