### PR TITLE
Fix/tec 3649 theme overrides 2

### DIFF
--- a/src/resources/postcss/base/full/typography/_anchors.pcss
+++ b/src/resources/postcss/base/full/typography/_anchors.pcss
@@ -28,7 +28,7 @@
 
 		.tribe-theme-twentyseventeen &,
 		.tribe-theme-twentyseventeen .site-footer .widget-area &,
-		.theme-twentyseventeen .site-footer .widget-area & {
+		.site-footer .widget-area & {
 			box-shadow: none;
 
 			&:hover,
@@ -114,7 +114,7 @@
 	}
 
 	.tribe-theme-twentyseventeen .site-footer .widget-area &,
-	.theme-twentyseventeen .site-footer .widget-area & {
+	.site-footer .widget-area & {
 
 		.tribe-common-anchor,
 		.tribe-common-anchor-thin {

--- a/src/resources/postcss/base/full/typography/_anchors.pcss
+++ b/src/resources/postcss/base/full/typography/_anchors.pcss
@@ -52,7 +52,7 @@
 		 * ------------------------------------------------------------------------- */
 
 		.tribe-theme-enfold &,
-		.theme-enfold & {
+		.main_color .sidebar & {
 			color: var(--color-text-primary);
 
 			&:hover,


### PR DESCRIPTION
**Ticket:** [TEC-3649]

This PR fixes theme overrides that were incorrectly applied. The WooCommerce plugin would add the body class `theme-twentyseventeen`, for example, to the body. However, this was an incorrect selector to use, and has been removed.

**Artifacts:**

Astra:
![image](https://user-images.githubusercontent.com/16699941/99712964-c029c000-2ade-11eb-9bf4-f6cc82372605.png)

Enfold:
![image](https://user-images.githubusercontent.com/16699941/99713020-d2a3f980-2ade-11eb-9114-e58071d27780.png)

Twenty Seventeen:
![image](https://user-images.githubusercontent.com/16699941/99713131-e5b6c980-2ade-11eb-8e34-378ad2f1de57.png)


[TEC-3649]: https://moderntribe.atlassian.net/browse/TEC-3649