### PR TITLE
Add param for settings hook.

### DIFF
--- a/src/Tribe/Customizer.php
+++ b/src/Tribe/Customizer.php
@@ -583,11 +583,13 @@ final class Tribe__Customizer {
 			 * Allows people to Register and de-register the method to register more Fields
 			 *
 			 * @since 4.4
+			 * @since TBD Add Customizer instance as a parameter.
 			 *
 			 * @param array                $section
 			 * @param WP_Customize_Manager $manager
+			 * @param Tribe__Customizer    $customizer The current customizer instance.
 			 */
-			do_action( "tribe_customizer_register_{$id}_settings", $this->sections[ $id ], $this->manager );
+			do_action( "tribe_customizer_register_{$id}_settings", $this->sections[ $id ], $this->manager, $this );
 		}
 
 		/**


### PR DESCRIPTION
Just adds the current customizer instance as a third param for the `tribe_customizer_register_{$id}_settings` hook.

There is no Customizer "bucket" branch, so PR'd against 20.12

Required by https://github.com/moderntribe/the-events-calendar/pull/3381