### PR TITLE
Do not cache and return the serialized value

### DIFF
--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -87,11 +87,11 @@ class Tribe__Cache implements ArrayAccess {
 	 * @return bool
 	 */
 	public function set_transient( $id, $value, $expiration = 0, $expiration_trigger = '' ) {
-		if ( $this->data_size_over_packet_size( $value, $serialized_value ) ) {
+		if ( $this->data_size_over_packet_size( $value ) ) {
 			return false;
 		}
 
-		return set_transient( $this->get_id( $id, $expiration_trigger ), $serialized_value, $expiration );
+		return set_transient( $this->get_id( $id, $expiration_trigger ), $value, $expiration );
 	}
 
 	/**
@@ -507,18 +507,13 @@ class Tribe__Cache implements ArrayAccess {
 	 *
 	 * @since TBD
 	 *
-	 * @param string|array|object $value            The value to check.
-	 * @param mixed|null          $serialized_value The serialized value, set by reference. Serialization is costly, since
-	 *                                              it's the only way to know the data size, the value is set by reference
-	 *                                              to allow wasting a perfectly good serialized result.
+	 * @param string|array|object $value The value to check.
 	 *
 	 * @return bool Whether the data, in its serialized form, would fit into the current database `max_allowed_packet`
 	 *              setting or not.
 	 */
-	public function data_size_over_packet_size( $value, &$serialized_value = null ) {
+	public function data_size_over_packet_size( $value ) {
 		if ( wp_using_ext_object_cache() ) {
-			$serialized_value = $value;
-
 			// We cannot know and that is a concern of the external caching system.
 			return false;
 		}

--- a/tests/wpunit/Tribe/CacheTest.php
+++ b/tests/wpunit/Tribe/CacheTest.php
@@ -209,17 +209,13 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 		$cache = tribe( 'cache' );
 
 		$this->assertTrue( $cache->set_transient( 'test', $small_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $small_size_value, $serialized ) );
-		$this->assertEquals( $small_size_value, $serialized );
+		$this->assertFalse( $cache->data_size_over_packet_size( $small_size_value ) );
 		$this->assertTrue( $cache->set_transient( 'test', $medium_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $medium_size_value, $serialized ) );
-		$this->assertEquals( $medium_size_value, $serialized );
+		$this->assertFalse( $cache->data_size_over_packet_size( $medium_size_value ) );
 		$this->assertTrue( $cache->set_transient( 'test', $large_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value, $serialized ) );
-		$this->assertEquals( $large_size_value, $serialized );
+		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value ) );
 		$this->assertFalse( $cache->set_transient( 'test', $too_large_size_value ) );
-		$this->assertTrue( $cache->data_size_over_packet_size( $too_large_size_value, $serialized ) );
-		$this->assertEquals( $too_large_size_value, $serialized );
+		$this->assertTrue( $cache->data_size_over_packet_size( $too_large_size_value ) );
 	}
 
 	/**
@@ -259,14 +255,11 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 		$cache = tribe( 'cache' );
 
 		$this->assertTrue( $cache->set_transient( 'test', $medium_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $medium_size_value, $serialized ) );
-		$this->assertEquals( serialize( $medium_size_value ), $serialized );
+		$this->assertFalse( $cache->data_size_over_packet_size( $medium_size_value ) );
 		$this->assertTrue( $cache->set_transient( 'test', $large_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value, $serialized ) );
-		$this->assertEquals( serialize( $large_size_value ), $serialized );
+		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value ) );
 		$this->assertFalse( $cache->set_transient( 'test', $too_large_size_value ) );
-		$this->assertTrue( $cache->data_size_over_packet_size( $too_large_size_value, $serialized ) );
-		$this->assertEquals( serialize( $too_large_size_value ), $serialized );
+		$this->assertTrue( $cache->data_size_over_packet_size( $too_large_size_value ) );
 	}
 
 	/**
@@ -289,8 +282,8 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 		$cache = tribe( 'cache' );
 
 		$this->assertTrue( $cache->set_transient( 'test', $large_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value, $serialized ) );
+		$this->assertFalse( $cache->data_size_over_packet_size( $large_size_value) );
 		$this->assertTrue( $cache->set_transient( 'test', $too_large_size_value ) );
-		$this->assertFalse( $cache->data_size_over_packet_size( $too_large_size_value, $serialized ) );
+		$this->assertFalse( $cache->data_size_over_packet_size( $too_large_size_value ) );
 	}
 }


### PR DESCRIPTION
Issue: https://moderntribe.atlassian.net/browse/TEC-3615

Fix following my previous PR that has introduced detection of too large transients.
I've found out, in the case of Objects, passing the serialized version to the `set_transient`
function would mangle its contents.

This fix removed the pre-serialized value setting.