### PR TITLE
Bump a11y dialog to 5.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "require": {
     "lucatume/di52": "~2.0.10",
     "firebase/php-jwt": "~5.0.0",
-    "faction23/a11y-dialog": "5.1.0",
+    "faction23/a11y-dialog": "5.1.1",
     "monolog/monolog": "1.24.*"
   },
   "repositories": [
@@ -52,7 +52,7 @@
       "type": "package",
       "package": {
         "name": "faction23/a11y-dialog",
-        "version": "5.1.0",
+        "version": "5.1.1",
         "source": {
           "url": "https://github.com/faction23/a11y-dialog",
           "type": "git",

--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "faction23/a11y-dialog",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/faction23/a11y-dialog",


### PR DESCRIPTION
🎫 [ETP-487]
🎥 not required because it's a library version bump. [Read this for more context](https://tribe.slack.com/archives/C0258NY1C/p1606927377259800).

[ETP-487]: https://moderntribe.atlassian.net/browse/ETP-487