### PR TITLE
Prevent version utilities from loading an instance just to get a prop/constant

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.12.13.1] 2020-11-20 =
+
+* Fix - Prevent `tribe_get_first_ever_installed_version()` from having to spawn an instance of the Main class for version history.
+
 = [4.12.13] 2020-11-19 =
 
 * Tweak - Allow deletion of non persistent keys from Tribe__Cache handling. [ET-917]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -19,7 +19,7 @@ class Tribe__Main {
 	const OPTIONNAME          = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK   = 'tribe_events_calendar_network_options';
 
-	const VERSION             = '4.12.13';
+	const VERSION             = '4.12.13.1';
 
 	const FEED_URL            = 'https://theeventscalendar.com/feed/';
 

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -716,6 +716,14 @@ if ( ! function_exists( 'tribe_get_least_version_ever_installed' ) ) {
 	 * @return string|boolean The SemVer version string or false if no info found.
 	 */
 	function tribe_get_least_version_ever_installed( $class ) {
+		if ( ! is_string( $class ) ) {
+			$class = get_class( $class );
+
+			if ( false === $class ) {
+				return false;
+			}
+		}
+
 		$history = tribe_plugin_version_history( $class );
 
 		// Try for the version history first.
@@ -761,6 +769,14 @@ if ( ! function_exists( 'tribe_get_greatest_version_ever_installed' ) ) {
 	 * @return string|boolean The SemVer version string or false if no info found.
 	 */
 	function tribe_get_greatest_version_ever_installed( $class ) {
+		if ( ! is_string( $class ) ) {
+			$class = get_class( $class );
+
+			if ( false === $class ) {
+				return false;
+			}
+		}
+
 		$history = tribe_plugin_version_history( $class );
 
 		// Try for the version history first.
@@ -841,6 +857,14 @@ if ( ! function_exists( 'tribe_get_first_ever_installed_version' ) ) {
 	 * @return string|boolean The SemVer version string or false if no info found.
 	 */
 	function tribe_get_first_ever_installed_version( $class ) {
+		if ( ! is_string( $class ) ) {
+			$class = get_class( $class );
+
+			if ( false === $class ) {
+				return false;
+			}
+		}
+
 		$history = tribe_plugin_version_history( $class );
 
 		// Try for the version history first.

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -741,7 +741,7 @@ if ( ! function_exists( 'tribe_get_least_version_ever_installed' ) ) {
 		}
 
 		// Fall back to the current plugin version.
-		if ( defined( get_class( $class ) . '::VERSION' ) ) {
+		if ( defined( $class . '::VERSION' ) ) {
 			return $class::VERSION;
 		}
 
@@ -794,7 +794,7 @@ if ( ! function_exists( 'tribe_get_greatest_version_ever_installed' ) ) {
 		}
 
 		// Fall back to the current plugin version.
-		if ( defined( get_class( $class ) . '::VERSION' ) ) {
+		if ( defined( $class . '::VERSION' ) ) {
 			return $class::VERSION;
 		}
 

--- a/tribe-common.php
+++ b/tribe-common.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Tribe Common
 Description: An event settings framework for managing shared options
-Version: 4.12.13
+Version: 4.12.13.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/1x
 Text Domain: tribe-common


### PR DESCRIPTION
Prevent version utilities from loading an instance just to get a prop/constant